### PR TITLE
Debug unify: Add button to jump to subst's origin

### DIFF
--- a/GillianCore/debugging/debugger/debugger.ml
+++ b/GillianCore/debugging/debugger/debugger.ml
@@ -176,7 +176,9 @@ struct
         let substitutions =
           asrt_report.subst |> Subst.to_list_pp
           |> List.map (fun subst ->
-                 List.find_opt (fun prev -> prev.subst = subst) prev_substs
+                 List.find_opt
+                   (fun prev -> [%eq: string * string] prev.subst subst)
+                   prev_substs
                  |> Option.value ~default:{ assert_id = id; subst })
         in
         let fold =

--- a/debugger-vscode-extension/src/types.ts
+++ b/debugger-vscode-extension/src/types.ts
@@ -26,11 +26,16 @@ export type ExecMap =
 
 export type UnifyResult = readonly ['Success' | 'Failure'];
 
+export type Substitution = {
+  readonly assertId: number;
+  readonly subst: readonly [string, string];
+};
+
 export type AssertionData = {
   readonly id: number;
   readonly fold: readonly [number, UnifyResult] | null;
   readonly assertion: string;
-  readonly substitutions: readonly [string, string][];
+  readonly substitutions: readonly Substitution[];
 };
 
 export type UnifySeg =

--- a/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyView.tsx
+++ b/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyView.tsx
@@ -42,7 +42,7 @@ const UnifyView = () => {
     <Allotment>
       <Allotment.Pane>{unifyMapView}</Allotment.Pane>
       <Allotment.Pane>
-        <UnifyData />
+        <UnifyData {...{ selectStep }} />
       </Allotment.Pane>
     </Allotment>
   );


### PR DESCRIPTION
Add a button to the debugger's unification interface, to jump to the assertion where a substitution is learned.
![image](https://user-images.githubusercontent.com/12882644/188524764-f62f8339-ab03-4556-b214-4745f7e86eb1.png)
