### PR TITLE
symbol() is now used to generate fresh svars

### DIFF
--- a/Gillian-C/lib/parserAndCompiler.ml
+++ b/Gillian-C/lib/parserAndCompiler.ml
@@ -383,24 +383,24 @@ let parse_and_compile_files paths =
         | a, b -> compare a b)
       init_asrts
   in
+  let main_path = List.hd paths in
+  let main_prog, Gilgen.{ genv_pred_asrts; genv_init_cmds; _ } =
+    Hashtbl.find compiled_progs (List.hd paths)
+  in
   let init_cmds =
     List.sort_uniq
       (fun a b ->
         match (a, b) with
         | ( Cmd.Call (_, _, Lit (String a) :: _, _, _),
             Cmd.Call (_, _, Lit (String b) :: _, _, _) ) -> String.compare a b
-        | a, b -> compare a b)
-      init_cmds
-  in
-  let main_path = List.hd paths in
-  let main_prog, Gilgen.{ genv_pred_asrts; genv_init_cmds; _ } =
-    Hashtbl.find compiled_progs (List.hd paths)
+        | _ -> failwith "Wrong init cmd")
+      (init_cmds @ genv_init_cmds)
   in
   let current_genv_config = CConstants.GEnvConfig.current_genv_config () in
   let all_imports =
     Imports.imports current_arch exec_mode current_genv_config @ imports
   in
-  let init_proc = Gilgen.make_init_proc (genv_init_cmds @ init_cmds) in
+  let init_proc = Gilgen.make_init_proc init_cmds in
   let init_proc_name = init_proc.Proc.proc_name in
   let all_proc_names = init_proc_name :: main_prog.proc_names in
   let () = Hashtbl.add main_prog.procs init_proc_name init_proc in

