### PR TITLE
Support debugging multiple procs simultaneously

### DIFF
--- a/GillianCore/GIL_Syntax/Annot.ml
+++ b/GillianCore/GIL_Syntax/Annot.ml
@@ -5,8 +5,6 @@ type t = {
   origin_loc : Location.t option;  (** Better not to know what this is for *)
   origin_id : int option;  (** Origin Id, that should be abstracted away *)
   loop_info : string list; [@default []]
-  lift_hidden : bool; [@default false]
-      (** Should this cmd be hidden when lifting? *)
   expansion_kind : expansion_kind; [@default NoExpansion]
       (** Should this command be expanded when lifting? (i.e. loops to functions in WISL) *)
 }
@@ -19,8 +17,8 @@ let set_loop_info (annot : t) (loop_info : string list) =
 
 let get_origin_loc annot = annot.origin_loc
 let get_origin_id annot = annot.origin_id
-let is_hidden (annot : t) = annot.lift_hidden
-let hide (annot : t) = { annot with lift_hidden = true }
+let is_hidden (annot : t) = Option.is_none annot.origin_id
+let hide (annot : t) = { annot with origin_id = None }
 let get_expansion_kind (annot : t) = annot.expansion_kind
 
 let set_expansion_kind expansion_kind (annot : t) =

--- a/GillianCore/GIL_Syntax/Annot.ml
+++ b/GillianCore/GIL_Syntax/Annot.ml
@@ -1,9 +1,14 @@
 (** {b GIL annot}. *)
+type expansion_kind = NoExpansion | Function of string [@@deriving yojson]
+
 type t = {
   origin_loc : Location.t option;  (** Better not to know what this is for *)
   origin_id : int option;  (** Origin Id, that should be abstracted away *)
   loop_info : string list; [@default []]
-  lift_hidden : bool; [@default false]  (** Hidden when lifting *)
+  lift_hidden : bool; [@default false]
+      (** Should this cmd be hidden when lifting? *)
+  expansion_kind : expansion_kind; [@default NoExpansion]
+      (** Should this command be expanded when lifting? (i.e. loops to functions in WISL) *)
 }
 [@@deriving yojson, make]
 
@@ -14,5 +19,9 @@ let set_loop_info (annot : t) (loop_info : string list) =
 
 let get_origin_loc annot = annot.origin_loc
 let get_origin_id annot = annot.origin_id
-let hide (annot : t) = { annot with lift_hidden = true }
 let is_hidden (annot : t) = annot.lift_hidden
+let hide (annot : t) = { annot with lift_hidden = true }
+let get_expansion_kind (annot : t) = annot.expansion_kind
+
+let set_expansion_kind expansion_kind (annot : t) =
+  { annot with expansion_kind }

--- a/GillianCore/GIL_Syntax/Annot.mli
+++ b/GillianCore/GIL_Syntax/Annot.mli
@@ -8,7 +8,6 @@ val make :
   ?origin_loc:Location.t ->
   ?origin_id:int ->
   ?loop_info:string list ->
-  ?lift_hidden:bool ->
   ?expansion_kind:expansion_kind ->
   unit ->
   t

--- a/GillianCore/GIL_Syntax/Annot.mli
+++ b/GillianCore/GIL_Syntax/Annot.mli
@@ -1,4 +1,6 @@
 (** {b GIL annot}. *)
+type expansion_kind = NoExpansion | Function of string [@@deriving yojson]
+
 type t [@@deriving yojson]
 
 (** Initialize an annotation *)
@@ -7,6 +9,7 @@ val make :
   ?origin_id:int ->
   ?loop_info:string list ->
   ?lift_hidden:bool ->
+  ?expansion_kind:expansion_kind ->
   unit ->
   t
 
@@ -21,5 +24,7 @@ val get_origin_loc : t -> Location.t option
 
 (* Get the origin id *)
 val get_origin_id : t -> int option
-val hide : t -> t
 val is_hidden : t -> bool
+val hide : t -> t
+val get_expansion_kind : t -> expansion_kind
+val set_expansion_kind : expansion_kind -> t -> t

--- a/GillianCore/GIL_Syntax/BranchCase.ml
+++ b/GillianCore/GIL_Syntax/BranchCase.ml
@@ -1,0 +1,7 @@
+type t =
+  | GuardedGoto of bool
+  | LCmd of int
+  | SpecExec of Flag.t
+  | LAction of Yojson.Safe.t list
+  | LActionFail of int
+[@@deriving yojson]

--- a/GillianCore/GIL_Syntax/Gil_syntax.ml
+++ b/GillianCore/GIL_Syntax/Gil_syntax.ml
@@ -3,6 +3,7 @@ module Annot = Annot
 module Asrt = Asrt
 module BinOp = BinOp
 module BiSpec = BiSpec
+module BranchCase = BranchCase
 module Cmd = Cmd
 module Constant = Constant
 module Expr = Expr

