### PR TITLE
Update compilation CLI to work better with continuous analysis

### DIFF
--- a/Gillian-JS/lib/Compiler/JS2GIL_ParserAndCompiler.ml
+++ b/Gillian-JS/lib/Compiler/JS2GIL_ParserAndCompiler.ml
@@ -28,6 +28,14 @@ let pp_err fmt = function
   | JS2GILErr s   -> Fmt.pf fmt "%s" s
   | JSParserErr s -> Fmt.pf fmt "Parsing error: %s\n" (JS_Parser.Error.str s)
 
+let create_compilation_result path prog =
+  let open CommandLine.ParserAndCompiler in
+  let open IncrementalAnalysis in
+  let source_files = SourceFiles.make () in
+  (* TODO (Alexis): Track any require()'d modules *)
+  SourceFiles.add_source_file source_files path;
+  { gil_progs = [ (path, prog) ]; source_files }
+
 let parse_and_compile_js path =
   try
     let e_str = Javert_utils.Io_utils.load_js_file path in
@@ -79,8 +87,11 @@ let parse_and_compile_jsil path =
 
 let parse_and_compile_files paths =
   let path = List.hd paths in
-  if !Javert_utils.Js_config.js then parse_and_compile_js path
-  else parse_and_compile_jsil path
+  let core_prog =
+    if !Javert_utils.Js_config.js then parse_and_compile_js path
+    else parse_and_compile_jsil path
+  in
+  Result.map (create_compilation_result path) core_prog
 
 let other_imports = [ ("jsil", parse_and_compile_jsil) ]
 

--- a/Gillian-JS/lib/Compiler/JS2GIL_ParserAndCompiler.ml
+++ b/Gillian-JS/lib/Compiler/JS2GIL_ParserAndCompiler.ml
@@ -33,8 +33,9 @@ let create_compilation_result path prog =
   let open IncrementalAnalysis in
   let source_files = SourceFiles.make () in
   (* TODO (Alexis): Track any require()'d modules *)
-  SourceFiles.add_source_file source_files path;
-  { gil_progs = [ (path, prog) ]; source_files }
+  let () = SourceFiles.add_source_file source_files path in
+  let gil_path = Filename.chop_extension path ^ ".gil" in
+  { gil_progs = [ (gil_path, prog) ]; source_files }
 
 let parse_and_compile_js path =
   try

--- a/GillianCore/GIL_Parser/gil_parsing.ml
+++ b/GillianCore/GIL_Parser/gil_parsing.ml
@@ -105,6 +105,9 @@ let cached_progs = Hashtbl.create Config.small_tbl_size
 
 let cache_gil_prog path prog = Hashtbl.add cached_progs path prog
 
+let cache_labelled_progs (progs : (string * (Annot.t, string) Prog.t) list) =
+  List.iter (fun (path, prog) -> cache_gil_prog path prog) progs
+
 let resolve_path path =
   let lookup_paths = "." :: Config.get_runtime_paths () in
   let rec find fname paths =

--- a/GillianCore/GIL_Syntax/Gil_syntax.mli
+++ b/GillianCore/GIL_Syntax/Gil_syntax.mli
@@ -883,6 +883,7 @@ module Prog : sig
 
   val get_proc_exn : ('a, 'b) t -> string -> ('a, 'b) Proc.t
   (** Get a specific procedure. Raises [Failure] if it does not exist *)
+
   (* FIXME: should raise Not_found instead *)
 
   val get_pred : ('a, 'b) t -> string -> Pred.t option

--- a/GillianCore/incrementalAnalysis/changeTracker.ml
+++ b/GillianCore/incrementalAnalysis/changeTracker.ml
@@ -1,9 +1,5 @@
 open Containers
 
-let cur_source_files = SourceFiles.make ()
-
-let reset () = SourceFiles.reset cur_source_files
-
 type t = {
   changed_procs : string list;
   new_procs : string list;
@@ -157,7 +153,7 @@ let get_dependent_procs_and_lemmas reverse_graph start_ids ~filter_id =
   in
   get_dependents IdSet.empty start_ids SS.empty SS.empty
 
-let get_changes prog prev_source_files prev_call_graph =
+let get_changes prog prev_source_files prev_call_graph cur_source_files =
   let changed_files, new_files =
     get_changed_files prev_source_files cur_source_files
   in

--- a/GillianCore/parserAndCompiler/ParserAndCompiler.ml
+++ b/GillianCore/parserAndCompiler/ParserAndCompiler.ml
@@ -1,3 +1,8 @@
+type compiled_progs = {
+  gil_progs : (string * (Annot.t, string) Prog.t) list;
+  source_files : SourceFiles.t;
+}
+
 module type S = sig
   module TargetLangOptions : sig
     (** Command line options specific to the target language. *)
@@ -16,19 +21,19 @@ module type S = sig
   val pp_err : Format.formatter -> err -> unit
   (** Pretty printer for type {!err} *)
 
-  val parse_and_compile_files :
-    string list -> ((Annot.t, string) Prog.t, err) result
-  (** Takes a path to a set of files, parses them with the user's language, and 
-      then compiles them to a single or a set of GIL programs. The returned GIL 
-      program should be ready to be analysed. *)
+  val parse_and_compile_files : string list -> (compiled_progs, err) result
+  (** Takes a set of source file paths, parses them with the user's language, and
+      then compiles them to a single or a set of GIL programs. The returned GIL
+      program(s) should be ready to be analysed. *)
 
   val other_imports :
     (string * (string -> ((Annot.t, string) Prog.t, err) result)) list
-
-  (** [other_imports] is a association list, that maps extensions to a parser and compiler functions.
-      For example, it is possible to import jsil file in a gil program, using [import file.jsil].
-      In order to do so, the [other_imports] list should contain the double [("jsil", parse_and_compile_jsil_file)] where
-      [parse_and_compile_jsil_file] is a function that takes a file name, parses that jsil file and compiles it to a gil program *)
+  (** [other_imports] is an association list that maps extensions to a parser
+      and compiler. For example, it is possible to import a JSIL file in a GIL
+      program using [import "file.jsil";]. In order to do so, the [other_imports]
+      list should contain the tuple [("jsil", parse_and_compile_jsil_file)] where
+      [parse_and_compile_jsil_file] is a function that takes a file path, parses
+      the file as a JSIL program, and compiles this to a GIL program. *)
 
   val env_var_import_path : string option
   (** Contains the name of the environment variable which contains the path to where the runtime is stored. *)

--- a/GillianCore/parserAndCompiler/ParserAndCompiler.mli
+++ b/GillianCore/parserAndCompiler/ParserAndCompiler.mli
@@ -1,5 +1,11 @@
 (** This defines an interface that allows a user to indicate how to parse their own programming language,
     preprocess the obtained language and compile it to GIL (type [LabProg.t]) *)
+
+type compiled_progs = {
+  gil_progs : (string * (Annot.t, string) Prog.t) list;
+  source_files : SourceFiles.t;
+}
+
 module type S = sig
   module TargetLangOptions : sig
     (** {2 Target-language specific options}
@@ -21,18 +27,19 @@ module type S = sig
   val pp_err : Format.formatter -> err -> unit
   (** Pretty printer for type {!err} *)
 
-  val parse_and_compile_files :
-    string list -> ((Annot.t, string) Prog.t, err) result
-  (** Takes a path to a set of files, parses them with the user's language, and 
-      then compiles them to a single or a set of GIL programs. The returned GIL 
-      program should be ready to be analysed. *)
+  val parse_and_compile_files : string list -> (compiled_progs, err) result
+  (** Takes a set of source file paths, parses them with the user's language, and
+      then compiles them to a single or a set of GIL programs. The returned GIL
+      program(s) should be ready to be analysed. *)
 
   val other_imports :
     (string * (string -> ((Annot.t, string) Prog.t, err) result)) list
-  (** [other_imports] is a association list, that maps extensions to a parser and compiler functions.
-      For example, it is possible to import jsil file in a gil program, using [import file.jsil].
-      In order to do so, the [other_imports] list should contain the double [("jsil", parse_and_compile_jsil_file)] where
-      [parse_and_compile_jsil_file] is a function that takes a file name, parses that jsil file and compiles it to a gil program *)
+  (** [other_imports] is an association list that maps extensions to a parser
+      and compiler. For example, it is possible to import a JSIL file in a GIL
+      program using [import "file.jsil";]. In order to do so, the [other_imports]
+      list should contain the tuple [("jsil", parse_and_compile_jsil_file)] where
+      [parse_and_compile_jsil_file] is a function that takes a file path, parses
+      the file as a JSIL program, and compiles this to a GIL program. *)
 
   val env_var_import_path : string option
   (** Contains the name of the environment variable which contains the path to where the runtime is stored. *)

--- a/GillianCore/parserAndCompiler/dune
+++ b/GillianCore/parserAndCompiler/dune
@@ -1,5 +1,5 @@
 (library
  (name parserAndCompiler)
  (public_name gillian.parserAndCompiler)
- (libraries cmdliner gil_syntax utils)
- (flags -open Gil_syntax -open Utils))
+ (libraries cmdliner gil_syntax utils incrementalAnalysis)
+ (flags -open Gil_syntax -open Utils -open IncrementalAnalysis))

--- a/wisl/lib/ParserAndCompiler/wParserAndCompiler.ml
+++ b/wisl/lib/ParserAndCompiler/wParserAndCompiler.ml
@@ -26,9 +26,16 @@ let parse_file file =
 
 let compile = Wisl2Gil.compile
 
+let create_compilation_result path prog =
+  let open CommandLine.ParserAndCompiler in
+  let open IncrementalAnalysis in
+  let source_files = SourceFiles.make () in
+  SourceFiles.add_source_file source_files path;
+  { gil_progs = [ (path, prog) ]; source_files }
+
 let parse_and_compile_files files =
   let path = List.hd files in
-  Ok (compile path (parse_file path))
+  Ok (create_compilation_result path (compile path (parse_file path)))
 
 let other_imports = []
 

--- a/wisl/lib/ParserAndCompiler/wParserAndCompiler.ml
+++ b/wisl/lib/ParserAndCompiler/wParserAndCompiler.ml
@@ -30,8 +30,9 @@ let create_compilation_result path prog =
   let open CommandLine.ParserAndCompiler in
   let open IncrementalAnalysis in
   let source_files = SourceFiles.make () in
-  SourceFiles.add_source_file source_files path;
-  { gil_progs = [ (path, prog) ]; source_files }
+  let () = SourceFiles.add_source_file source_files path in
+  let gil_path = Filename.chop_extension path ^ ".gil" in
+  { gil_progs = [ (gil_path, prog) ]; source_files }
 
 let parse_and_compile_files files =
   let path = List.hd files in


### PR DESCRIPTION
Depends on #39. `compile` mode should now output all GIL files correctly.