--- a/Gillian-C/runtime/binops_common.gil
+++ b/Gillian-C/runtime/binops_common.gil
@@ -165,7 +165,7 @@ proc i__binop_mod(v1, v2) {
 proc i__binop_mulfs(v1, v2) {
         goto [ l-nth(v1, 0i) = "single" ] llon unde;
   llon: goto [ l-nth(v2, 0i) = "single" ] blon unde;
-  blon: ret := {{ "single", l-nth(v1, 1i) i* l-nth(v2, 1i) }};
+  blon: ret := {{ "single", l-nth(v1, 1i) * l-nth(v2, 1i) }};
         return;
   unde: fail[operator]("Using *s operator for non-long elements")
 };

--- a/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays1.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays1.js
@@ -309,10 +309,10 @@ buckets.arrays.forEach = function (array, callback) {
 
 // ------------------------------ our test now -------------------------------
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays2.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays2.js
@@ -309,10 +309,10 @@ buckets.arrays.forEach = function (array, callback) {
 
 // ------------------------------ our test now -------------------------------
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays3.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays3.js
@@ -309,10 +309,10 @@ buckets.arrays.forEach = function (array, callback) {
 
 // ------------------------------ our test now -------------------------------
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays4.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays4.js
@@ -309,10 +309,10 @@ buckets.arrays.forEach = function (array, callback) {
 
 // ------------------------------ our test now -------------------------------
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays5.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays5.js
@@ -309,10 +309,10 @@ buckets.arrays.forEach = function (array, callback) {
 
 // ------------------------------ our test now -------------------------------
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays6.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays6.js
@@ -309,10 +309,10 @@ buckets.arrays.forEach = function (array, callback) {
 
 // ------------------------------ our test now -------------------------------
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays7.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays7.js
@@ -309,10 +309,10 @@ buckets.arrays.forEach = function (array, callback) {
 
 // ------------------------------ our test now -------------------------------
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays8.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays8.js
@@ -309,10 +309,10 @@ buckets.arrays.forEach = function (array, callback) {
 
 // ------------------------------ our test now -------------------------------
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));
@@ -334,7 +334,7 @@ var reset = function() {
 reset();
 
 // swap
-var i = symb_number(i);
+var i = symb_number();
 var res = buckets.arrays.swap(numberArray, 0, i);
 var l = numberArray.length;
 Assert(((i >= 0) and (i < l) and res) or (((i < 0) or (i >= l)) and (not res)));

--- a/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays9.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/arrays/arrays9.js
@@ -309,10 +309,10 @@ buckets.arrays.forEach = function (array, callback) {
 
 // ------------------------------ our test now -------------------------------
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/Buckets/bag/bag1.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bag/bag1.js
@@ -952,8 +952,8 @@ buckets.Bag = function (toStrFunction) {
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
+var n1 = symb_number();
+var n2 = symb_number();
 
 bag.add(n1, n2);
 var res1 = bag.size();

--- a/Gillian-JS/Examples/Cosette/Buckets/bag/bag2.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bag/bag2.js
@@ -952,8 +952,8 @@ buckets.Bag = function (toStrFunction) {
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
+var n1 = symb_number();
+var n2 = symb_number();
 
 bag.add(n1);
 

--- a/Gillian-JS/Examples/Cosette/Buckets/bag/bag3.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bag/bag3.js
@@ -952,10 +952,10 @@ buckets.Bag = function (toStrFunction) {
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
-var n4 = symb_number(n4);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
+var n4 = symb_number();
 
 bag.add(n1);
 bag.add(n1, n2);

--- a/Gillian-JS/Examples/Cosette/Buckets/bag/bag4.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bag/bag4.js
@@ -952,10 +952,10 @@ buckets.Bag = function (toStrFunction) {
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-//var n3 = symb_number(n3);
-//var n4 = symb_number(n4);
+var n1 = symb_number();
+var n2 = symb_number();
+//var n3 = symb_number();
+//var n4 = symb_number();
 //Assume(n3 > 0);
 //Assume(n4 > 0);
 

--- a/Gillian-JS/Examples/Cosette/Buckets/bag/bag5.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bag/bag5.js
@@ -952,8 +952,8 @@ buckets.Bag = function (toStrFunction) {
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
+var n1 = symb_number();
+var n2 = symb_number();
 
 bag.add(n1);
 bag.add(n2);

--- a/Gillian-JS/Examples/Cosette/Buckets/bag/bag6.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bag/bag6.js
@@ -952,10 +952,10 @@ buckets.Bag = function (toStrFunction) {
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
-var n4 = symb_number(n4);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
+var n4 = symb_number();
 
 var res1 = bag.isEmpty();
 Assert(res1);

--- a/Gillian-JS/Examples/Cosette/Buckets/bag/bag7.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bag/bag7.js
@@ -952,9 +952,9 @@ buckets.Bag = function (toStrFunction) {
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
 
 bag.add(n1);
 bag.add(n2);

--- a/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree1.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree1.js
@@ -1114,9 +1114,9 @@ buckets.BSTree = function (compareFunction) {
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree10.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree10.js
@@ -1114,9 +1114,9 @@ buckets.BSTree = function (compareFunction) {
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree11.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree11.js
@@ -1114,9 +1114,9 @@ buckets.BSTree = function (compareFunction) {
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));
@@ -1133,7 +1133,7 @@ bst2 = new buckets.BSTree();
 var res2 = bst.equals(bst2);
 Assert(not res2);
 
-var x4 = symb_number(x4);
+var x4 = symb_number();
 
 bst2.add(x2);
 bst2.add(x3);

--- a/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree2.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree2.js
@@ -1114,10 +1114,10 @@ buckets.BSTree = function (compareFunction) {
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree3.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree3.js
@@ -1114,9 +1114,9 @@ buckets.BSTree = function (compareFunction) {
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree4.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree4.js
@@ -1114,9 +1114,9 @@ buckets.BSTree = function (compareFunction) {
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree5.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree5.js
@@ -1114,9 +1114,9 @@ buckets.BSTree = function (compareFunction) {
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));
@@ -1128,7 +1128,7 @@ bst.add(x3);
 
 // test2: something fails
 
-var x4 = symb_number(x4);
+var x4 = symb_number();
 var ar2 = [];
 bst.inorderTraversal(function(x) {
   if (x === x4) {

--- a/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree6.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree6.js
@@ -1114,9 +1114,9 @@ buckets.BSTree = function (compareFunction) {
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));
@@ -1128,7 +1128,7 @@ bst.add(x3);
 
 // test2: something fails
 
-var x4 = symb_number(x4);
+var x4 = symb_number();
 var ar2 = [];
 bst.preorderTraversal(function(x) {
   if (x === x4) {

--- a/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree7.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree7.js
@@ -1114,9 +1114,9 @@ buckets.BSTree = function (compareFunction) {
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));
@@ -1128,7 +1128,7 @@ bst.add(x3);
 
 // test2: something fails
 
-var x4 = symb_number(x4);
+var x4 = symb_number();
 var ar2 = [];
 bst.postorderTraversal(function(x) {
   if (x === x4) {

--- a/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree8.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree8.js
@@ -1114,9 +1114,9 @@ buckets.BSTree = function (compareFunction) {
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));
@@ -1128,7 +1128,7 @@ bst.add(x3);
 
 // test2: something fails
 
-var x4 = symb_number(x4);
+var x4 = symb_number();
 var ar2 = [];
 bst.levelTraversal(function(x) {
   if (x === x4) {

--- a/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree9.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/bstree/bstree9.js
@@ -1114,9 +1114,9 @@ buckets.BSTree = function (compareFunction) {
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary1.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary1.js
@@ -353,10 +353,10 @@ buckets.Dictionary = function (toStrFunction) {
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 dict.set(s1, x1);
 var res1 = dict.set(s2, x2);
@@ -366,7 +366,7 @@ Assert(((s1 = s2) and (res1 = x1)) or ((not (s1 = s2)) and (res1 = undefined)));
 var res2 = dict.set(s1, undefined);
 Assert(res2 = undefined);
 
-var s3 = symb_string(s3);
+var s3 = symb_string();
 Assume(not (s3 = s1));
 Assume(not (s3 = s2));
 

--- a/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary2.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary2.js
@@ -353,10 +353,10 @@ buckets.Dictionary = function (toStrFunction) {
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 dict.set(s1, x1);
 dict.set(s2, x2);

--- a/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary3.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary3.js
@@ -353,10 +353,10 @@ buckets.Dictionary = function (toStrFunction) {
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 Assume(not (s1 = s2));
 

--- a/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary4.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary4.js
@@ -353,10 +353,10 @@ buckets.Dictionary = function (toStrFunction) {
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 Assume(not (s1 = s2));
 
@@ -366,7 +366,7 @@ dict.set(s2, x2);
 
 var res1 = "";
 var res2 = 0;
-var s3 = symb_string(s3);
+var s3 = symb_string();
 
 dict.forEach(function(k, v) {
   if (k === s3) {

--- a/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary5.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary5.js
@@ -353,10 +353,10 @@ buckets.Dictionary = function (toStrFunction) {
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 dict.set(s1, x1);
 dict.set(s2, x2);

--- a/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary6.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary6.js
@@ -353,10 +353,10 @@ buckets.Dictionary = function (toStrFunction) {
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 dict.set(s1, x1);
 dict.set(s2, x2);

--- a/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary7.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/dictionary/dictionary7.js
@@ -353,10 +353,10 @@ buckets.Dictionary = function (toStrFunction) {
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 Assume(not (s1 = s2));
 

--- a/Gillian-JS/Examples/Cosette/Buckets/heap/heap1.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/heap/heap1.js
@@ -557,10 +557,10 @@ buckets.Heap = function (compareFunction) {
 
 var heap = new buckets.Heap();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/heap/heap2.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/heap/heap2.js
@@ -557,10 +557,10 @@ buckets.Heap = function (compareFunction) {
 
 var heap = new buckets.Heap();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/heap/heap3.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/heap/heap3.js
@@ -557,10 +557,10 @@ buckets.Heap = function (compareFunction) {
 
 var heap = new buckets.Heap();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/heap/heap4.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/heap/heap4.js
@@ -557,10 +557,10 @@ buckets.Heap = function (compareFunction) {
 
 var heap = new buckets.Heap();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/linkedlist/bug/linkedlist_bug_1.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/linkedlist/bug/linkedlist_bug_1.js
@@ -520,9 +520,9 @@ buckets.LinkedList = function () {
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 list.add(x1)
 list.add(x2)

--- a/Gillian-JS/Examples/Cosette/Buckets/linkedlist/bug/linkedlist_bug_2.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/linkedlist/bug/linkedlist_bug_2.js
@@ -524,10 +524,10 @@ buckets.LinkedList = function () {
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/linkedlist/bug/linkedlist_bug_3.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/linkedlist/bug/linkedlist_bug_3.js
@@ -532,10 +532,10 @@ buckets.LinkedList = function () {
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist1.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist1.js
@@ -536,10 +536,10 @@ buckets.LinkedList = function () {
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist2.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist2.js
@@ -536,10 +536,10 @@ buckets.LinkedList = function () {
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist3.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist3.js
@@ -536,10 +536,10 @@ buckets.LinkedList = function () {
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist4.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist4.js
@@ -536,10 +536,10 @@ buckets.LinkedList = function () {
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist5.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist5.js
@@ -537,10 +537,10 @@ buckets.LinkedList = function () {
 var list1 = new buckets.LinkedList();
 var list2 = new buckets.LinkedList();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 list1.add(x1);
 list1.add(x2);

--- a/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist6.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist6.js
@@ -536,10 +536,10 @@ buckets.LinkedList = function () {
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 // Assume(not (x1 = x2));
 // Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist7.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist7.js
@@ -536,9 +536,9 @@ buckets.LinkedList = function () {
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist8.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist8.js
@@ -536,10 +536,10 @@ buckets.LinkedList = function () {
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist9.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/linkedlist/linkedlist9.js
@@ -536,10 +536,10 @@ buckets.LinkedList = function () {
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/multidictionary/bug/multidictionary_bug.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/multidictionary/bug/multidictionary_bug.js
@@ -755,9 +755,9 @@ buckets.MultiDictionary = function (toStrFunction, valuesEqualsFunction) {
 
 var dict = new buckets.MultiDictionary()
 
-var s = symb_string(s);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
+var s = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
 
 dict.set(s, x1);
 dict.set(s, x2);

--- a/Gillian-JS/Examples/Cosette/Buckets/multidictionary/multidictionary1.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/multidictionary/multidictionary1.js
@@ -749,10 +749,10 @@ buckets.MultiDictionary = function (toStrFunction, valuesEqualsFunction) {
 
 var dict = new buckets.MultiDictionary()
 
-var s1 = symb_string(s1);
-var s2 = symb_string(s2);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
+var s1 = symb_string();
+var s2 = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
 
 dict.set(s1, x1);
 dict.set(s2, x2);
@@ -760,7 +760,7 @@ dict.set(s2, x2);
 var res1 = dict.set(s1, undefined);
 Assert(not res1);
 
-var s3 = symb_string(s3);
+var s3 = symb_string();
 Assume(not (s1 = s3));
 Assume(not (s2 = s3));
 var res2 = dict.get(s3).length;

--- a/Gillian-JS/Examples/Cosette/Buckets/multidictionary/multidictionary2.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/multidictionary/multidictionary2.js
@@ -749,10 +749,10 @@ buckets.MultiDictionary = function (toStrFunction, valuesEqualsFunction) {
 
 var dict = new buckets.MultiDictionary()
 
-var s1 = symb_string(s1);
-var s2 = symb_string(s2);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
+var s1 = symb_string();
+var s2 = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
 
 Assume(not (x1 = x2));
 

--- a/Gillian-JS/Examples/Cosette/Buckets/multidictionary/multidictionary3.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/multidictionary/multidictionary3.js
@@ -749,11 +749,11 @@ buckets.MultiDictionary = function (toStrFunction, valuesEqualsFunction) {
 
 var dict = new buckets.MultiDictionary()
 
-var s1 = symb_string(s1);
-var s2 = symb_string(s2);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var s1 = symb_string();
+var s2 = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume (not (x1 = x2));
 Assume (not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/multidictionary/multidictionary4.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/multidictionary/multidictionary4.js
@@ -749,11 +749,11 @@ buckets.MultiDictionary = function (toStrFunction, valuesEqualsFunction) {
 
 var dict = new buckets.MultiDictionary()
 
-var s1 = symb_string(s1);
-var s2 = symb_string(s2);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var s1 = symb_string();
+var s2 = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume (not (x1 = x2));
 Assume (not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/multidictionary/multidictionary5.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/multidictionary/multidictionary5.js
@@ -749,11 +749,11 @@ buckets.MultiDictionary = function (toStrFunction, valuesEqualsFunction) {
 
 var dict = new buckets.MultiDictionary()
 
-var s1 = symb_string(s1);
-var s2 = symb_string(s2);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var s1 = symb_string();
+var s2 = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume (not (x1 = x2));
 Assume (not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/Buckets/multidictionary/multidictionary6.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/multidictionary/multidictionary6.js
@@ -750,10 +750,10 @@ buckets.MultiDictionary = function (toStrFunction, valuesEqualsFunction) {
 var dict1 = new buckets.MultiDictionary();
 var dict2 = new buckets.MultiDictionary();
 
-var s1 = symb_string(s1);
-var s2 = symb_string(s2);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
+var s1 = symb_string();
+var s2 = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
 
 Assume (not (x1 = x2));
 

--- a/Gillian-JS/Examples/Cosette/Buckets/priorityqueue/priorityqueue1.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/priorityqueue/priorityqueue1.js
@@ -716,9 +716,9 @@ buckets.PriorityQueue = function (compareFunction) {
 
 var pqueue = new buckets.PriorityQueue();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 pqueue.enqueue(x1);
 pqueue.add(x2);

--- a/Gillian-JS/Examples/Cosette/Buckets/priorityqueue/priorityqueue2.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/priorityqueue/priorityqueue2.js
@@ -716,9 +716,9 @@ buckets.PriorityQueue = function (compareFunction) {
 
 var pqueue = new buckets.PriorityQueue();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 pqueue.enqueue(x1);
 pqueue.enqueue(x2);

--- a/Gillian-JS/Examples/Cosette/Buckets/priorityqueue/priorityqueue3.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/priorityqueue/priorityqueue3.js
@@ -716,9 +716,9 @@ buckets.PriorityQueue = function (compareFunction) {
 
 var pqueue = new buckets.PriorityQueue();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 pqueue.enqueue(x1);
 pqueue.enqueue(x2);

--- a/Gillian-JS/Examples/Cosette/Buckets/priorityqueue/priorityqueue4.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/priorityqueue/priorityqueue4.js
@@ -716,9 +716,9 @@ buckets.PriorityQueue = function (compareFunction) {
 
 var pqueue = new buckets.PriorityQueue();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 pqueue.enqueue(x1);
 pqueue.enqueue(x2);

--- a/Gillian-JS/Examples/Cosette/Buckets/priorityqueue/priorityqueue5.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/priorityqueue/priorityqueue5.js
@@ -716,9 +716,9 @@ buckets.PriorityQueue = function (compareFunction) {
 
 var pqueue = new buckets.PriorityQueue();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 pqueue.enqueue(x1);
 pqueue.enqueue(x2);

--- a/Gillian-JS/Examples/Cosette/Buckets/queue/queue1.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/queue/queue1.js
@@ -679,9 +679,9 @@ buckets.Queue = function () {
 
 var queue = new buckets.Queue();
 
-var x1 = symb_number(x1); // 1
-var x2 = symb_number(x2); // 2
-var x3 = symb_number(x3); // 3
+var x1 = symb_number(); // 1
+var x2 = symb_number(); // 2
+var x3 = symb_number(); // 3
 Assume((x1 < x2) and (x2 < x3));
 
 function createQueue() {
@@ -700,7 +700,7 @@ Assert(size = 0);
 createQueue();
 var size = queue.size();
 Assert(size = 3);
-var x4 = symb_number(x4);
+var x4 = symb_number();
 queue.add(x4); // synonym to enqueue
 var size = queue.size();
 Assert(size = 4);

--- a/Gillian-JS/Examples/Cosette/Buckets/queue/queue2.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/queue/queue2.js
@@ -678,9 +678,9 @@ buckets.Queue = function () {
 
 var queue = new buckets.Queue();
 
-var x1 = symb_number(x1); // 1
-var x2 = symb_number(x2); // 2
-var x3 = symb_number(x3); // 3
+var x1 = symb_number(); // 1
+var x2 = symb_number(); // 2
+var x3 = symb_number(); // 3
 Assume((x1 < x2) and (x2 < x3));
 
 function createQueue() {

--- a/Gillian-JS/Examples/Cosette/Buckets/queue/queue3.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/queue/queue3.js
@@ -678,9 +678,9 @@ buckets.Queue = function () {
 
 var queue = new buckets.Queue();
 
-var x1 = symb_number(x1); // 1
-var x2 = symb_number(x2); // 2
-var x3 = symb_number(x3); // 3
+var x1 = symb_number(); // 1
+var x2 = symb_number(); // 2
+var x3 = symb_number(); // 3
 Assume((x1 < x2) and (x2 < x3));
 
 function createQueue() {

--- a/Gillian-JS/Examples/Cosette/Buckets/queue/queue4.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/queue/queue4.js
@@ -678,9 +678,9 @@ buckets.Queue = function () {
 
 var queue = new buckets.Queue();
 
-var x1 = symb_number(x1); // 1
-var x2 = symb_number(x2); // 2
-var x3 = symb_number(x3); // 3
+var x1 = symb_number(); // 1
+var x2 = symb_number(); // 2
+var x3 = symb_number(); // 3
 Assume((x1 < x2) and (x2 < x3));
 
 function createQueue() {

--- a/Gillian-JS/Examples/Cosette/Buckets/queue/queue5.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/queue/queue5.js
@@ -678,9 +678,9 @@ buckets.Queue = function () {
 
 var queue = new buckets.Queue();
 
-var x1 = symb_number(x1); // 1
-var x2 = symb_number(x2); // 2
-var x3 = symb_number(x3); // 3
+var x1 = symb_number(); // 1
+var x2 = symb_number(); // 2
+var x3 = symb_number(); // 3
 Assume((x1 < x2) and (x2 < x3));
 
 function createQueue() {

--- a/Gillian-JS/Examples/Cosette/Buckets/queue/queue6.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/queue/queue6.js
@@ -678,9 +678,9 @@ buckets.Queue = function () {
 
 var queue = new buckets.Queue();
 
-var x1 = symb_number(x1); // 1
-var x2 = symb_number(x2); // 2
-var x3 = symb_number(x3); // 3
+var x1 = symb_number(); // 1
+var x2 = symb_number(); // 2
+var x3 = symb_number(); // 3
 Assume((x1 < x2) and (x2 < x3));
 
 function createQueue() {

--- a/Gillian-JS/Examples/Cosette/Buckets/set/set1.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/set/set1.js
@@ -548,12 +548,12 @@ buckets.Set = function (toStringFunction) {
 
 var set = new buckets.Set();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
+var x1 = symb_number();
+var x2 = symb_number();
 
 set.add(x1);
 var res = set.add(x2);
 
-var x3 = symb_number(x3);
+var x3 = symb_number();
 var res2 = set.contains(x3);
 

--- a/Gillian-JS/Examples/Cosette/Buckets/set/set2.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/set/set2.js
@@ -549,9 +549,9 @@ buckets.Set = function (toStringFunction) {
 var set1 = new buckets.Set();
 var set2 = new buckets.Set();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 

--- a/Gillian-JS/Examples/Cosette/Buckets/set/set3.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/set/set3.js
@@ -549,10 +549,10 @@ buckets.Set = function (toStringFunction) {
 var set1 = new buckets.Set();
 var set2 = new buckets.Set();
 
-var x1 = symb_string(x1);
-var x2 = symb_string(x2);
-var x3 = symb_string(x3);
-var x4 = symb_string(x4);
+var x1 = symb_string();
+var x2 = symb_string();
+var x3 = symb_string();
+var x4 = symb_string();
 
 set1.add(x1);
 set1.add(x2);

--- a/Gillian-JS/Examples/Cosette/Buckets/set/set4.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/set/set4.js
@@ -549,9 +549,9 @@ buckets.Set = function (toStringFunction) {
 var set1 = new buckets.Set();
 var set2 = new buckets.Set();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x3));
 

--- a/Gillian-JS/Examples/Cosette/Buckets/set/set5.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/set/set5.js
@@ -548,8 +548,8 @@ buckets.Set = function (toStringFunction) {
 
 var set = new buckets.Set();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
+var x1 = symb_number();
+var x2 = symb_number();
 
 var res1 = set.isEmpty();
 Assert(res1);

--- a/Gillian-JS/Examples/Cosette/Buckets/set/set6.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/set/set6.js
@@ -549,9 +549,9 @@ buckets.Set = function (toStringFunction) {
 var set1 = new buckets.Set();
 var set2 = new buckets.Set();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x3));
 

--- a/Gillian-JS/Examples/Cosette/Buckets/stack/stack1.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/stack/stack1.js
@@ -670,9 +670,9 @@ buckets.Stack = function () {
 
 var stack = new buckets.Stack();
 
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));
 Assume(not (n2 = n3));

--- a/Gillian-JS/Examples/Cosette/Buckets/stack/stack2.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/stack/stack2.js
@@ -670,9 +670,9 @@ buckets.Stack = function () {
 
 var stack = new buckets.Stack();
 
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));
 Assume(not (n2 = n3));

--- a/Gillian-JS/Examples/Cosette/Buckets/stack/stack3.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/stack/stack3.js
@@ -670,9 +670,9 @@ buckets.Stack = function () {
 
 var stack = new buckets.Stack();
 
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));
 Assume(not (n2 = n3));

--- a/Gillian-JS/Examples/Cosette/Buckets/stack/stack4.js
+++ b/Gillian-JS/Examples/Cosette/Buckets/stack/stack4.js
@@ -670,9 +670,9 @@ buckets.Stack = function () {
 
 var stack = new buckets.Stack();
 
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));
 Assume(not (n2 = n3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays1.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays1.js
@@ -1,9 +1,9 @@
 var buckets = require('../../buckets');
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays2.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays2.js
@@ -1,9 +1,9 @@
 var buckets = require('../../buckets');
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays3.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays3.js
@@ -1,9 +1,9 @@
 var buckets = require('../../buckets');
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays4.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays4.js
@@ -1,9 +1,9 @@
 var buckets = require('../../buckets');
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays5.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays5.js
@@ -1,9 +1,9 @@
 var buckets = require('../../buckets');
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays6.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays6.js
@@ -1,9 +1,9 @@
 var buckets = require('../../buckets');
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays7.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays7.js
@@ -1,9 +1,9 @@
 var buckets = require('../../buckets');
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays8.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays8.js
@@ -1,9 +1,9 @@
 var buckets = require('../../buckets');
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));
@@ -25,7 +25,7 @@ var reset = function() {
 reset();
 
 // swap
-var i = symb_number(i);
+var i = symb_number();
 var res = buckets.arrays.swap(numberArray, 0, i);
 var l = numberArray.length;
 Assert(((i >= 0) and (i < l) and res) or (((i < 0) or (i >= l)) and (not res)));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays9.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/array/arrays9.js
@@ -1,9 +1,9 @@
 var buckets = require('../../buckets');
 
-var n1 = symb_number(n1); // 1
-var n2 = symb_number(n2); // 8
-var n3 = symb_number(n3); // 10
-var n4 = symb_number(n4); // 42
+var n1 = symb_number(); // 1
+var n2 = symb_number(); // 8
+var n3 = symb_number(); // 10
+var n4 = symb_number(); // 42
 
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag1.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag1.js
@@ -4,8 +4,8 @@ var buckets = require('../../buckets');
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
+var n1 = symb_number();
+var n2 = symb_number();
 
 bag.add(n1, n2);
 var res1 = bag.size();

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag2.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag2.js
@@ -4,8 +4,8 @@ var buckets = require('../../buckets');
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
+var n1 = symb_number();
+var n2 = symb_number();
 
 bag.add(n1);
 

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag3.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag3.js
@@ -4,10 +4,10 @@ var buckets = require('../../buckets');
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
-var n4 = symb_number(n4);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
+var n4 = symb_number();
 
 bag.add(n1);
 bag.add(n1, n2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag4.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag4.js
@@ -4,10 +4,10 @@ var buckets = require('../../buckets');
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-//var n3 = symb_number(n3);
-//var n4 = symb_number(n4);
+var n1 = symb_number();
+var n2 = symb_number();
+//var n3 = symb_number();
+//var n4 = symb_number();
 //Assume(n3 > 0);
 //Assume(n4 > 0);
 

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag5.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag5.js
@@ -4,8 +4,8 @@ var buckets = require('../../buckets');
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
+var n1 = symb_number();
+var n2 = symb_number();
 
 bag.add(n1);
 bag.add(n2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag6.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag6.js
@@ -4,10 +4,10 @@ var buckets = require('../../buckets');
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
-var n4 = symb_number(n4);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
+var n4 = symb_number();
 
 var res1 = bag.isEmpty();
 Assert(res1);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag7.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bag/bag7.js
@@ -4,9 +4,9 @@ var buckets = require('../../buckets');
 var bag = new buckets.Bag();
 
 // size
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
 
 bag.add(n1);
 bag.add(n2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree1.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree1.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree10.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree10.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree11.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree11.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));
@@ -21,7 +21,7 @@ bst2 = new buckets.BSTree();
 var res2 = bst.equals(bst2);
 Assert(not res2);
 
-var x4 = symb_number(x4);
+var x4 = symb_number();
 
 bst2.add(x2);
 bst2.add(x3);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree2.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree2.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree3.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree3.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree4.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree4.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree5.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree5.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));
@@ -16,7 +16,7 @@ bst.add(x3);
 
 // test2: something fails
 
-var x4 = symb_number(x4);
+var x4 = symb_number();
 var ar2 = [];
 bst.inorderTraversal(function(x) {
   if (x === x4) {

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree6.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree6.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));
@@ -16,7 +16,7 @@ bst.add(x3);
 
 // test2: something fails
 
-var x4 = symb_number(x4);
+var x4 = symb_number();
 var ar2 = [];
 bst.preorderTraversal(function(x) {
   if (x === x4) {

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree7.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree7.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));
@@ -16,7 +16,7 @@ bst.add(x3);
 
 // test2: something fails
 
-var x4 = symb_number(x4);
+var x4 = symb_number();
 var ar2 = [];
 bst.postorderTraversal(function(x) {
   if (x === x4) {

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree8.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree8.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));
@@ -16,7 +16,7 @@ bst.add(x3);
 
 // test2: something fails
 
-var x4 = symb_number(x4);
+var x4 = symb_number();
 var ar2 = [];
 bst.levelTraversal(function(x) {
   if (x === x4) {

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree9.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/bstree/bstree9.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var bst = new buckets.BSTree();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary1.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary1.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 dict.set(s1, x1);
 var res1 = dict.set(s2, x2);
@@ -14,7 +14,7 @@ Assert(((s1 = s2) and (res1 = x1)) or ((not (s1 = s2)) and (res1 = undefined)));
 var res2 = dict.set(s1, undefined);
 Assert(res2 = undefined);
 
-var s3 = symb_string(s3);
+var s3 = symb_string();
 Assume(not (s3 = s1));
 Assume(not (s3 = s2));
 

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary2.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary2.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 dict.set(s1, x1);
 dict.set(s2, x2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary3.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary3.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 Assume(not (s1 = s2));
 

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary4.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary4.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 Assume(not (s1 = s2));
 
@@ -14,7 +14,7 @@ dict.set(s2, x2);
 
 var res1 = "";
 var res2 = 0;
-var s3 = symb_string(s3);
+var s3 = symb_string();
 
 dict.forEach(function(k, v) {
   if (k === s3) {

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary5.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary5.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 dict.set(s1, x1);
 dict.set(s2, x2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary6.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary6.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 dict.set(s1, x1);
 dict.set(s2, x2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary7.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/dictionary/dictionary7.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var dict = new buckets.Dictionary();
 
-var x1 = symb_number(x1); //1
-var x2 = symb_number(x2); //2
-var s1 = symb_string(s1); // "2"
-var s2 = symb_string(s2); // "foo"
+var x1 = symb_number(); //1
+var x2 = symb_number(); //2
+var s1 = symb_string(); // "2"
+var s2 = symb_string(); // "foo"
 
 Assume(not (s1 = s2));
 

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/heap/heap1.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/heap/heap1.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var heap = new buckets.Heap();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/heap/heap2.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/heap/heap2.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var heap = new buckets.Heap();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/heap/heap3.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/heap/heap3.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var heap = new buckets.Heap();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/heap/heap4.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/heap/heap4.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var heap = new buckets.Heap();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/bug/linkedlist_bug_1.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/bug/linkedlist_bug_1.js
@@ -2,9 +2,9 @@ var buckets = require('../../../buckets_with_bugs');
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 list.add(x1)
 list.add(x2)

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/bug/linkedlist_bug_2.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/bug/linkedlist_bug_2.js
@@ -2,10 +2,10 @@ var buckets = require('../../../buckets_with_bugs');
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/bug/linkedlist_bug_3.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/bug/linkedlist_bug_3.js
@@ -2,10 +2,10 @@ var buckets = require('../../../buckets_with_bugs');
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist1.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist1.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist2.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist2.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist3.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist3.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist4.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist4.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist5.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist5.js
@@ -3,10 +3,10 @@ var buckets = require('../../buckets');
 var list1 = new buckets.LinkedList();
 var list2 = new buckets.LinkedList();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 list1.add(x1);
 list1.add(x2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist6.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist6.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 // Assume(not (x1 = x2));
 // Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist7.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist7.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist8.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist8.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist9.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/linkedlist/linkedlist9.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var list = new buckets.LinkedList()
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
-var x4 = symb_number(x4);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
+var x4 = symb_number();
 
 Assume(not (x1 = x2));
 Assume(not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/bug/multidictionary_bug.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/bug/multidictionary_bug.js
@@ -2,9 +2,9 @@ var buckets = require('../../../buckets_with_bugs');
 
 var dict = new buckets.MultiDictionary()
 
-var s = symb_string(s);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
+var s = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
 
 dict.set(s, x1);
 dict.set(s, x2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/multidictionary1.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/multidictionary1.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var dict = new buckets.MultiDictionary()
 
-var s1 = symb_string(s1);
-var s2 = symb_string(s2);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
+var s1 = symb_string();
+var s2 = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
 
 dict.set(s1, x1);
 dict.set(s2, x2);
@@ -13,7 +13,7 @@ dict.set(s2, x2);
 var res1 = dict.set(s1, undefined);
 Assert(not res1);
 
-var s3 = symb_string(s3);
+var s3 = symb_string();
 Assume(not (s1 = s3));
 Assume(not (s2 = s3));
 var res2 = dict.get(s3).length;

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/multidictionary2.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/multidictionary2.js
@@ -2,10 +2,10 @@ var buckets = require('../../buckets');
 
 var dict = new buckets.MultiDictionary()
 
-var s1 = symb_string(s1);
-var s2 = symb_string(s2);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
+var s1 = symb_string();
+var s2 = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
 
 Assume(not (x1 = x2));
 

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/multidictionary3.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/multidictionary3.js
@@ -2,11 +2,11 @@ var buckets = require('../../buckets');
 
 var dict = new buckets.MultiDictionary()
 
-var s1 = symb_string(s1);
-var s2 = symb_string(s2);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var s1 = symb_string();
+var s2 = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume (not (x1 = x2));
 Assume (not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/multidictionary4.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/multidictionary4.js
@@ -2,11 +2,11 @@ var buckets = require('../../buckets');
 
 var dict = new buckets.MultiDictionary()
 
-var s1 = symb_string(s1);
-var s2 = symb_string(s2);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var s1 = symb_string();
+var s2 = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume (not (x1 = x2));
 Assume (not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/multidictionary5.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/multidictionary5.js
@@ -2,11 +2,11 @@ var buckets = require('../../buckets');
 
 var dict = new buckets.MultiDictionary()
 
-var s1 = symb_string(s1);
-var s2 = symb_string(s2);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var s1 = symb_string();
+var s2 = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume (not (x1 = x2));
 Assume (not (x1 = x3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/multidictionary6.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/multidictionary/multidictionary6.js
@@ -3,10 +3,10 @@ var buckets = require('../../buckets');
 var dict1 = new buckets.MultiDictionary();
 var dict2 = new buckets.MultiDictionary();
 
-var s1 = symb_string(s1);
-var s2 = symb_string(s2);
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
+var s1 = symb_string();
+var s2 = symb_string();
+var x1 = symb_number();
+var x2 = symb_number();
 
 Assume (not (x1 = x2));
 

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/priorityqueue/priorityqueue1.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/priorityqueue/priorityqueue1.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var pqueue = new buckets.PriorityQueue();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 pqueue.enqueue(x1);
 pqueue.add(x2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/priorityqueue/priorityqueue2.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/priorityqueue/priorityqueue2.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var pqueue = new buckets.PriorityQueue();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 pqueue.enqueue(x1);
 pqueue.enqueue(x2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/priorityqueue/priorityqueue3.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/priorityqueue/priorityqueue3.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var pqueue = new buckets.PriorityQueue();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 pqueue.enqueue(x1);
 pqueue.enqueue(x2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/priorityqueue/priorityqueue4.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/priorityqueue/priorityqueue4.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var pqueue = new buckets.PriorityQueue();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 pqueue.enqueue(x1);
 pqueue.enqueue(x2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/priorityqueue/priorityqueue5.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/priorityqueue/priorityqueue5.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var pqueue = new buckets.PriorityQueue();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 pqueue.enqueue(x1);
 pqueue.enqueue(x2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/queue/queue1.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/queue/queue1.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var queue = new buckets.Queue();
 
-var x1 = symb_number(x1); // 1
-var x2 = symb_number(x2); // 2
-var x3 = symb_number(x3); // 3
+var x1 = symb_number(); // 1
+var x2 = symb_number(); // 2
+var x3 = symb_number(); // 3
 Assume((x1 < x2) and (x2 < x3));
 
 function createQueue() {
@@ -19,7 +19,7 @@ Assert(size = 0);
 createQueue();
 var size = queue.size();
 Assert(size = 3);
-var x4 = symb_number(x4);
+var x4 = symb_number();
 queue.add(x4); // synonym to enqueue
 var size = queue.size();
 Assert(size = 4);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/queue/queue2.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/queue/queue2.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var queue = new buckets.Queue();
 
-var x1 = symb_number(x1); // 1
-var x2 = symb_number(x2); // 2
-var x3 = symb_number(x3); // 3
+var x1 = symb_number(); // 1
+var x2 = symb_number(); // 2
+var x3 = symb_number(); // 3
 Assume((x1 < x2) and (x2 < x3));
 
 function createQueue() {

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/queue/queue3.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/queue/queue3.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var queue = new buckets.Queue();
 
-var x1 = symb_number(x1); // 1
-var x2 = symb_number(x2); // 2
-var x3 = symb_number(x3); // 3
+var x1 = symb_number(); // 1
+var x2 = symb_number(); // 2
+var x3 = symb_number(); // 3
 Assume((x1 < x2) and (x2 < x3));
 
 function createQueue() {

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/queue/queue4.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/queue/queue4.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var queue = new buckets.Queue();
 
-var x1 = symb_number(x1); // 1
-var x2 = symb_number(x2); // 2
-var x3 = symb_number(x3); // 3
+var x1 = symb_number(); // 1
+var x2 = symb_number(); // 2
+var x3 = symb_number(); // 3
 Assume((x1 < x2) and (x2 < x3));
 
 function createQueue() {

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/queue/queue5.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/queue/queue5.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var queue = new buckets.Queue();
 
-var x1 = symb_number(x1); // 1
-var x2 = symb_number(x2); // 2
-var x3 = symb_number(x3); // 3
+var x1 = symb_number(); // 1
+var x2 = symb_number(); // 2
+var x3 = symb_number(); // 3
 Assume((x1 < x2) and (x2 < x3));
 
 function createQueue() {

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/queue/queue6.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/queue/queue6.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var queue = new buckets.Queue();
 
-var x1 = symb_number(x1); // 1
-var x2 = symb_number(x2); // 2
-var x3 = symb_number(x3); // 3
+var x1 = symb_number(); // 1
+var x2 = symb_number(); // 2
+var x3 = symb_number(); // 3
 Assume((x1 < x2) and (x2 < x3));
 
 function createQueue() {

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/set/set1.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/set/set1.js
@@ -2,11 +2,11 @@ var buckets = require('../../buckets');
 
 var set = new buckets.Set();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
+var x1 = symb_number();
+var x2 = symb_number();
 
 set.add(x1);
 var res = set.add(x2);
 
-var x3 = symb_number(x3);
+var x3 = symb_number();
 var res2 = set.contains(x3);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/set/set2.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/set/set2.js
@@ -3,9 +3,9 @@ var buckets = require('../../buckets');
 var set1 = new buckets.Set();
 var set2 = new buckets.Set();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x2));
 

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/set/set3.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/set/set3.js
@@ -3,10 +3,10 @@ var buckets = require('../../buckets');
 var set1 = new buckets.Set();
 var set2 = new buckets.Set();
 
-var x1 = symb_string(x1);
-var x2 = symb_string(x2);
-var x3 = symb_string(x3);
-var x4 = symb_string(x4);
+var x1 = symb_string();
+var x2 = symb_string();
+var x3 = symb_string();
+var x4 = symb_string();
 
 set1.add(x1);
 set1.add(x2);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/set/set4.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/set/set4.js
@@ -3,9 +3,9 @@ var buckets = require('../../buckets');
 var set1 = new buckets.Set();
 var set2 = new buckets.Set();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x3));
 

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/set/set5.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/set/set5.js
@@ -2,8 +2,8 @@ var buckets = require('../../buckets');
 
 var set = new buckets.Set();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
+var x1 = symb_number();
+var x2 = symb_number();
 
 var res1 = set.isEmpty();
 Assert(res1);

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/set/set6.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/set/set6.js
@@ -3,9 +3,9 @@ var buckets = require('../../buckets');
 var set1 = new buckets.Set();
 var set2 = new buckets.Set();
 
-var x1 = symb_number(x1);
-var x2 = symb_number(x2);
-var x3 = symb_number(x3);
+var x1 = symb_number();
+var x2 = symb_number();
+var x3 = symb_number();
 
 Assume(not (x1 = x3));
 

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/stack/stack1.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/stack/stack1.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var stack = new buckets.Stack();
 
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));
 Assume(not (n2 = n3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/stack/stack2.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/stack/stack2.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var stack = new buckets.Stack();
 
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));
 Assume(not (n2 = n3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/stack/stack3.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/stack/stack3.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var stack = new buckets.Stack();
 
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));
 Assume(not (n2 = n3));

--- a/Gillian-JS/Examples/Cosette/BucketsMultifile/stack/stack4.js
+++ b/Gillian-JS/Examples/Cosette/BucketsMultifile/stack/stack4.js
@@ -2,9 +2,9 @@ var buckets = require('../../buckets');
 
 var stack = new buckets.Stack();
 
-var n1 = symb_number(n1);
-var n2 = symb_number(n2);
-var n3 = symb_number(n3);
+var n1 = symb_number();
+var n2 = symb_number();
+var n3 = symb_number();
 Assume(not (n1 = n2));
 Assume(not (n1 = n3));
 Assume(not (n2 = n3));

--- a/Gillian-JS/Examples/Cosette/CaseStudies/BST/bst_find_1.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/BST/bst_find_1.js
@@ -52,10 +52,10 @@ function isNode(n, v, l, r) {
 }
 
 /* Test 1 */
-var v1 = symb_number(v1);
-var v2 = symb_number(v2);
-var v3 = symb_number(v3);
-var v4 = symb_number(v4);
+var v1 = symb_number();
+var v2 = symb_number();
+var v3 = symb_number();
+var v4 = symb_number();
 
 Assume((v1 < v2) and (v2 < v3));
 Assume((not (v4 = v1)) and (not (v4 = v2)) and (not (v4 = v3)));

--- a/Gillian-JS/Examples/Cosette/CaseStudies/BST/bst_find_min_1.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/BST/bst_find_min_1.js
@@ -46,9 +46,9 @@ function isNode(n, v, l, r) {
 }
 
 /* Test 1 */
-var v1 = symb_number(v1);
-var v2 = symb_number(v2);
-var v3 = symb_number(v3);
+var v1 = symb_number();
+var v2 = symb_number();
+var v3 = symb_number();
 
 Assume((v1 < v2) and (v2 < v3));
 

--- a/Gillian-JS/Examples/Cosette/CaseStudies/BST/bst_insert_1.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/BST/bst_insert_1.js
@@ -34,7 +34,7 @@ function isNode(n, v, l, r) {
 
 
 /* Test 1 */
-var v = symb_number(v);
+var v = symb_number();
 
 var res = insert(v, null);
 var ret = isNode(res, v, null, null);

--- a/Gillian-JS/Examples/Cosette/CaseStudies/BST/bst_insert_2.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/BST/bst_insert_2.js
@@ -33,8 +33,8 @@ function isNode(n, v, l, r) {
 }
 
 /* Test 2 */
-var v = symb_number(v);
-var w = symb_number(w);
+var v = symb_number();
+var w = symb_number();
 
 var root = insert(v, null);
 insert(w, root);

--- a/Gillian-JS/Examples/Cosette/CaseStudies/BST/bst_remove_1.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/BST/bst_remove_1.js
@@ -74,9 +74,9 @@ function isNode(n, v, l, r) {
 }
 
 /* Test 1 */
-var v1 = symb_number(v1);
-var v2 = symb_number(v2);
-var v3 = symb_number(v3);
+var v1 = symb_number();
+var v2 = symb_number();
+var v3 = symb_number();
 
 Assume((v1 < v2) and (v2 < v3));
 

--- a/Gillian-JS/Examples/Cosette/CaseStudies/DLL/dll.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/DLL/dll.js
@@ -32,7 +32,7 @@ var cl1 = listCopy(l1);
 Assert(cl1 = null);
 
 /* Append to empty list */
-var v1 = symb(v1);
+var v1 = symb();
 var l2 = listAppend(l1, v1);
 var in2 = isNode(l2, v1, null, null);
 Assert (in2);
@@ -43,7 +43,7 @@ var in3 = isNode(l3, v1, null, null);
 Assert (in3);
 
 /* Append to non-empty list */
-var v2 = symb(v2);
+var v2 = symb();
 var l4 = listAppend(l3, v2);
 var in4 = isNode(l4, v1, null, l4.next) && isNode(l4.next, v2, l4, null);
 Assert (in4);

--- a/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_1.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_1.js
@@ -40,7 +40,7 @@ function evalBinop (op, l1, l2) {
 
 /** Test 1 */
 
-var store = {}, x = symb(x);
+var store = {}, x = symb();
 var tx = typeof x; Assume(not (tx = "object")); 
 try {
   evalExpr(store, x)

--- a/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_2.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_2.js
@@ -39,7 +39,7 @@ function evalBinop (op, l1, l2) {
 }
 
 /** Test 2 */
-var store = {}, x = symb(x);
+var store = {}, x = symb();
 var tx = typeof x; Assume(tx = "object"); 
 try {
   evalExpr(store, x)

--- a/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_3.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_3.js
@@ -41,7 +41,7 @@ function evalBinop (op, l1, l2) {
 /** Test 3 */
 
 var store = {}; 
-var n = symb_number(n), s = symb_string(s); 
+var n = symb_number(), s = symb_string(); 
 var lit = { type: "lit",  val: n }; 
 var e   = { type: "unop", op: s, arg: lit}; 
 Assume (not (s = "not"));

--- a/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_4.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_4.js
@@ -41,7 +41,7 @@ function evalBinop (op, l1, l2) {
 /** Test 3 */
 
 var store = {}; 
-var b = symb_bool(b);
+var b = symb_bool();
 var lit = { type: "lit",  val: b }; 
 var e   = { type: "unop", op: "not", arg: lit}; 
 var ret = evalExpr(store, e);

--- a/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_5.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_5.js
@@ -41,7 +41,7 @@ function evalBinop (op, l1, l2) {
 /** Test 3 */
 
 var store = {}; 
-var n1 = symb_number(n1), n2 = symb_number(n2), op = symb_string(op); 
+var n1 = symb_number(), n2 = symb_number(), op = symb_string(); 
 var l1 = { type: "lit",  val: n1 }, l2 = { type: "lit",  val: n2 }; 
 var e   = { type: "binop", op: op, left: l1, right: l2}; 
 Assume ((not (op = "and")) and (not (op = "or")));

--- a/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_6.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_6.js
@@ -41,7 +41,7 @@ function evalBinop (op, l1, l2) {
 /** Test 3 */
 
 var store = {}; 
-var b1 = symb_bool(b1), b2 = symb_bool(b2), op = symb_string(op); 
+var b1 = symb_bool(), b2 = symb_bool(), op = symb_string(); 
 var l1 = { type: "lit",  val: b1 }, l2 = { type: "lit",  val: b2 }; 
 var e   = { type: "binop", op: op, left: l1, right: l2}; 
 Assume ((not (op = "+")) and (not (op = "-")));

--- a/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_7.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/ExprEval/exprEval_7.js
@@ -41,7 +41,7 @@ function evalBinop (op, l1, l2) {
 /** Test 3 */
 
 var store = Object.create(null); 
-var x = symb_string(x), y = symb_string(y), v = symb(v);
+var x = symb_string(), y = symb_string(), v = symb();
 var lit = { type: "var",  name: x };
 store[y] = v;
 

--- a/Gillian-JS/Examples/Cosette/CaseStudies/IDGen/IdGen.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/IDGen/IdGen.js
@@ -17,7 +17,7 @@ var makeIdGen = function (prefix) {
 	}
 };
 
-var prefix = symb_string(prefix);
+var prefix = symb_string();
 
 var idgen = makeIdGen (prefix);
 var id  = idgen.getId();

--- a/Gillian-JS/Examples/Cosette/CaseStudies/KVMap/kv_map_1.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/KVMap/kv_map_1.js
@@ -28,10 +28,10 @@ Map.prototype.put = function (k, v) {
     throw new Error("Invalid Key")
 }
 
-var k1 = symb_string(k1);
-var k2 = symb_string(k2);
+var k1 = symb_string();
+var k2 = symb_string();
 
-var v1 = symb_number(v1);
+var v1 = symb_number();
 
 var map = new Map();
 var cts = map._contents;

--- a/Gillian-JS/Examples/Cosette/CaseStudies/KVMap/kv_map_2.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/KVMap/kv_map_2.js
@@ -30,7 +30,7 @@ Map.prototype.put = function (k, v) {
 
 var map = new Map();
 
-var ivk = symb_number(ivk);
+var ivk = symb_number();
 
 try {
   map.get(ivk);

--- a/Gillian-JS/Examples/Cosette/CaseStudies/PriQ/pri_q_1.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/PriQ/pri_q_1.js
@@ -58,8 +58,8 @@ try {
   var em = e.message; Assert(em = "Queue is empty");
 }
 
-var pri = symb_number(pri);
-var val = symb(val);
+var pri = symb_number();
+var val = symb();
 pq.enqueue(pri, val);
 var t2 = isNode(pq._head, pri, val, null)
 Assert(t2);

--- a/Gillian-JS/Examples/Cosette/CaseStudies/PriQ/pri_q_2.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/PriQ/pri_q_2.js
@@ -51,11 +51,11 @@ function isNode(n, pri, val, next) {
 
 var pq = new PriorityQueue();
 
-var pri1 = symb_number(pri1);
-var val1 = symb(val1);
+var pri1 = symb_number();
+var val1 = symb();
 
-var pri2 = symb_number(pri2);
-var val2 = symb(val2);
+var pri2 = symb_number();
+var val2 = symb();
 
 pq.enqueue(pri1, val1);
 pq.enqueue(pri2, val2);

--- a/Gillian-JS/Examples/Cosette/CaseStudies/SLL/sll.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/SLL/sll.js
@@ -29,7 +29,7 @@ var cl1 = listCopy(l1);
 Assert(cl1 = null);
 
 /* Append to empty list */
-var v1 = symb(v1);
+var v1 = symb();
 var l2 = listAppend(l1, v1);
 var in2 = isNode(l2, v1, null);
 Assert (in2);
@@ -40,7 +40,7 @@ var in3 = isNode(l3, v1, null);
 Assert (in3);
 
 /* Append to non-empty list */
-var v2 = symb(v2);
+var v2 = symb();
 var l4 = listAppend(l3, v2);
 var in4 = isNode(l4, v1, l4.next) && isNode(l4.next, v2, null);
 Assert (in4);

--- a/Gillian-JS/Examples/Cosette/CaseStudies/Sort/sort_1.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/Sort/sort_1.js
@@ -19,9 +19,9 @@ function isNode(n, v, nxt) {
   return ((nv === v) && (nx === nxt));
 }
 
-var v1 = symb_number(v1);
-var v2 = symb_number(v2);
-var v3 = symb_number(v3);
+var v1 = symb_number();
+var v2 = symb_number();
+var v3 = symb_number();
 
 Assume((v1 < v2) and (v2 < v3));
 

--- a/Gillian-JS/Examples/Cosette/CaseStudies/Sort/sort_2.js
+++ b/Gillian-JS/Examples/Cosette/CaseStudies/Sort/sort_2.js
@@ -34,8 +34,8 @@ function isNode(n, v, nxt) {
 var s1 = sort(null);
 Assert(s1 = null);
 
-var v1 = symb_number(v1);
-var v2 = symb_number(v2);
+var v1 = symb_number();
+var v2 = symb_number();
 
 var n2 = { value: v2, next : null};
 var n1 = { value: v1, next: n2 };

--- a/Gillian-JS/Examples/Cosette/simple_example.js
+++ b/Gillian-JS/Examples/Cosette/simple_example.js
@@ -1,4 +1,4 @@
-var n1 = symb_number(n1), n2 = symb_number(n2);
+var n1 = symb_number(), n2 = symb_number();
 
 Assume((0 <= n1) and (0 <= n2) and (not (n1 = n2)));
 
@@ -6,7 +6,7 @@ var res = n1 + n2;
 
 Assert((n1 <= res) and (n2 <= res));
 
-var x = symb(x);
+var x = symb();
 Assume(not (typeOf x = Obj));
 
 var tx = typeof(x);

--- a/Gillian-JS/lib/Compiler/JS2JSIL_Compiler.ml
+++ b/Gillian-JS/lib/Compiler/JS2JSIL_Compiler.ml
@@ -2198,7 +2198,7 @@ let rec translate_expr tr_ctx e :
       let cmd1 = (metadata, None, LLogic (FreshSVar x_v)) in
       let x_v = PVar x_v in
       let cmd2 =
-        (metadata, None, LLogic (LCmd.AssumeType (x_v, Type.StringType)))
+        (metadata, None, LLogic (LCmd.AssumeType (x_v, Type.BooleanType)))
       in
       ([ cmd1; cmd2 ], x_v, [])
   | JS_Parser.Syntax.Call (e_f, xes)

--- a/Gillian-JS/lib/Compiler/JS2JSIL_Compiler.ml
+++ b/Gillian-JS/lib/Compiler/JS2JSIL_Compiler.ml
@@ -2134,73 +2134,73 @@ let rec translate_expr tr_ctx e :
   | JS_Parser.Syntax.Call (e_f, xes)
     when e_f.JS_Parser.Syntax.exp_stx
          = JS_Parser.Syntax.Var js_symbolic_constructs.js_symb ->
-      let x =
-        match List.map (fun xe -> xe.JS_Parser.Syntax.exp_stx) xes with
-        | [ JS_Parser.Syntax.Var x ] -> "#" ^ x
+      let () =
+        match xes with
+        | [] -> ()
         | _ -> raise (Failure "Invalid symbolic")
       in
       let x_v = fresh_var () ^ "_v" in
-      let cmd1 = (metadata, None, LBasic (BCmd.Assignment (x_v, LVar x))) in
-      let cmd2 = (metadata, None, LLogic (LCmd.SpecVar [ x ])) in
+      let cmd1 = (metadata, None, LLogic (LCmd.FreshSVar x_v)) in
+      let x_v = PVar x_v in
+      let cmd2 =
+        (metadata, None, LLogic (LCmd.Assume (Not (Eq (x_v, Lit Empty)))))
+      in
       let cmd3 =
-        (metadata, None, LLogic (LCmd.Assume (Not (Eq (LVar x, Lit Empty)))))
+        (metadata, None, LLogic (LCmd.Assume (Not (Eq (x_v, Lit Nono)))))
       in
       let cmd4 =
-        (metadata, None, LLogic (LCmd.Assume (Not (Eq (LVar x, Lit Nono)))))
-      in
-      let cmd5 =
         ( metadata,
           None,
           LLogic
-            (LCmd.Assume (Not (Eq (UnOp (TypeOf, LVar x), Lit (Type ListType)))))
+            (LCmd.Assume (Not (Eq (UnOp (TypeOf, x_v), Lit (Type ListType)))))
         )
       in
-      ([ cmd1; cmd2; cmd3; cmd4; cmd5 ], PVar x_v, [])
+      ([ cmd1; cmd2; cmd3; cmd4 ], x_v, [])
   | JS_Parser.Syntax.Call (e_f, xes)
     when e_f.JS_Parser.Syntax.exp_stx
          = JS_Parser.Syntax.Var js_symbolic_constructs.js_symb_number ->
-      let x =
-        match List.map (fun xe -> xe.JS_Parser.Syntax.exp_stx) xes with
-        | [ JS_Parser.Syntax.Var x ] -> "#" ^ x
+      let () =
+        match xes with
+        | [] -> ()
         | _ -> raise (Failure "Invalid symb_number")
       in
       let x_v = fresh_var () ^ "_v" in
-      let cmd1 = (metadata, None, LBasic (BCmd.Assignment (x_v, LVar x))) in
-      let cmd2 = (metadata, None, LLogic (LCmd.SpecVar [ x ])) in
-      let cmd3 =
-        (metadata, None, LLogic (LCmd.AssumeType (x, Type.NumberType)))
+      let cmd1 = (metadata, None, LLogic (FreshSVar x_v)) in
+      let x_v = PVar x_v in
+      let cmd2 =
+        (metadata, None, LLogic (LCmd.AssumeType (x_v, Type.NumberType)))
       in
-      ([ cmd1; cmd2; cmd3 ], PVar x_v, [])
+      ([ cmd1; cmd2 ], x_v, [])
   | JS_Parser.Syntax.Call (e_f, xes)
     when e_f.JS_Parser.Syntax.exp_stx
          = JS_Parser.Syntax.Var js_symbolic_constructs.js_symb_string ->
-      let x =
-        match List.map (fun xe -> xe.JS_Parser.Syntax.exp_stx) xes with
-        | [ JS_Parser.Syntax.Var x ] -> "#" ^ x
-        | _ -> raise (Failure "Invalid symb_number")
+      let () =
+        match xes with
+        | [] -> ()
+        | _ -> raise (Failure "Invalid symb_string")
       in
       let x_v = fresh_var () ^ "_v" in
-      let cmd1 = (metadata, None, LBasic (BCmd.Assignment (x_v, LVar x))) in
-      let cmd2 = (metadata, None, LLogic (LCmd.SpecVar [ x ])) in
-      let cmd3 =
-        (metadata, None, LLogic (LCmd.AssumeType (x, Type.StringType)))
+      let cmd1 = (metadata, None, LLogic (FreshSVar x_v)) in
+      let x_v = PVar x_v in
+      let cmd2 =
+        (metadata, None, LLogic (LCmd.AssumeType (x_v, Type.StringType)))
       in
-      ([ cmd1; cmd2; cmd3 ], PVar x_v, [])
+      ([ cmd1; cmd2 ], x_v, [])
   | JS_Parser.Syntax.Call (e_f, xes)
     when e_f.JS_Parser.Syntax.exp_stx
          = JS_Parser.Syntax.Var js_symbolic_constructs.js_symb_bool ->
-      let x =
-        match List.map (fun xe -> xe.JS_Parser.Syntax.exp_stx) xes with
-        | [ JS_Parser.Syntax.Var x ] -> "#" ^ x
+      let () =
+        match xes with
+        | [] -> ()
         | _ -> raise (Failure "Invalid symb_bool")
       in
       let x_v = fresh_var () ^ "_v" in
-      let cmd1 = (metadata, None, LBasic (BCmd.Assignment (x_v, LVar x))) in
-      let cmd2 = (metadata, None, LLogic (LCmd.SpecVar [ x ])) in
-      let cmd3 =
-        (metadata, None, LLogic (LCmd.AssumeType (x, Type.BooleanType)))
+      let cmd1 = (metadata, None, LLogic (FreshSVar x_v)) in
+      let x_v = PVar x_v in
+      let cmd2 =
+        (metadata, None, LLogic (LCmd.AssumeType (x_v, Type.StringType)))
       in
-      ([ cmd1; cmd2; cmd3 ], PVar x_v, [])
+      ([ cmd1; cmd2 ], x_v, [])
   | JS_Parser.Syntax.Call (e_f, xes)
     when Gillian.Utils.(ExecMode.biabduction_exec !Config.current_exec_mode)
          &&

--- a/Gillian-JS/lib/Compiler/JSIL2GIL.ml
+++ b/Gillian-JS/lib/Compiler/JSIL2GIL.ml
@@ -67,7 +67,7 @@ let rec jsil2gil_lcmd (lcmd : LCmd.t) : GLCmd.t =
   | Assert f -> Assert f
   | Assume f -> Assume f
   | AssumeType (x, t) -> AssumeType (x, t)
-  | SpecVar xs -> SpecVar xs
+  | FreshSVar x -> FreshSVar x
   | SL slcmd -> SL (jsil2gil_slcmd slcmd)
 
 let jsil2gil_sspec (sspec : Spec.st) : GSpec.st =

--- a/Gillian-JS/lib/JSIL/LCmd.ml
+++ b/Gillian-JS/lib/JSIL/LCmd.ml
@@ -15,8 +15,8 @@ type t =
   | Macro of string * Expr.t list  (** Macro            *)
   | Assert of Formula.t  (** Assert           *)
   | Assume of Formula.t  (** Assume           *)
-  | AssumeType of string * Type.t  (** Assume Type      *)
-  | SpecVar of string list  (** Spec Var         *)
+  | AssumeType of Expr.t * Type.t  (** Assume Type      *)
+  | FreshSVar of string
   | SL of SLCmd.t
 
 let rec pp fmt lcmd =
@@ -35,7 +35,7 @@ let rec pp fmt lcmd =
   | Macro (name, lparams) -> Fmt.pf fmt "%s(%a)" name pp_params lparams
   | Assert a -> Fmt.pf fmt "assert (%a)" Formula.pp a
   | Assume a -> Fmt.pf fmt "assume (%a)" Formula.pp a
-  | SpecVar xs ->
-      Fmt.pf fmt "spec_var (%a)" (Fmt.list ~sep:Fmt.comma Fmt.string) xs
+  | FreshSVar x -> Fmt.pf fmt "%s := symbol()" x
   | SL sl_cmd -> SLCmd.pp fmt sl_cmd
-  | AssumeType (x, t) -> Fmt.pf fmt "assume_type (%s, %s)" x (Type.str t)
+  | AssumeType (e, t) ->
+      Fmt.pf fmt "assume_type (%a, %s)" Expr.pp e (Type.str t)

--- a/Gillian-JS/lib/JSIL/LCmd.ml
+++ b/Gillian-JS/lib/JSIL/LCmd.ml
@@ -35,7 +35,7 @@ let rec pp fmt lcmd =
   | Macro (name, lparams) -> Fmt.pf fmt "%s(%a)" name pp_params lparams
   | Assert a -> Fmt.pf fmt "assert (%a)" Formula.pp a
   | Assume a -> Fmt.pf fmt "assume (%a)" Formula.pp a
-  | FreshSVar x -> Fmt.pf fmt "%s := symbol()" x
+  | FreshSVar x -> Fmt.pf fmt "%s := fresh_svar()" x
   | SL sl_cmd -> SLCmd.pp fmt sl_cmd
   | AssumeType (e, t) ->
       Fmt.pf fmt "assume_type (%a, %s)" Expr.pp e (Type.str t)

--- a/Gillian-JS/lib/Parsing/Javert_Lexer.mll
+++ b/Gillian-JS/lib/Parsing/Javert_Lexer.mll
@@ -122,7 +122,7 @@
       "assert",       Javert_Parser.ASSERT;
       "assume",       Javert_Parser.ASSUME;
       "assume_type",  Javert_Parser.ASSUME_TYPE;
-      "spec_var",     Javert_Parser.SPEC_VAR;
+      "symbol", Javert_Parser.SYMBOL;
       "bind",         Javert_Parser.BIND;
       "existentials", Javert_Parser.EXISTENTIALS;
       "sep_assert",   Javert_Parser.SEPASSERT;

--- a/Gillian-JS/lib/Parsing/Javert_Lexer.mll
+++ b/Gillian-JS/lib/Parsing/Javert_Lexer.mll
@@ -122,7 +122,7 @@
       "assert",       Javert_Parser.ASSERT;
       "assume",       Javert_Parser.ASSUME;
       "assume_type",  Javert_Parser.ASSUME_TYPE;
-      "symbol", Javert_Parser.SYMBOL;
+      "fresh_svar",   Javert_Parser.FRESH_SVAR;
       "bind",         Javert_Parser.BIND;
       "existentials", Javert_Parser.EXISTENTIALS;
       "sep_assert",   Javert_Parser.SEPASSERT;

--- a/Gillian-JS/lib/Parsing/Javert_Parser.mly
+++ b/Gillian-JS/lib/Parsing/Javert_Parser.mly
@@ -120,7 +120,7 @@ let normalised_lvar_r = Str.regexp "##NORMALISED_LVAR"
 %token SEPASSERT
 %token INVARIANT
 %token ASSUME_TYPE
-%token SPEC_VAR
+%token SYMBOL
 %token LSTNTH
 %token LSTSUB
 %token STRNTH
@@ -565,10 +565,10 @@ logic_cmd_target:
     { let (name, params) = macro in LCmd.Macro (name, params) }
   | ASSUME; LBRACE; a = pure_assertion_target; RBRACE
     { LCmd.Assume a }
-  | ASSUME_TYPE; LBRACE; x=LVAR; COMMA; t=type_target; RBRACE
-    { LCmd.AssumeType (x, t) }
-  | SPEC_VAR; LBRACE; xs = separated_list(COMMA, LVAR); RBRACE
-    { LCmd.SpecVar xs }
+  | ASSUME_TYPE; LBRACE; e=expr_target; COMMA; t=type_target; RBRACE
+    { LCmd.AssumeType (e, t) }
+  | v = VAR; DEFEQ; SYMBOL; LBRACE; RBRACE
+    { LCmd.FreshSVar v}
   | BRANCH; LBRACE; fo = pure_assertion_target; RBRACE
      { LCmd.Branch fo }
 

--- a/Gillian-JS/lib/Parsing/Javert_Parser.mly
+++ b/Gillian-JS/lib/Parsing/Javert_Parser.mly
@@ -120,7 +120,7 @@ let normalised_lvar_r = Str.regexp "##NORMALISED_LVAR"
 %token SEPASSERT
 %token INVARIANT
 %token ASSUME_TYPE
-%token SYMBOL
+%token FRESH_SVAR
 %token LSTNTH
 %token LSTSUB
 %token STRNTH
@@ -567,7 +567,7 @@ logic_cmd_target:
     { LCmd.Assume a }
   | ASSUME_TYPE; LBRACE; e=expr_target; COMMA; t=type_target; RBRACE
     { LCmd.AssumeType (e, t) }
-  | v = VAR; DEFEQ; SYMBOL; LBRACE; RBRACE
+  | v = VAR; DEFEQ; FRESH_SVAR; LBRACE; RBRACE
     { LCmd.FreshSVar v}
   | BRANCH; LBRACE; fo = pure_assertion_target; RBRACE
      { LCmd.Branch fo }

--- a/GillianCore/CommandLine/CommandLine.ml
+++ b/GillianCore/CommandLine/CommandLine.ml
@@ -447,6 +447,7 @@ struct
         incremental
         entry_point
         () =
+      let () = Fmt_tty.setup_std_outputs () in
       let () = Config.current_exec_mode := Symbolic in
       let () = PC.initialize Symbolic in
       let () = Printexc.record_backtrace @@ L.Mode.enabled () in

--- a/GillianCore/GIL_Parser/GIL_Lexer.mll
+++ b/GillianCore/GIL_Parser/GIL_Lexer.mll
@@ -110,7 +110,7 @@
       "assert",       GIL_Parser.ASSERT;
       "assume",       GIL_Parser.ASSUME;
       "assume_type",  GIL_Parser.ASSUME_TYPE;
-      "symbol",       GIL_Parser.SYMBOL;
+      "fresh_svar",   GIL_Parser.FRESH_SVAR;
       "bind",         GIL_Parser.BIND;
       "existentials", GIL_Parser.EXISTENTIALS;
       "sep_assert",   GIL_Parser.SEPASSERT;

--- a/GillianCore/GIL_Parser/GIL_Lexer.mll
+++ b/GillianCore/GIL_Parser/GIL_Lexer.mll
@@ -110,7 +110,7 @@
       "assert",       GIL_Parser.ASSERT;
       "assume",       GIL_Parser.ASSUME;
       "assume_type",  GIL_Parser.ASSUME_TYPE;
-      "spec_var",     GIL_Parser.SPEC_VAR;
+      "symbol",       GIL_Parser.SYMBOL;
       "bind",         GIL_Parser.BIND;
       "existentials", GIL_Parser.EXISTENTIALS;
       "sep_assert",   GIL_Parser.SEPASSERT;

--- a/GillianCore/GIL_Parser/GIL_Parser.mly
+++ b/GillianCore/GIL_Parser/GIL_Parser.mly
@@ -125,7 +125,6 @@ let normalised_lvar_r = Str.regexp "##NORMALISED_LVAR"
 %token SEPASSERT
 %token INVARIANT
 %token ASSUME_TYPE
-%token SPEC_VAR
 %token LSTNTH
 %token LSTSUB
 %token STRNTH
@@ -185,6 +184,7 @@ let normalised_lvar_r = Str.regexp "##NORMALISED_LVAR"
 %token LIF
 %token LTHEN
 %token LELSE
+%token SYMBOL
 (* Procedure specification keywords *)
 %token AXIOMATIC
 %token INCOMPLETE
@@ -763,12 +763,13 @@ g_logic_cmd_target:
     { LCmd.Assume a }
 
 (* assume_type (x, t) *)
-  | ASSUME_TYPE; LBRACE; x=LVAR; COMMA; t=type_target; RBRACE
-    { LCmd.AssumeType (x, t) }
+  | ASSUME_TYPE; LBRACE; e=expr_target; COMMA; t=type_target; RBRACE
+    { LCmd.AssumeType (e, t) }
 
-(* spec_var (x, t) *)
-  | SPEC_VAR; LBRACE; xs = separated_list(COMMA, LVAR); RBRACE
-    { LCmd.SpecVar xs }
+
+  (* x := e *)
+  | v=VAR; DEFEQ; SYMBOL; LBRACE; RBRACE
+    { LCmd.FreshSVar (v) }
 
 (* branch (fo) *)
   | BRANCH; LBRACE; fo = pure_assertion_target; RBRACE

--- a/GillianCore/GIL_Parser/GIL_Parser.mly
+++ b/GillianCore/GIL_Parser/GIL_Parser.mly
@@ -184,7 +184,7 @@ let normalised_lvar_r = Str.regexp "##NORMALISED_LVAR"
 %token LIF
 %token LTHEN
 %token LELSE
-%token SYMBOL
+%token FRESH_SVAR
 (* Procedure specification keywords *)
 %token AXIOMATIC
 %token INCOMPLETE
@@ -768,7 +768,7 @@ g_logic_cmd_target:
 
 
   (* x := e *)
-  | v=VAR; DEFEQ; SYMBOL; LBRACE; RBRACE
+  | v=VAR; DEFEQ; FRESH_SVAR; LBRACE; RBRACE
     { LCmd.FreshSVar (v) }
 
 (* branch (fo) *)

--- a/GillianCore/GIL_Syntax/Gil_syntax.mli
+++ b/GillianCore/GIL_Syntax/Gil_syntax.mli
@@ -630,7 +630,7 @@ module LCmd : sig
     | Assert of Formula.t  (** Assert *)
     | Assume of Formula.t  (** Assume *)
     | AssumeType of Expr.t * Type.t  (** Assume Type *)
-    | FreshSVar of string  (** x := Symbol() *)
+    | FreshSVar of string  (** x := fresh_svar() *)
     | SL of SLCmd.t  (** Separation-logic-related commands ({!type:SLCmd.t}) *)
 
   (** Deprecated. Use {!Visitors} instead *)

--- a/GillianCore/GIL_Syntax/Gil_syntax.mli
+++ b/GillianCore/GIL_Syntax/Gil_syntax.mli
@@ -629,8 +629,8 @@ module LCmd : sig
     | Macro of string * Expr.t list  (** Macros *)
     | Assert of Formula.t  (** Assert *)
     | Assume of Formula.t  (** Assume *)
-    | AssumeType of string * Type.t  (** Assume Type *)
-    | SpecVar of string list  (** Specification variables (spec vars) *)
+    | AssumeType of Expr.t * Type.t  (** Assume Type *)
+    | FreshSVar of string  (** x := Symbol() *)
     | SL of SLCmd.t  (** Separation-logic-related commands ({!type:SLCmd.t}) *)
 
   (** Deprecated. Use {!Visitors} instead *)
@@ -1136,7 +1136,7 @@ module Visitors : sig
            ; visit_Assert : 'c -> LCmd.t -> Formula.t -> LCmd.t
            ; visit_Assignment : 'c -> 'f Cmd.t -> string -> Expr.t -> 'f Cmd.t
            ; visit_Assume : 'c -> LCmd.t -> Formula.t -> LCmd.t
-           ; visit_AssumeType : 'c -> LCmd.t -> string -> Type.t -> LCmd.t
+           ; visit_AssumeType : 'c -> LCmd.t -> Expr.t -> Type.t -> LCmd.t
            ; visit_BAnd : 'c -> BinOp.t -> BinOp.t
            ; visit_BOr : 'c -> BinOp.t -> BinOp.t
            ; visit_BSetMem : 'c -> BinOp.t -> BinOp.t
@@ -1297,7 +1297,7 @@ module Visitors : sig
            ; visit_SignedRightShift : 'c -> BinOp.t -> BinOp.t
            ; visit_SignedRightShiftL : 'c -> BinOp.t -> BinOp.t
            ; visit_Skip : 'c -> 'f Cmd.t -> 'f Cmd.t
-           ; visit_SpecVar : 'c -> LCmd.t -> string list -> LCmd.t
+           ; visit_FreshSVar : 'c -> LCmd.t -> string -> LCmd.t
            ; visit_Star : 'c -> Asrt.t -> Asrt.t -> Asrt.t -> Asrt.t
            ; visit_StrCat : 'c -> BinOp.t -> BinOp.t
            ; visit_StrLen : 'c -> UnOp.t -> UnOp.t
@@ -1376,7 +1376,7 @@ module Visitors : sig
       method visit_Assert : 'c -> LCmd.t -> Formula.t -> LCmd.t
       method visit_Assignment : 'c -> 'f Cmd.t -> string -> Expr.t -> 'f Cmd.t
       method visit_Assume : 'c -> LCmd.t -> Formula.t -> LCmd.t
-      method visit_AssumeType : 'c -> LCmd.t -> string -> Type.t -> LCmd.t
+      method visit_AssumeType : 'c -> LCmd.t -> Expr.t -> Type.t -> LCmd.t
       method visit_BAnd : 'c -> BinOp.t -> BinOp.t
       method visit_BOr : 'c -> BinOp.t -> BinOp.t
       method visit_BSetMem : 'c -> BinOp.t -> BinOp.t
@@ -1553,7 +1553,7 @@ module Visitors : sig
       method visit_SignedRightShift : 'c -> BinOp.t -> BinOp.t
       method visit_SignedRightShiftL : 'c -> BinOp.t -> BinOp.t
       method visit_Skip : 'c -> 'f Cmd.t -> 'f Cmd.t
-      method visit_SpecVar : 'c -> LCmd.t -> string list -> LCmd.t
+      method visit_FreshSVar : 'c -> LCmd.t -> string -> LCmd.t
       method visit_Star : 'c -> Asrt.t -> Asrt.t -> Asrt.t -> Asrt.t
       method visit_StrCat : 'c -> BinOp.t -> BinOp.t
       method visit_StrLen : 'c -> UnOp.t -> UnOp.t
@@ -1670,7 +1670,7 @@ module Visitors : sig
            ; visit_Assert : 'c -> Formula.t -> 'f
            ; visit_Assignment : 'c -> string -> Expr.t -> 'f
            ; visit_Assume : 'c -> Formula.t -> 'f
-           ; visit_AssumeType : 'c -> string -> Type.t -> 'f
+           ; visit_AssumeType : 'c -> Expr.t -> Type.t -> 'f
            ; visit_BAnd : 'c -> 'f
            ; visit_BOr : 'c -> 'f
            ; visit_BSetMem : 'c -> 'f
@@ -1810,7 +1810,7 @@ module Visitors : sig
            ; visit_SignedRightShift : 'c -> 'f
            ; visit_SignedRightShiftL : 'c -> 'f
            ; visit_Skip : 'c -> 'f
-           ; visit_SpecVar : 'c -> string list -> 'f
+           ; visit_FreshSVar : 'c -> string -> 'f
            ; visit_Star : 'c -> Asrt.t -> Asrt.t -> 'f
            ; visit_StrCat : 'c -> 'f
            ; visit_StrLen : 'c -> 'f
@@ -1885,7 +1885,7 @@ module Visitors : sig
       method visit_Assert : 'c -> Formula.t -> 'f
       method visit_Assignment : 'c -> string -> Expr.t -> 'f
       method visit_Assume : 'c -> Formula.t -> 'f
-      method visit_AssumeType : 'c -> string -> Type.t -> 'f
+      method visit_AssumeType : 'c -> Expr.t -> Type.t -> 'f
       method visit_BAnd : 'c -> 'f
       method visit_BOr : 'c -> 'f
       method visit_BSetMem : 'c -> 'f
@@ -2032,7 +2032,7 @@ module Visitors : sig
       method visit_SignedRightShift : 'c -> 'f
       method visit_SignedRightShiftL : 'c -> 'f
       method visit_Skip : 'c -> 'f
-      method visit_SpecVar : 'c -> string list -> 'f
+      method visit_FreshSVar : 'c -> string -> 'f
       method visit_Star : 'c -> Asrt.t -> Asrt.t -> 'f
       method visit_StrCat : 'c -> 'f
       method visit_StrLen : 'c -> 'f
@@ -2112,7 +2112,7 @@ module Visitors : sig
            ; visit_Assert : 'c -> Formula.t -> unit
            ; visit_Assignment : 'c -> string -> Expr.t -> unit
            ; visit_Assume : 'c -> Formula.t -> unit
-           ; visit_AssumeType : 'c -> string -> Type.t -> unit
+           ; visit_AssumeType : 'c -> Expr.t -> Type.t -> unit
            ; visit_BAnd : 'c -> unit
            ; visit_BOr : 'c -> unit
            ; visit_BSetMem : 'c -> unit
@@ -2256,7 +2256,7 @@ module Visitors : sig
            ; visit_SignedRightShift : 'c -> unit
            ; visit_SignedRightShiftL : 'c -> unit
            ; visit_Skip : 'c -> unit
-           ; visit_SpecVar : 'c -> string list -> unit
+           ; visit_FreshSVar : 'c -> string -> unit
            ; visit_Star : 'c -> Asrt.t -> Asrt.t -> unit
            ; visit_StrCat : 'c -> unit
            ; visit_StrLen : 'c -> unit
@@ -2326,7 +2326,7 @@ module Visitors : sig
       method visit_Assert : 'c -> Formula.t -> unit
       method visit_Assignment : 'c -> string -> Expr.t -> unit
       method visit_Assume : 'c -> Formula.t -> unit
-      method visit_AssumeType : 'c -> string -> Type.t -> unit
+      method visit_AssumeType : 'c -> Expr.t -> Type.t -> unit
       method visit_BAnd : 'c -> unit
       method visit_BOr : 'c -> unit
       method visit_BSetMem : 'c -> unit
@@ -2477,7 +2477,7 @@ module Visitors : sig
       method visit_SignedRightShift : 'c -> unit
       method visit_SignedRightShiftL : 'c -> unit
       method visit_Skip : 'c -> unit
-      method visit_SpecVar : 'c -> string list -> unit
+      method visit_FreshSVar : 'c -> string -> unit
       method visit_Star : 'c -> Asrt.t -> Asrt.t -> unit
       method visit_StrCat : 'c -> unit
       method visit_StrLen : 'c -> unit

--- a/GillianCore/GIL_Syntax/LCmd.ml
+++ b/GillianCore/GIL_Syntax/LCmd.ml
@@ -9,7 +9,7 @@ type t = TypeDef__.lcmd =
   | Assert of Formula.t  (** Assert           *)
   | Assume of Formula.t  (** Assume           *)
   | AssumeType of Expr.t * Type.t  (** Assume Type      *)
-  | FreshSVar of string  (** x := Symbol() *)
+  | FreshSVar of string  (** x := fresh_svar() *)
   | SL of SLCmd.t
 
 let rec map

--- a/GillianCore/GIL_Syntax/LCmd.ml
+++ b/GillianCore/GIL_Syntax/LCmd.ml
@@ -8,8 +8,8 @@ type t = TypeDef__.lcmd =
   | Macro of string * Expr.t list  (** Macro            *)
   | Assert of Formula.t  (** Assert           *)
   | Assume of Formula.t  (** Assume           *)
-  | AssumeType of string * Type.t  (** Assume Type      *)
-  | SpecVar of string list  (** Spec Var         *)
+  | AssumeType of Expr.t * Type.t  (** Assume Type      *)
+  | FreshSVar of string  (** x := Symbol() *)
   | SL of SLCmd.t
 
 let rec map
@@ -34,8 +34,8 @@ let rec map
   | Macro (s, l) -> Macro (s, List.map map_e l)
   | Assume a -> Assume (map_p a)
   | Assert a -> Assert (map_p a)
-  | AssumeType _ -> mapped_lcmd
-  | SpecVar _ -> mapped_lcmd
+  | AssumeType (e, t) -> AssumeType (map_e e, t)
+  | FreshSVar _ -> mapped_lcmd
   | SL sl_cmd -> SL (map_sl sl_cmd)
 
 let fold = List.fold_left SS.union SS.empty
@@ -48,9 +48,8 @@ let rec pvars (lcmd : t) : SS.t =
       SS.union (Expr.pvars e) (SS.union (pvars_lcmds lthen) (pvars_lcmds lelse))
   | Macro (_, es) -> pvars_es es
   | Branch pf | Assert pf | Assume pf -> Formula.pvars pf
-  | AssumeType (x, _) ->
-      if Names.is_pvar_name x then SS.singleton x else SS.empty
-  | SpecVar _ -> SS.empty
+  | AssumeType (e, _) -> Expr.pvars e
+  | FreshSVar name -> SS.singleton name
   | SL slcmd -> SLCmd.pvars slcmd
 
 let rec lvars (lcmd : t) : SS.t =
@@ -61,10 +60,9 @@ let rec lvars (lcmd : t) : SS.t =
       SS.union (Expr.lvars e) (SS.union (lvars_lcmds lthen) (lvars_lcmds lelse))
   | Macro (_, es) -> lvars_es es
   | Branch pf | Assert pf | Assume pf -> Formula.lvars pf
-  | AssumeType (x, _) ->
-      if Names.is_lvar_name x then SS.singleton x else SS.empty
-  | SpecVar svars -> SS.of_list svars
+  | AssumeType (e, _) -> Expr.lvars e
   | SL slcmd -> SLCmd.lvars slcmd
+  | FreshSVar _ -> SS.empty
 
 let rec locs (lcmd : t) : SS.t =
   let locs_es es = fold (List.map Expr.locs es) in
@@ -74,9 +72,9 @@ let rec locs (lcmd : t) : SS.t =
       SS.union (Expr.locs e) (SS.union (locs_lcmds lthen) (locs_lcmds lelse))
   | Macro (_, es) -> locs_es es
   | Branch pf | Assert pf | Assume pf -> Formula.locs pf
-  | AssumeType _ -> SS.empty
-  | SpecVar svars -> SS.of_list svars
+  | AssumeType (e, _) -> Expr.locs e
   | SL slcmd -> SLCmd.locs slcmd
+  | FreshSVar _ -> SS.empty
 
 let rec pp fmt lcmd =
   let pp_list = Fmt.list ~sep:Fmt.semi pp in
@@ -93,7 +91,7 @@ let rec pp fmt lcmd =
   | Macro (name, lparams) -> Fmt.pf fmt "%s(@[%a@])" name pp_params lparams
   | Assert a -> Fmt.pf fmt "assert (@[%a@])" Formula.pp a
   | Assume a -> Fmt.pf fmt "assume (@[%a@])" Formula.pp a
-  | AssumeType (x, t) -> Fmt.pf fmt "assume_type (%s, %s)" x (Type.str t)
-  | SpecVar xs ->
-      Fmt.pf fmt "spec_var (@[%a@])" (Fmt.list ~sep:Fmt.comma Fmt.string) xs
+  | AssumeType (e, t) ->
+      Fmt.pf fmt "assume_type (%a, %s)" Expr.pp e (Type.str t)
   | SL sl_cmd -> SLCmd.pp fmt sl_cmd
+  | FreshSVar x -> Fmt.pf fmt "%s := Symbol()" x

--- a/GillianCore/GIL_Syntax/LCmd.ml
+++ b/GillianCore/GIL_Syntax/LCmd.ml
@@ -94,4 +94,4 @@ let rec pp fmt lcmd =
   | AssumeType (e, t) ->
       Fmt.pf fmt "assume_type (%a, %s)" Expr.pp e (Type.str t)
   | SL sl_cmd -> SLCmd.pp fmt sl_cmd
-  | FreshSVar x -> Fmt.pf fmt "%s := Symbol()" x
+  | FreshSVar x -> Fmt.pf fmt "%s := fresh_svar()" x

--- a/GillianCore/GIL_Syntax/TypeDef__.ml
+++ b/GillianCore/GIL_Syntax/TypeDef__.ml
@@ -175,8 +175,8 @@ and lcmd =
   | Macro of string * expr list
   | Assert of formula
   | Assume of formula
-  | AssumeType of string * typ
-  | SpecVar of string list
+  | AssumeType of expr * typ
+  | FreshSVar of string
   | SL of slcmd
 
 and 'label cmd =

--- a/GillianCore/engine/GeneralSemantics/General/GInterpreter.ml
+++ b/GillianCore/engine/GeneralSemantics/General/GInterpreter.ml
@@ -583,8 +583,8 @@ struct
              fos)
     | FreshSVar x ->
         let new_svar = Generators.fresh_svar () in
-        let state' = State.add_spec_vars state (SS.singleton x) in
-        let v = State.eval_expr state' (LVar new_svar) in
+        let state' = State.add_spec_vars state (SS.singleton new_svar) in
+        let v = Val.from_expr (LVar new_svar) |> Option.get in
         [ update_store state' x v ]
     | Assert f -> (
         let store_subst = Store.to_ssubst (State.get_store state) in

--- a/GillianCore/engine/GeneralSemantics/General/GInterpreter.ml
+++ b/GillianCore/engine/GeneralSemantics/General/GInterpreter.ml
@@ -542,18 +542,13 @@ struct
     let eval_expr = make_eval_expr state in
     match lcmd with
     | AssumeType (e, t) -> (
-        match Val.from_expr e with
-        | Some v_x -> (
-            match State.assume_t state v_x t with
-            | Some state' -> [ state' ]
-            | _ ->
-                Fmt.failwith
-                  "ERROR: AssumeType: Cannot assume type %s for expression %a."
-                  (Type.str t) Expr.pp e)
+        let v_x = eval_expr e in
+        match State.assume_t state v_x t with
+        | Some state' -> [ state' ]
         | _ ->
             Fmt.failwith
-              "ERROR: AssumeType: Variable %a cannot be turned into a value."
-              Expr.pp e)
+              "ERROR: AssumeType: Cannot assume type %s for expression %a."
+              (Type.str t) Expr.pp e)
     | Assume f ->
         let store_subst = Store.to_ssubst (State.get_store state) in
         let f' = SVal.SESubst.substitute_formula store_subst ~partial:true f in

--- a/GillianCore/engine/SymbolicSemantics/SState.ml
+++ b/GillianCore/engine/SymbolicSemantics/SState.ml
@@ -216,7 +216,7 @@ module Make (SMemory : SMemory.S) :
         | ESet es -> ESet (List.map f es)
         | NOp (op, es) -> NOp (op, List.map f es)
         | LstSub (e1, e2, e3) -> LstSub (f e1, f e2, f e3)
-        | _ -> expr
+        | Lit _ | LVar _ | ALoc _ -> expr
       in
       (* Perform reduction *)
       if no_reduce then result

--- a/GillianCore/utils/generators.ml
+++ b/GillianCore/utils/generators.ml
@@ -28,8 +28,11 @@ let fresh_lvar, reset_lvar = fresh_sth lvar_prefix
 (** Logical variable counter *)
 let fresh_lvar_bi, reset_lvar_bi = fresh_sth lvar_prefix_bi
 
+let fresh_svar, reset_svar = fresh_sth "#gen__"
+
 let reset () =
   reset_loc ();
   reset_pvar ();
   reset_lvar ();
-  reset_lvar_bi ()
+  reset_lvar_bi ();
+  reset_svar ()

--- a/GillianCore/utils/generators.mli
+++ b/GillianCore/utils/generators.mli
@@ -2,4 +2,5 @@ val fresh_loc : unit -> string
 val fresh_pvar : unit -> string
 val fresh_lvar : unit -> string
 val fresh_lvar_bi : unit -> string
+val fresh_svar : unit -> string
 val reset : unit -> unit

--- a/GillianCore/utils/names.ml
+++ b/GillianCore/utils/names.ml
@@ -19,6 +19,8 @@ let aloc_prefix = "_$l_"
 (** Logical variable prefix  *)
 let lvar_prefix = "_lvar_"
 
+let svar_prefix = "#var_"
+
 (** Logical variable prefix  *)
 let lvar_prefix_bi = "_lvar_bi_"
 

--- a/GillianCore/utils/names.ml
+++ b/GillianCore/utils/names.ml
@@ -19,8 +19,6 @@ let aloc_prefix = "_$l_"
 (** Logical variable prefix  *)
 let lvar_prefix = "_lvar_"
 
-let svar_prefix = "#var_"
-
 (** Logical variable prefix  *)
 let lvar_prefix_bi = "_lvar_bi_"
 


### PR DESCRIPTION
- create a FreshSvar LCmd to create symbolic variables, usable in a loop
- Removes the SpecVar command, which was only used to create fresh svars anyway
- Change the signature of AssumeType, which now takes an expression. It always could have anyway, since it's reverse-typing the expression anyway