### PR TITLE
remove useless functions from state and memory interfaces

### DIFF
--- a/Gillian-C/lib/CMemory.ml
+++ b/Gillian-C/lib/CMemory.ml
@@ -32,7 +32,6 @@ let pp fmt h =
 let ga_to_setter = LActions.ga_to_setter_str
 let ga_to_getter = LActions.ga_to_getter_str
 let ga_to_deleter = LActions.ga_to_deleter_str
-let ga_loc_indexes _ = [ 0 ]
 
 let execute_store heap params =
   let open Gillian.Gil_syntax.Literal in

--- a/Gillian-C/lib/LActions.ml
+++ b/Gillian-C/lib/LActions.ml
@@ -222,16 +222,3 @@ let ga_to_deleter_str = ga_to_action_str ga_to_deleter
 (** Additional stuff *)
 
 let is_overlapping_asrt_str str = ga_from_str str |> is_overlapping_asrt
-
-let ga_loc_indexes ga =
-  match ga with
-  | GMem Single -> [ 0 ]
-  | GMem Array -> [ 0 ]
-  | GMem Hole -> [ 0 ]
-  | GMem Zeros -> [ 0 ]
-  | GMem Bounds -> [ 0 ]
-  | GMem Freed -> [ 0 ]
-  | GGenv Definition -> [ 0 ]
-  | GGenv Symbol -> [ 1 ]
-
-let ga_loc_indexes_str ga_str = ga_from_str ga_str |> ga_loc_indexes

--- a/Gillian-C/lib/LActions.mli
+++ b/Gillian-C/lib/LActions.mli
@@ -63,4 +63,3 @@ val ga_to_deleter_str : string -> string
 (** {3 Gillian-related things} *)
 
 val is_overlapping_asrt_str : string -> bool
-val ga_loc_indexes_str : string -> int list

--- a/Gillian-C/lib/MonadicSMemory.ml
+++ b/Gillian-C/lib/MonadicSMemory.ml
@@ -966,7 +966,6 @@ let assertions ?to_keep:_ heap =
 
 let mem_constraints _heap = []
 let is_overlapping_asrt = LActions.is_overlapping_asrt_str
-let ga_loc_indexes = LActions.ga_loc_indexes_str
 
 (** Things defined for BiAbduction *)
 

--- a/Gillian-JS/lib/Semantics/JSILCMemory.ml
+++ b/Gillian-JS/lib/Semantics/JSILCMemory.ml
@@ -169,12 +169,6 @@ module M : Memory_S = struct
     else if a_id = JSILNames.aProps then JSILNames.delProps
     else raise (Failure "DEATH. ga_to_setter")
 
-  let ga_loc_indexes (a_id : string) : int list =
-    if a_id = JSILNames.aCell then [ 0 ]
-    else if a_id = JSILNames.aMetadata then [ 0 ]
-    else if a_id = JSILNames.aProps then [ 0 ]
-    else raise (Failure "DEATH. ga_to_setter")
-
   (** Non-implemented functions *)
   let assertions ?to_keep:_ (_ : t) : Asrt.t list =
     raise (Failure "ERROR: to_assertions called for concrete executions")

--- a/Gillian-JS/lib/Semantics/JSILSMemory.ml
+++ b/Gillian-JS/lib/Semantics/JSILSMemory.ml
@@ -587,12 +587,6 @@ module M = struct
     else if a_id = JSILNames.aProps then JSILNames.delProps
     else raise (Failure "DEATH. ga_to_setter")
 
-  let ga_loc_indexes (a_id : string) : int list =
-    if a_id = JSILNames.aCell then [ 0 ]
-    else if a_id = JSILNames.aMetadata then [ 0 ]
-    else if a_id = JSILNames.aProps then [ 0 ]
-    else raise (Failure "DEATH. ga_to_setter")
-
   let mem_constraints (state : t) : Formula.t list = SHeap.wf_assertions state
 
   let is_overlapping_asrt (a : string) : bool =

--- a/GillianCore/engine/Abstraction/PState.ml
+++ b/GillianCore/engine/Abstraction/PState.ml
@@ -1179,13 +1179,6 @@ module Make
     let state, _, _ = astate in
     State.mem_constraints state
 
-  let merge_ins (action : string) (l_ins : vt list) (o_ins : vt list) : vt list
-      =
-    State.merge_ins action l_ins o_ins
-
-  let split_ins (action : string) (ins : vt list) : vt list * vt list =
-    State.split_ins action ins
-
   let is_overlapping_asrt (a : string) : bool = State.is_overlapping_asrt a
   let pp_err = State.pp_err
   let pp_fix = State.pp_fix

--- a/GillianCore/engine/BiAbduction/BiState.ml
+++ b/GillianCore/engine/BiAbduction/BiState.ml
@@ -546,13 +546,6 @@ struct
     let _, state, _ = bi_state in
     State.mem_constraints state
 
