### PR TITLE
for and while loop fixes in JS-2-JSIL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ see_deps.py
 
 # VSCode
 .vscode/settings.json
+
+# test-262
+javert-test262


### PR DESCRIPTION
Fixes incorrect break tracking for for and while loops introduced by invariants.