### PR TITLE
Fix slowness when running bulk tests in Gillian-C

### DIFF
--- a/Gillian-C/lib/config_compcert.ml
+++ b/Gillian-C/lib/config_compcert.ml
@@ -20,10 +20,10 @@ module Warnings = struct
   let as_error = find_unit_cmd "-Werror" options
 end
 
-module Optim = struct
+module Optimisations = struct
   open Compcert.Clflags
 
-  let optimization_options =
+  let options =
     [
       option_ftailcalls;
       option_fifconversion;
@@ -34,7 +34,7 @@ module Optim = struct
       option_finline_functions_called_once;
     ]
 
-  let disable_all () = List.iter (fun r -> r := false) optimization_options
+  let disable_all () = List.iter (fun r -> r := false) options
 end
 
 module Preprocessor = struct

--- a/Gillian-C/lib/parserAndCompiler.ml
+++ b/Gillian-C/lib/parserAndCompiler.ml
@@ -262,14 +262,12 @@ let parse_and_compile_files paths =
 
   (* Create main GIL program with references to all other files *)
   let open Gillian.Gil_syntax in
-  let open Gillian.Utils in
   let rec combine paths comb_imports comb_init_asrts comb_init_cmds =
     match paths with
     | []           -> (comb_imports, comb_init_asrts, comb_init_cmds)
     | path :: rest ->
-        let prog, init_asrts, init_cmds, _ = Hashtbl.find compiled_progs path in
+        let _, init_asrts, init_cmds, _ = Hashtbl.find compiled_progs path in
         let gil_path = Filename.chop_extension path ^ ".gil" in
-        let () = Io_utils.save_file_pp gil_path Prog.pp_labeled prog in
         combine rest
           (comb_imports @ [ (gil_path, true) ])
           (comb_init_asrts @ init_asrts)

--- a/GillianCore/CommandLine/CommandLine.ml
+++ b/GillianCore/CommandLine/CommandLine.ml
@@ -98,8 +98,8 @@ struct
 
   let no_print_failures =
     let doc =
-      "Do not print the list of all the failed tests at the end of execution \
-       bulk execution"
+      "Do not print the list of all the failed tests at the end of the bulk \
+       execution"
     in
     Arg.(value & flag & info [ "no-print-all-failures" ] ~doc)
 


### PR DESCRIPTION
This involves caching the parsed and compiled files so that they can be reused across different test runs but within the same running instance of Gillian-C.