-  let merge_ins (action : string) (l_ins : vt list) (o_ins : vt list) : vt list
-      =
-    State.merge_ins action l_ins o_ins
-
-  let split_ins (action : string) (ins : vt list) : vt list * vt list =
-    State.split_ins action ins
-
   let is_overlapping_asrt (a : string) : bool = State.is_overlapping_asrt a
   let pp_err = State.pp_err
   let pp_fix = State.pp_fix

--- a/GillianCore/engine/ConcreteSemantics/CMemory.ml
+++ b/GillianCore/engine/ConcreteSemantics/CMemory.ml
@@ -24,7 +24,6 @@ module type S = sig
   val ga_to_setter : string -> string
   val ga_to_getter : string -> string
   val ga_to_deleter : string -> string
-  val ga_loc_indexes : string -> int list
   val is_overlapping_asrt : string -> bool
 
   (** State Copy *)

--- a/GillianCore/engine/ConcreteSemantics/CState.ml
+++ b/GillianCore/engine/ConcreteSemantics/CState.ml
@@ -204,12 +204,6 @@ module Make
   let mem_constraints (_ : t) : Formula.t list =
     raise (Failure "DEATH. mem_constraints")
 
-  let split_ins (_ : string) (_ : vt list) : vt list * vt list =
-    raise (Failure "DEATH. split_ins")
-
-  let merge_ins (_ : string) (_ : vt list) (_ : vt list) : vt list =
-    raise (Failure "merge_ins. DEATH")
-
   let pp_fix _ _ = raise (Failure "str_of_fix from non-symbolic state.")
 
   let get_recovery_vals _ =

--- a/GillianCore/engine/GeneralSemantics/State.ml
+++ b/GillianCore/engine/GeneralSemantics/State.ml
@@ -152,8 +152,6 @@ module type S = sig
   val produce_posts : t -> st -> Asrt.t list -> t list
   val produce : t -> st -> Asrt.t -> (t list, string) result
   val update_subst : t -> st -> unit
-  val split_ins : string -> vt list -> vt list * vt list
-  val merge_ins : string -> vt list -> vt list -> vt list
   val mem_constraints : t -> Formula.t list
   val can_fix : err_t list -> bool
   val get_failing_constraint : err_t -> Formula.t

--- a/GillianCore/engine/SymbolicSemantics/SMemory.ml
+++ b/GillianCore/engine/SymbolicSemantics/SMemory.ml
@@ -32,7 +32,6 @@ module type S = sig
   val ga_to_setter : string -> string
   val ga_to_getter : string -> string
   val ga_to_deleter : string -> string
-  val ga_loc_indexes : string -> int list
   val is_overlapping_asrt : string -> bool
 
   (** State Copy *)

--- a/GillianCore/monadic/MonadicSMemory.ml
+++ b/GillianCore/monadic/MonadicSMemory.ml
@@ -28,7 +28,6 @@ module type S = sig
   val ga_to_setter : string -> string
   val ga_to_getter : string -> string
   val ga_to_deleter : string -> string
-  val ga_loc_indexes : string -> int list
   val is_overlapping_asrt : string -> bool
 
   (** State Copy *)

--- a/wisl/lib/semantics/wislCMemory.ml
+++ b/wisl/lib/semantics/wislCMemory.ml
@@ -16,13 +16,6 @@ let ga_to_setter = WislLActions.ga_to_setter_str
 let ga_to_getter = WislLActions.ga_to_getter_str
 let ga_to_deleter = WislLActions.ga_to_deleter_str
 
-let ga_loc_indexes a_id =
-  WislLActions.(
-    match ga_from_str a_id with
-    | Cell -> [ 0 ]
-    | Bound -> [ 0 ]
-    | Freed -> [ 0 ])
-
 (* Small util for retrocompat *)
 let vstr v = Format.asprintf "%a" Values.pp v
 

--- a/wisl/lib/semantics/wislSMemory.ml
+++ b/wisl/lib/semantics/wislSMemory.ml
@@ -259,14 +259,6 @@ let execute_action ?unification:_ name heap pfs gamma args =
 let ga_to_setter = WislLActions.ga_to_setter_str
 let ga_to_getter = WislLActions.ga_to_getter_str
 let ga_to_deleter = WislLActions.ga_to_deleter_str
-
-let ga_loc_indexes a_id =
-  WislLActions.(
-    match ga_from_str a_id with
-    | Cell -> [ 0 ]
-    | Bound -> [ 0 ]
-    | Freed -> [ 0 ])
-
 let copy = WislSHeap.copy
 let pp fmt h = Format.fprintf fmt "%a" WislSHeap.pp h
 


### PR DESCRIPTION
Just read and merge, it compiles so there's nothing to confirm