### PR TITLE
Logging: reporters command line interface

### DIFF
--- a/GillianCore/logging/databaseReporter.ml
+++ b/GillianCore/logging/databaseReporter.ml
@@ -30,11 +30,11 @@ let set_not_empty () = (get_state ()).empty <- false
 class virtual ['a] t =
   object (self)
     method log (report : 'a Report.t) =
-      if enabled () then
+      if enabled () then (
         if is_empty () then set_not_empty ()
         else Printf.fprintf self#out_channel ",\n";
-      Report.yojson_of_t self#specific_serializer report
-      |> Yojson.Safe.to_channel self#out_channel
+        Report.yojson_of_t self#specific_serializer report
+        |> Yojson.Safe.to_channel self#out_channel )
 
     method wrap_up = wrap_up ()
 

--- a/GillianCore/logging/databaseReporter.ml
+++ b/GillianCore/logging/databaseReporter.ml
@@ -7,8 +7,6 @@ end
 include Reporter.Make (struct
   include Types
 
-  let enabled = false
-
   let conf = { filename = "database.log" }
 
   let initialize { filename; _ } =

--- a/GillianCore/logging/fileReporter.ml
+++ b/GillianCore/logging/fileReporter.ml
@@ -7,9 +7,7 @@ end
 include Reporter.Make (struct
   include Types
 
-  let enabled = true
-
-  let conf = { filename = "out.log" }
+  let conf = { filename = "file.log" }
 
   let initialize { filename; _ } =
     let out_channel = open_out filename in

--- a/GillianCore/logging/logging.mli
+++ b/GillianCore/logging/logging.mli
@@ -27,8 +27,6 @@ end
 module FileReporter : sig
   val enable : unit -> unit
 
-  val disable : unit -> unit
-
   class virtual ['a] t :
     object
       method log : 'a Report.t -> unit
@@ -43,8 +41,6 @@ end
 
 module DatabaseReporter : sig
   val enable : unit -> unit
-
-  val disable : unit -> unit
 
   class virtual ['a] t :
     object

--- a/GillianCore/logging/reporter.ml
+++ b/GillianCore/logging/reporter.ml
@@ -1,8 +1,6 @@
 type 'a t = < log : 'a Report.t -> unit ; wrap_up : unit >
 
 module Make (P : sig
-  val enabled : bool
-
   type conf
 
   val conf : conf
@@ -14,11 +12,9 @@ module Make (P : sig
   val wrap_up : state -> unit
 end) =
 struct
-  let enabled, enable, disable =
-    let enabled = ref P.enabled in
-    ( (fun () -> !enabled),
-      (fun () -> enabled := true),
-      fun () -> enabled := false )
+  let enabled, enable =
+    let enabled = ref false in
+    ((fun () -> !enabled), fun () -> enabled := true)
 
   type conf = P.conf
 


### PR DESCRIPTION
Allows the user to control which reporters are used when logging by enabling them from the command line.