--- a/GillianCore/GIL_Syntax/Gil_syntax.mli
+++ b/GillianCore/GIL_Syntax/Gil_syntax.mli
@@ -904,6 +904,8 @@ end
 
 module Annot : sig
   (** {b GIL annot}. *)
+  type expansion_kind = NoExpansion | Function of string [@@deriving yojson]
+
   type t [@@deriving yojson]
 
   (** make an annotation *)
@@ -912,6 +914,7 @@ module Annot : sig
     ?origin_id:int ->
     ?loop_info:string list ->
     ?lift_hidden:bool ->
+    ?expansion_kind:expansion_kind ->
     unit ->
     t
 
@@ -926,8 +929,10 @@ module Annot : sig
 
   (* Get the origin id *)
   val get_origin_id : t -> int option
-  val hide : t -> t
   val is_hidden : t -> bool
+  val hide : t -> t
+  val get_expansion_kind : t -> expansion_kind
+  val set_expansion_kind : expansion_kind -> t -> t
 end
 
 module Proc : sig

--- a/GillianCore/GIL_Syntax/Gil_syntax.mli
+++ b/GillianCore/GIL_Syntax/Gil_syntax.mli
@@ -902,6 +902,16 @@ module BiSpec : sig
   val pp : Format.formatter -> t -> unit
 end
 
+module BranchCase : sig
+  type t =
+    | GuardedGoto of bool
+    | LCmd of int
+    | SpecExec of Flag.t
+    | LAction of Yojson.Safe.t list
+    | LActionFail of int
+  [@@deriving yojson]
+end
+
 module Annot : sig
   (** {b GIL annot}. *)
   type expansion_kind = NoExpansion | Function of string [@@deriving yojson]

--- a/GillianCore/GIL_Syntax/Gil_syntax.mli
+++ b/GillianCore/GIL_Syntax/Gil_syntax.mli
@@ -913,7 +913,6 @@ module Annot : sig
     ?origin_loc:Location.t ->
     ?origin_id:int ->
     ?loop_info:string list ->
-    ?lift_hidden:bool ->
     ?expansion_kind:expansion_kind ->
     unit ->
     t

--- a/GillianCore/debugging/adapter/dapCustom.ml
+++ b/GillianCore/debugging/adapter/dapCustom.ml
@@ -8,7 +8,7 @@ module Events (Debugger : Debugger.S) = struct
     let type_ = "debugStateUpdate"
 
     module Payload = struct
-      type t = Debugger.Inspect.debug_state [@@deriving yojson]
+      type t = Debugger.Inspect.debug_state_view [@@deriving yojson]
     end
   end
 
@@ -54,7 +54,7 @@ module Commands (Debugger : Debugger.S) = struct
     end
 
     module Result = struct
-      type t = Debugger.Inspect.debug_state [@@deriving yojson]
+      type t = Debugger.Inspect.debug_state_view [@@deriving yojson]
     end
   end
 

--- a/GillianCore/debugging/debugger/debugger.ml
+++ b/GillianCore/debugging/debugger/debugger.ml
@@ -605,14 +605,9 @@ struct
         let new_display =
           Lifter.get_origin_node_str tl_ast cmd_data.origin_id
         in
-        if new_display = "No info!" then
-          DL.failwith
-            (fun () ->
-              let cmd_data =
-                cmd_data_to_yojson branch_case_to_yojson cmd_data
-              in
-              [ ("cmd_data", cmd_data) ])
-            "HORROR: tried to lift hidden command!";
+        let new_display =
+          if new_display = "No info!" then cmd_data.display else new_display
+        in
         { cmd_data with display = new_display }
       in
       let eq_opt ida idb =

--- a/GillianCore/debugging/debugger/debugger.ml
+++ b/GillianCore/debugging/debugger/debugger.ml
@@ -681,6 +681,7 @@ struct
     mutable lifted_exec_map : branch_case ExecMap.t option;
     mutable proc_name : string option;
     mutable unify_maps : (rid * UnifyMap.t) list;
+    report_state : L.report_state;
   }
 
   type debug_cfg = {
@@ -690,6 +691,7 @@ struct
     tl_ast : tl_ast option;
     tests : (string * Verification.t) list;
     main_proc_name : string;
+    report_state_base : L.report_state;
   }
 
   type debug_state = {
@@ -698,7 +700,7 @@ struct
     mutable cur_proc_name : string;
   }
 
-  let get_proc_state ?proc_name dbg =
+  let get_proc_state ?proc_name ?(activate_report_state = true) dbg =
     let proc_name =
       match proc_name with
       | Some proc_name ->
@@ -707,6 +709,8 @@ struct
       | None -> dbg.cur_proc_name
     in
     let proc_state = Hashtbl.find dbg.procs proc_name in
+    if activate_report_state then
+      L.activate_report_state proc_state.report_state;
     proc_state
 
   module Inspect = struct
@@ -1006,6 +1010,7 @@ struct
               "Debugger: don't know how to handle report of type '%s'!" t)
 
   let launch_proc cfg proc_name =
+    let report_state = L.(clone_report_state cfg.report_state_base) in
     let rec aux = function
       | Verification.SAInterpreter.Finished _ ->
           Error "HORROR: Shouldn't encounter Finished when debugging!"
@@ -1065,14 +1070,19 @@ struct
                     lifted_exec_map = lifted_map;
                     proc_name = None;
                     unify_maps = [];
+                    report_state;
                   }
                 in
                 state
                 |> update_report_id_and_inspection_fields cur_report_id cfg;
                 Ok state)
     in
-    let cont_func = Verification.verify_up_to_procs ~proc_name cfg.prog in
-    aux cont_func
+    report_state
+    |> L.with_report_state (fun () ->
+           let cont_func =
+             Verification.verify_up_to_procs ~proc_name cfg.prog
+           in
+           aux cont_func)
 
   let launch file_name proc_name =
     let () = Fmt_tty.setup_std_outputs () in
@@ -1109,9 +1119,11 @@ struct
         tl_ast;
         tests;
         main_proc_name = proc_name;
+        report_state_base = L.(clone_report_state global_report_state);
       }
     in
     let++ main_proc_state = launch_proc cfg proc_name in
+    main_proc_state.report_state |> L.activate_report_state;
     let dbg = { cfg; procs = Hashtbl.create 0; cur_proc_name = proc_name } in
     Hashtbl.add dbg.procs proc_name main_proc_state;
     dbg
@@ -1578,8 +1590,9 @@ struct
     aux ~launch 0 None
 
   let terminate dbg =
-    let () = Verification.postprocess_files dbg.cfg.source_files in
-    let () = if !Config.stats then Statistics.print_statistics () in
+    L.(activate_report_state global_report_state);
+    Verification.postprocess_files dbg.cfg.source_files;
+    if !Config.stats then Statistics.print_statistics ();
     L.wrap_up ()
 
   let get_frames ?proc_name dbg =

--- a/GillianCore/debugging/debugger/debugger.ml
+++ b/GillianCore/debugging/debugger/debugger.ml
@@ -1216,23 +1216,9 @@ struct
     let cmd_display = cmd.cmd in
     let origin_id = Annot.get_origin_id cmd.annot in
     let source = state |> get_current_source in
-    let submap =
-      let open ExecMap in
-      match Annot.get_expansion_kind cmd.annot with
-      | NoExpansion -> NoSubmap
-      | Function fname -> (
-          match launch_proc cfg fname with
-          | Error msg ->
-              DL.log (fun m -> m "Failed to launch proc %s: %s" fname msg);
-              NoSubmap
-          | Ok state' ->
-              Hashtbl.replace dbg.procs fname state';
-              Proc fname)
-    in
     ExecMap.(
       let new_cmd =
-        new_cmd cmd_kind cur_report_id cmd_display ~unifys ~errors ~submap
-          origin_id
+        new_cmd cmd_kind cur_report_id cmd_display ~unifys ~errors origin_id
       in
       let exec_map = state.exec_map |> insert_cmd new_cmd branch_path source in
       match exec_map with

--- a/GillianCore/debugging/debugger/debugger.ml
+++ b/GillianCore/debugging/debugger/debugger.ml
@@ -7,6 +7,7 @@ open DebuggerTypes
 open Syntaxes.Option
 
 type rid = L.ReportId.t [@@deriving show, yojson]
+type branch_case = BranchCase.t [@@deriving yojson]
 
 let ( let** ) = Result.bind
 let ( let++ ) f o = Result.map o f
@@ -99,7 +100,11 @@ struct
         | LCmd x -> ("LCmd", ("Logical command", Fmt.str "%d" x))
         | SpecExec fl -> ("SpecExec", ("Spec exec", Fmt.str "%a" Flag.pp fl))
         | LAction vs ->
-            let vs = vs |> List.map show_state_vt in
+            let vs =
+              vs
+              |> List_utils.map_results state_vt_of_yojson
+              |> Result.get_ok |> List.map show_state_vt
+            in
             ( "LAction",
               ( "Logical action",
                 Fmt.str "%a" (Fmt.list ~sep:(Fmt.any ", ") Fmt.string) vs ) )

--- a/GillianCore/debugging/debugger/debugger.ml
+++ b/GillianCore/debugging/debugger/debugger.ml
@@ -1082,6 +1082,10 @@ struct
                 |> update_report_id_and_inspection_fields cur_report_id cfg;
                 Ok state)
     in
+    Config.Verification.(
+      let procs_to_verify = !procs_to_verify in
+      if not (procs_to_verify |> List.mem proc_name) then
+        set_procs_to_verify (procs_to_verify @ [ proc_name ]));
     report_state
     |> L.with_report_state (fun () ->
            let cont_func =
@@ -1096,6 +1100,11 @@ struct
     let () = Config.stats := false in
     let () = Config.lemma_proof := true in
     let () = Config.manual_proof := false in
+    let () =
+      match proc_name with
+      | None -> ()
+      | Some proc_name -> Config.Verification.set_procs_to_verify [ proc_name ]
+    in
     (* If the file is a GIL file, assume it is already compiled *)
     let already_compiled = is_gil_file file_name in
     let outfile_opt = None in

--- a/GillianCore/debugging/debugger/debugger.ml
+++ b/GillianCore/debugging/debugger/debugger.ml
@@ -600,9 +600,14 @@ struct
         let new_display =
           Lifter.get_origin_node_str tl_ast cmd_data.origin_id
         in
-        let new_display =
-          if new_display = "No info!" then cmd_data.display else new_display
-        in
+        if new_display = "No info!" then
+          DL.failwith
+            (fun () ->
+              let cmd_data =
+                cmd_data_to_yojson branch_case_to_yojson cmd_data
+              in
+              [ ("cmd_data", cmd_data) ])
+            "HORROR: tried to lift hidden command!";
         { cmd_data with display = new_display }
       in
       let eq_opt ida idb =

--- a/GillianCore/debugging/debugger/debugger.ml
+++ b/GillianCore/debugging/debugger/debugger.ml
@@ -1091,11 +1091,6 @@ struct
     let () = Config.stats := false in
     let () = Config.lemma_proof := true in
     let () = Config.manual_proof := false in
-    let () =
-      match proc_name with
-      | None -> ()
-      | Some proc_name -> Config.Verification.set_procs_to_verify [ proc_name ]
-    in
     (* If the file is a GIL file, assume it is already compiled *)
     let already_compiled = is_gil_file file_name in
     let outfile_opt = None in

--- a/GillianCore/debugging/debugger/debugger.mli
+++ b/GillianCore/debugging/debugger/debugger.mli
@@ -25,48 +25,29 @@ module type S = sig
     val get_debug_state : debug_state -> debug_state_view
 
     val get_unification :
-      ?proc_name:string ->
-      Logging.ReportId.t ->
-      debug_state ->
-      Logging.ReportId.t * UnifyMap.t
+      Logging.ReportId.t -> debug_state -> Logging.ReportId.t * UnifyMap.t
   end
 
   val launch : string -> string option -> (debug_state, string) result
-
-  val jump_to_id :
-    ?proc_name:string ->
-    Logging.ReportId.t ->
-    debug_state ->
-    (unit, string) result
-
-  val jump_to_start : ?proc_name:string -> debug_state -> unit
-  val step_in : ?proc_name:string -> ?reverse:bool -> debug_state -> stop_reason
-  val step : ?proc_name:string -> ?reverse:bool -> debug_state -> stop_reason
+  val jump_to_id : Logging.ReportId.t -> debug_state -> (unit, string) result
+  val jump_to_start : debug_state -> unit
+  val step_in : ?reverse:bool -> debug_state -> stop_reason
+  val step : ?reverse:bool -> debug_state -> stop_reason
 
   val step_specific :
-    ?proc_name:string ->
     PackagedBranchCase.t option ->
     Logging.ReportId.t ->
     debug_state ->
     (stop_reason, string) result
 
-  val step_out : ?proc_name:string -> debug_state -> stop_reason
-
-  val run :
-    ?proc_name:string ->
-    ?reverse:bool ->
-    ?launch:bool ->
-    debug_state ->
-    stop_reason
-
+  val step_out : debug_state -> stop_reason
+  val run : ?reverse:bool -> ?launch:bool -> debug_state -> stop_reason
   val terminate : debug_state -> unit
-  val get_frames : ?proc_name:string -> debug_state -> frame list
-  val get_scopes : ?proc_name:string -> debug_state -> scope list
-  val get_variables : ?proc_name:string -> int -> debug_state -> variable list
-  val get_exception_info : ?proc_name:string -> debug_state -> exception_info
-
-  val set_breakpoints :
-    ?proc_name:string -> string option -> int list -> debug_state -> unit
+  val get_frames : debug_state -> frame list
+  val get_scopes : debug_state -> scope list
+  val get_variables : int -> debug_state -> variable list
+  val get_exception_info : debug_state -> exception_info
+  val set_breakpoints : string option -> int list -> debug_state -> unit
 end
 
 module Make

--- a/GillianCore/debugging/debugger/debugger.mli
+++ b/GillianCore/debugging/debugger/debugger.mli
@@ -25,29 +25,54 @@ module type S = sig
     val get_debug_state : debugger_state -> debug_state
 
     val get_unification :
-      Logging.ReportId.t -> debugger_state -> Logging.ReportId.t * UnifyMap.t
+      ?proc_name:string ->
+      Logging.ReportId.t ->
+      debugger_state ->
+      Logging.ReportId.t * UnifyMap.t
   end
 
   val launch : string -> string option -> (debugger_state, string) result
-  val jump_to_id : Logging.ReportId.t -> debugger_state -> (unit, string) result
-  val jump_to_start : debugger_state -> unit
-  val step_in : ?reverse:bool -> debugger_state -> stop_reason
-  val step : ?reverse:bool -> debugger_state -> stop_reason
+
+  val jump_to_id :
+    ?proc_name:string ->
+    Logging.ReportId.t ->
+    debugger_state ->
+    (unit, string) result
+
+  val jump_to_start : ?proc_name:string -> debugger_state -> unit
+
+  val step_in :
+    ?proc_name:string -> ?reverse:bool -> debugger_state -> stop_reason
+
+  val step : ?proc_name:string -> ?reverse:bool -> debugger_state -> stop_reason
 
   val step_specific :
+    ?proc_name:string ->
     PackagedBranchCase.t option ->
     Logging.ReportId.t ->
     debugger_state ->
     (stop_reason, string) result
 
-  val step_out : debugger_state -> stop_reason
-  val run : ?reverse:bool -> ?launch:bool -> debugger_state -> stop_reason
+  val step_out : ?proc_name:string -> debugger_state -> stop_reason
+
+  val run :
+    ?proc_name:string ->
+    ?reverse:bool ->
+    ?launch:bool ->
+    debugger_state ->
+    stop_reason
+
   val terminate : debugger_state -> unit
-  val get_frames : debugger_state -> frame list
-  val get_scopes : debugger_state -> scope list
-  val get_variables : int -> debugger_state -> variable list
-  val get_exception_info : debugger_state -> exception_info
-  val set_breakpoints : string option -> int list -> debugger_state -> unit
+  val get_frames : ?proc_name:string -> debugger_state -> frame list
+  val get_scopes : ?proc_name:string -> debugger_state -> scope list
+
+  val get_variables :
+    ?proc_name:string -> int -> debugger_state -> variable list
+
+  val get_exception_info : ?proc_name:string -> debugger_state -> exception_info
+
+  val set_breakpoints :
+    ?proc_name:string -> string option -> int list -> debugger_state -> unit
 end
 
 module Make

--- a/GillianCore/debugging/debugger/debugger.mli
+++ b/GillianCore/debugging/debugger/debugger.mli
@@ -5,7 +5,7 @@ open DebuggerTypes
 
 module type S = sig
   type tl_ast
-  type debugger_state
+  type debug_state
 
   module PackagedBranchCase : sig
     type t [@@deriving yojson]
@@ -20,59 +20,53 @@ module type S = sig
   end
 
   module Inspect : sig
-    type debug_state [@@deriving yojson]
+    type debug_state_view [@@deriving yojson]
 
-    val get_debug_state : debugger_state -> debug_state
+    val get_debug_state : debug_state -> debug_state_view
 
     val get_unification :
       ?proc_name:string ->
       Logging.ReportId.t ->
-      debugger_state ->
+      debug_state ->
       Logging.ReportId.t * UnifyMap.t
   end
 
-  val launch : string -> string option -> (debugger_state, string) result
+  val launch : string -> string option -> (debug_state, string) result
 
   val jump_to_id :
     ?proc_name:string ->
     Logging.ReportId.t ->
-    debugger_state ->
+    debug_state ->
     (unit, string) result
 
-  val jump_to_start : ?proc_name:string -> debugger_state -> unit
-
-  val step_in :
-    ?proc_name:string -> ?reverse:bool -> debugger_state -> stop_reason
-
-  val step : ?proc_name:string -> ?reverse:bool -> debugger_state -> stop_reason
+  val jump_to_start : ?proc_name:string -> debug_state -> unit
+  val step_in : ?proc_name:string -> ?reverse:bool -> debug_state -> stop_reason
+  val step : ?proc_name:string -> ?reverse:bool -> debug_state -> stop_reason
 
   val step_specific :
     ?proc_name:string ->
     PackagedBranchCase.t option ->
     Logging.ReportId.t ->
-    debugger_state ->
+    debug_state ->
     (stop_reason, string) result
 
-  val step_out : ?proc_name:string -> debugger_state -> stop_reason
+  val step_out : ?proc_name:string -> debug_state -> stop_reason
 
   val run :
     ?proc_name:string ->
     ?reverse:bool ->
     ?launch:bool ->
-    debugger_state ->
+    debug_state ->
     stop_reason
 
-  val terminate : debugger_state -> unit
-  val get_frames : ?proc_name:string -> debugger_state -> frame list
-  val get_scopes : ?proc_name:string -> debugger_state -> scope list
-
-  val get_variables :
-    ?proc_name:string -> int -> debugger_state -> variable list
-
-  val get_exception_info : ?proc_name:string -> debugger_state -> exception_info
+  val terminate : debug_state -> unit
+  val get_frames : ?proc_name:string -> debug_state -> frame list
+  val get_scopes : ?proc_name:string -> debug_state -> scope list
+  val get_variables : ?proc_name:string -> int -> debug_state -> variable list
+  val get_exception_info : ?proc_name:string -> debug_state -> exception_info
 
   val set_breakpoints :
-    ?proc_name:string -> string option -> int list -> debugger_state -> unit
+    ?proc_name:string -> string option -> int list -> debug_state -> unit
 end
 
 module Make

--- a/GillianCore/engine/Abstraction/Verifier.ml
+++ b/GillianCore/engine/Abstraction/Verifier.ml
@@ -1049,7 +1049,6 @@ struct
 
   let verify_up_to_procs ?(proc_name : string option) (prog : prog_t) :
       SAInterpreter.result_t SAInterpreter.cont_func =
-    proc_name |> ignore;
     L.with_normal_phase ~title:"Program verification" (fun () ->
         (* Analyse all procedures and lemmas *)
         let procs_to_verify =

--- a/GillianCore/engine/Abstraction/Verifier.ml
+++ b/GillianCore/engine/Abstraction/Verifier.ml
@@ -1073,9 +1073,18 @@ struct
                procedure (unless specified).
                Assume there is at least one procedure*)
         let test =
-          match proc_tests with
-          | test :: _ -> test
-          | _ -> failwith "No tests found!"
+          match proc_name with
+          | Some proc_name -> (
+              match
+                proc_tests |> List.find_opt (fun test -> test.name = proc_name)
+              with
+              | Some test -> test
+              | None ->
+                  Fmt.failwith "Couldn't find test for proc '%s'!" proc_name)
+          | None -> (
+              match proc_tests with
+              | test :: _ -> test
+              | _ -> failwith "No tests found!")
         in
         SAInterpreter.init_evaluate_proc
           (fun x -> x)

--- a/GillianCore/engine/Abstraction/Verifier.mli
+++ b/GillianCore/engine/Abstraction/Verifier.mli
@@ -34,7 +34,9 @@ module type S = sig
   val verify_prog : prog_t -> bool -> SourceFiles.t option -> unit
 
   val verify_up_to_procs :
-    prog_t -> SAInterpreter.result_t SAInterpreter.cont_func
+    ?proc_name:string ->
+    prog_t ->
+    SAInterpreter.result_t SAInterpreter.cont_func
 
   val postprocess_files : SourceFiles.t option -> unit
 

--- a/GillianCore/engine/GeneralSemantics/General/GInterpreter.mli
+++ b/GillianCore/engine/GeneralSemantics/General/GInterpreter.mli
@@ -1,10 +1,4 @@
-type 'state_vt branch_case' =
-  | GuardedGoto of bool
-  | LCmd of int
-  | SpecExec of Flag.t
-  | LAction of 'state_vt list
-  | LActionFail of int
-[@@deriving yojson]
+type branch_case = BranchCase.t
 
 module type S = sig
   module CallStack : CallStack.S
@@ -14,7 +8,7 @@ module type S = sig
   type store_t
   type state_t
   type state_err_t [@@deriving show]
-  type state_vt [@@deriving show]
+  type state_vt [@@deriving yojson, show]
   type heap_t
 
   module Val : Val.S with type t = vt
@@ -22,7 +16,6 @@ module type S = sig
 
   type invariant_frames = (string * state_t) list
   type err_t = (vt, state_err_t) ExecErr.t [@@deriving show, yojson]
-  type branch_case = state_vt branch_case' [@@deriving yojson]
   type branch_path = branch_case list [@@deriving yojson]
 
   type cconf_t =

--- a/GillianCore/logging/logging.ml
+++ b/GillianCore/logging/logging.ml
@@ -5,14 +5,7 @@ module Reporter = Reporter
 module Loggable = Loggable
 module LogQueryer = LogQueryer
 module ReportId = ReportId
-
-type report_state = ReportBuilder.report_state
-
-let new_report_state = ReportBuilder.new_report_state
-let clone_report_state = ReportBuilder.clone_report_state
-let global_report_state = ReportBuilder.global_report_state
-let activate_report_state = ReportBuilder.activate_report_state
-let with_report_state = ReportBuilder.with_report_state
+module ReportState = ReportBuilder.ReportState
 
 let () =
   Printexc.register_printer (function

--- a/GillianCore/logging/logging.ml
+++ b/GillianCore/logging/logging.ml
@@ -6,6 +6,14 @@ module Loggable = Loggable
 module LogQueryer = LogQueryer
 module ReportId = ReportId
 
+type report_state = ReportBuilder.report_state
+
+let new_report_state = ReportBuilder.new_report_state
+let clone_report_state = ReportBuilder.clone_report_state
+let global_report_state = ReportBuilder.global_report_state
+let activate_report_state = ReportBuilder.activate_report_state
+let with_report_state = ReportBuilder.with_report_state
+
 let () =
   Printexc.register_printer (function
     | Failure s ->

--- a/GillianCore/logging/logging.mli
+++ b/GillianCore/logging/logging.mli
@@ -94,13 +94,15 @@ module LogQueryer : sig
   val get_unify_for : ReportId.t -> (ReportId.t * string) option
 end
 
-type report_state
+module ReportState : sig
+  type t
 
-val new_report_state : unit -> report_state
-val clone_report_state : report_state -> report_state
-val global_report_state : report_state
-val activate_report_state : report_state -> unit
-val with_report_state : (unit -> 'a) -> report_state -> 'a
+  val make : unit -> t
+  val clone : t -> t
+  val global_state : t
+  val activate : t -> unit
+  val with_state : (unit -> 'a) -> t -> 'a
+end
 
 (** Initializes the logging module with the specified reporters and initializes
     the reporters *)

--- a/GillianCore/logging/logging.mli
+++ b/GillianCore/logging/logging.mli
@@ -94,6 +94,14 @@ module LogQueryer : sig
   val get_unify_for : ReportId.t -> (ReportId.t * string) option
 end
 
+type report_state
+
+val new_report_state : unit -> report_state
+val clone_report_state : report_state -> report_state
+val global_report_state : report_state
+val activate_report_state : report_state -> unit
+val with_report_state : (unit -> 'a) -> report_state -> 'a
+
 (** Initializes the logging module with the specified reporters and initializes
     the reporters *)
 val initialize : Reporter.t list -> unit

--- a/GillianCore/logging/reportBuilder.ml
+++ b/GillianCore/logging/reportBuilder.ml
@@ -1,47 +1,48 @@
-type report_state = {
-  previous : ReportId.t option ref;
-  parents : ReportId.t Stack.t;
-}
+module ReportState = struct
+  type t = { previous : ReportId.t option ref; parents : ReportId.t Stack.t }
 
-let new_report_state () = { previous = ref None; parents = Stack.create () }
+  let make () = { previous = ref None; parents = Stack.create () }
 
-let clone_report_state { previous; parents } =
-  { previous = ref !previous; parents = Stack.copy parents }
+  let clone { previous; parents } =
+    { previous = ref !previous; parents = Stack.copy parents }
 
-let global_report_state = new_report_state ()
-let active_report_state = ref global_report_state
-let activate_report_state state = active_report_state := state
+  let global_state = make ()
+  let active_state = ref global_state
+  let activate state = active_state := state
 
-let with_report_state f state =
-  let prev_report_state = !active_report_state in
-  active_report_state := state;
-  let result = f () in
-  active_report_state := prev_report_state;
-  result
+  let with_state f state =
+    let prev_report_state = !active_state in
+    active_state := state;
+    let result = f () in
+    active_state := prev_report_state;
+    result
+end
+
+open ReportState
 
 let get_previous () =
-  let { previous; _ } = !active_report_state in
+  let { previous; _ } = !active_state in
   !previous
 
 let set_previous id =
-  let { previous; _ } = !active_report_state in
+  let { previous; _ } = !active_state in
   match id with
   | None -> ()
   | id -> previous := id
 
 let get_parent () =
-  let { parents; _ } = !active_report_state in
+  let { parents; _ } = !active_state in
   Stack.top_opt parents
 
 let set_parent id =
-  let { previous; parents } = !active_report_state in
+  let { previous; parents } = !active_state in
   previous := None;
   Stack.push id parents
 
 let release_parent = function
   | None -> ()
   | Some rid as id_opt ->
-      let { previous; parents } = !active_report_state in
+      let { previous; parents } = !active_state in
       let parent_id = Stack.pop parents in
       assert (ReportId.equal rid parent_id);
       previous := id_opt

--- a/GillianCore/utils/list_utils.ml
+++ b/GillianCore/utils/list_utils.ml
@@ -153,3 +153,13 @@ let cons_opt x xs =
   match x with
   | None -> xs
   | Some x -> x :: xs
+
+let map_results f l =
+  let rec aux acc = function
+    | [] -> Ok (List.rev acc)
+    | x :: xs -> (
+        match f x with
+        | Ok x -> aux (x :: acc) xs
+        | Error e -> Error e)
+  in
+  aux [] l

--- a/debugger-vscode-extension/src/types.ts
+++ b/debugger-vscode-extension/src/types.ts
@@ -6,12 +6,18 @@ export type BranchCase = {
   readonly json: any;
 };
 
+type Submap =
+  | readonly ['NoSubmap']
+  | readonly ['Submap', ExecMap]
+  | readonly ['Proc', string];
+
 export type CmdData = {
   readonly id: number;
   readonly originId: number | null;
   readonly display: string;
   readonly unifys: readonly (readonly [number, UnifyKind, UnifyResult])[];
   readonly errors: readonly string[];
+  readonly submap: Submap;
 };
 
 export type ExecMap =
@@ -53,13 +59,19 @@ export type UnifyMap = readonly [
 
 // #endregion
 
-export type DebugState = {
+export type DebugProcState = {
   readonly execMap: ExecMap;
   readonly liftedExecMap: ExecMap | null;
   readonly currentCmdId: number;
   readonly unifys: readonly (readonly [number, UnifyKind, UnifyResult])[];
   readonly procName: string;
 };
+
+export type DebugState = {
+  readonly mainProc : string;
+  readonly currentProc : string;
+  readonly procs: Record<string, DebugProcState>;
+}
 
 export type UnifyStep =
   | readonly ['Assertion', AssertionData]

--- a/debugger-vscode-extension/src/webviews/src/ExecMap/ExecMapView.tsx
+++ b/debugger-vscode-extension/src/webviews/src/ExecMap/ExecMapView.tsx
@@ -16,7 +16,8 @@ type D = ExecMapNodeData;
 type A = BranchCase | null;
 
 const ExecMapView = ({ state }: Props) => {
-  const { execMap, currentCmdId, procName, liftedExecMap } = state;
+  const { mainProc, procs } = state;
+  const { execMap, currentCmdId, procName, liftedExecMap } = procs[mainProc];
   const usedExecMap = liftedExecMap ?? execMap;
 
   const initElem: TransformResult<M, D, A> = {

--- a/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyData.tsx
+++ b/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyData.tsx
@@ -29,7 +29,7 @@ const extractTargets = (seg: UnifySeg): { [key: number]: UnifyStep } => {
 };
 
 const UnifyData = ({ selectStep }: Props) => {
-  const procName = useStore(store => store.debugState?.procName || '');
+  const mainProcName = useStore(store => store.debugState?.mainProc || '');
   const [{ path, unifications }, baseUnifyKind] = useStore(store => [
     store.unifyState,
     showBaseUnifyKind(store),
@@ -58,7 +58,7 @@ const UnifyData = ({ selectStep }: Props) => {
   const unifyNames = [
     <>
       <span>
-        Unify <Code>{procName}</Code> ({baseUnifyKind})
+        Unify <Code>{mainProcName}</Code> ({baseUnifyKind})
       </span>
     </>,
   ];

--- a/debugger-vscode-extension/src/webviews/src/index.tsx
+++ b/debugger-vscode-extension/src/webviews/src/index.tsx
@@ -10,8 +10,10 @@ VSCodeAPI.onMessage(e => {
   const store = useDebugStore.getState();
 
   if (message.type === 'state_update') {
-    store.updateDebugState(message.state);
-    const { unifys } = message.state;
+    const { state } = message;
+    store.updateDebugState(state);
+    const currentProcState = state.procs[state.currentProc];
+    const { unifys } = currentProcState;
     if (unifys.length > 0) {
       const [unifyId, ,] = unifys[0];
       const isInStore = store.selectBaseUnification(unifyId);

--- a/debugger-vscode-extension/src/webviews/src/util.tsx
+++ b/debugger-vscode-extension/src/webviews/src/util.tsx
@@ -37,7 +37,7 @@ export const getUnifyName = (store: Store): [ReactNode, ReactNode] => {
   const { path, unifications } = store.unifyState;
   if (path.length < 2) {
     const kind = showBaseUnifyKind(store);
-    const procName = store.debugState?.procName || 'unknown proc';
+    const procName = store.debugState?.mainProc || 'unknown proc';
     return [
       <>
         Unify <Code>{procName}</Code>

--- a/wisl/lib/ParserAndCompiler/wisl2Gil.ml
+++ b/wisl/lib/ParserAndCompiler/wisl2Gil.ml
@@ -590,7 +590,10 @@ let compile_inv_and_while ~fname ~while_stmt ~invariant =
       ()
   in
   let lab_cmds =
-    List.map (fun cmd -> (annot_while, None, cmd)) (call_cmd :: reassign_vars)
+    ( Annot.(set_expansion_kind (Function loop_fname) annot_while),
+      None,
+      call_cmd )
+    :: List.map (fun cmd -> (annot_while, None, cmd)) reassign_vars
   in
   (lab_cmds, loop_funct)
 

--- a/wisl/lib/syntax/WStmt.ml
+++ b/wisl/lib/syntax/WStmt.ml
@@ -50,6 +50,7 @@ and pp fmt stmt =
 and pp_head fmt stmt =
   match get stmt with
   | If (e, _, _) -> Format.fprintf fmt "if (%a)" WExpr.pp e
+  | While (e, _) -> Format.fprintf fmt "while (%a)" WExpr.pp e
   | _ -> pp fmt stmt
 
 let is_while s =


### PR DESCRIPTION
Not in the parallel sense - essentially allows context switching between multiple procs when debugging.

This is in preparation for debugging loops, which, in WISL, are abstracted away as function calls upon compilation.