### PR TITLE
Add HTML reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ racket/compiled
 *.aux
 *.out
 *.log
+*.log.html
 tutorial/main.pdf
 
 # esy + docker stuff

--- a/GillianCore/CommandLine/CommandLine.ml
+++ b/GillianCore/CommandLine/CommandLine.ml
@@ -101,10 +101,7 @@ struct
     in
     let c = Arg.(list & conv (parse, print)) in
     let default : reporter_info list =
-      [
-        { name = "file"; reporter = L.file_reporter };
-        { name = "html"; reporter = L.html_reporter };
-      ]
+      [ { name = "html"; reporter = L.html_reporter } ]
     in
     let doc =
       "Controls which reporters are used when logging. The value REPORTERS \

--- a/GillianCore/CommandLine/CommandLine.ml
+++ b/GillianCore/CommandLine/CommandLine.ml
@@ -91,6 +91,7 @@ struct
     let parse : string -> (reporter_info, [> `Msg of string ]) Result.t =
       function
       | "file" -> Ok { name = "file"; reporter = L.file_reporter }
+      | "html" -> Ok { name = "html"; reporter = L.html_reporter }
       | "database" | "db" ->
           Ok { name = "database"; reporter = L.database_reporter }
       | other -> Error (`Msg ("unknown value \"" ^ other ^ "\""))
@@ -100,7 +101,10 @@ struct
     in
     let c = Arg.(list & conv (parse, print)) in
     let default : reporter_info list =
-      [ { name = "file"; reporter = L.file_reporter } ]
+      [
+        { name = "file"; reporter = L.file_reporter };
+        { name = "html"; reporter = L.html_reporter };
+      ]
     in
     let doc =
       "Controls which reporters are used when logging. The value REPORTERS \

--- a/GillianCore/logging/database_reporter.ml
+++ b/GillianCore/logging/database_reporter.ml
@@ -29,4 +29,6 @@ let log (report : Report.t) =
     Log_database.store_report ~id ~title ~elapsed_time ~previous ~parent
       ~content ~severity ~type_
 
+let start_phase () = ()
+let end_phase () = ()
 let wrap_up () = Log_database.close_db ()

--- a/GillianCore/logging/dune
+++ b/GillianCore/logging/dune
@@ -4,3 +4,19 @@
  (libraries fmt sqlite3)
  (preprocess
   (pps ppx_deriving.std ppx_deriving_yojson)))
+
+(rule
+ (target html_reporter_aux.ml)
+ (deps
+  (:css log.css)
+  (:js log.js))
+ (action
+  (with-stdout-to
+   %{target}
+   (progn
+    (echo "let css = {|")
+    (cat %{css})
+    (echo "|}")
+    (echo "let js = {|")
+    (cat %{js})
+    (echo "|}")))))

--- a/GillianCore/logging/file_reporter.ml
+++ b/GillianCore/logging/file_reporter.ml
@@ -28,6 +28,9 @@ let log (report : Report.t) : unit =
           Format.fprintf formatter "@,@?"
       | _ -> ())
 
+let start_phase () = ()
+let end_phase () = ()
+
 let wrap_up () =
   match !out_channel with
   | None -> ()

--- a/GillianCore/logging/html_reporter.ml
+++ b/GillianCore/logging/html_reporter.ml
@@ -1,0 +1,233 @@
+let filename = "file.log.html"
+
+type state = {
+  out : out_channel;
+  fmt : Format.formatter;
+  buf : Buffer.t;
+  buf_fmt : Format.formatter;
+  pre_div_pos : int option;
+  mutable phase_depth : int;
+  mutable line_number : int;
+}
+
+let state : state option ref = ref None
+
+let css =
+  {|
+  html {
+    --lh: 1rem;
+    --side-color: #919191;
+    line-height: var(--lh);
+  }
+
+  .container {
+    margin-left: 50px;
+    border-left: 1px solid var(--side-color);
+    padding-left: 4px;
+  }
+
+  .phase {
+    border-left: 1px solid black;
+    padding-left: 4px;
+    overflow: hidden;
+  }
+
+  .phase :nth-child(1) {
+    margin-top: 0;
+  }
+
+  .phase-button {
+    position: absolute;
+    left: 50px;
+    width: 1.2em;
+    height: 1.2em;
+    background-color: black;
+    color: white;
+    font-size: 0.8em;
+    border-radius: 100%;
+    box-sizing: border-box;
+    padding-left: 1px;
+    padding-top: 1px;
+    cursor: pointer;
+    transform: translateY(-50%);
+  }
+
+  .phase-button:has(+ .phase:empty),
+  .phase-button[collapsed] + .phase > .phase-button{
+    display: none;
+  }
+
+  .phase-button::before {
+    content: "▼";
+  }
+
+  .phase-button[collapsed] {
+    padding-top: 0px;
+    padding-left: 3px;
+  }
+
+  .phase-button[collapsed]::before {
+    content: "▶";
+  }
+
+  .phase-button:hover + .phase {
+    border-color: red !important;
+  }
+
+  .phase-button[collapsed] + .phase {
+    height: 0;
+    border-top: 1px solid black;
+  }
+
+  pre {
+    margin: 0;
+  }
+
+  .msg {
+    margin-top: 1em;
+  }
+
+  .msg:hover {
+    background-color: #f5f5f5;
+  }
+
+  .msg[collapsed] {
+    --max-lines: 1;
+    height: calc(var(--lh) * var(--max-lines));
+    overflow-y: hidden;
+    border-bottom: 1px dotted black;
+  }
+
+  .msg-line {
+    min-height: var(--lh);
+  }
+
+  .line-num {
+    position: absolute;
+    color: var(--side-color);
+    left: 5px;
+    width: 40px;
+    text-align: right;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+
+  .msg[collapsed] .line-num:not(:first-of-type),
+  .phase-button[collapsed] + .phase .line-num {
+    display: none;
+  }
+|}
+
+let js =
+  {|
+  function toggleCollapsed(e) {
+    e.toggleAttribute('collapsed');
+  }
+
+  function toggleCollapsedIfMultiline(e) {
+    if (e.querySelectorAll('.msg-line').length > 1)
+      toggleCollapsed(e);
+  }
+|}
+
+let html_pre =
+  Fmt.str
+    {|
+  <!DOCTYPE html>
+  <html>
+  <head>
+    <title>Gillian log</title>
+    <style>%s</style>
+    <script type="application/javascript">%s</script>
+  </head>
+  <body>
+    <div class="container">
+|}
+    css js
+
+let html_post = "</div></body></html>"
+
+let log_str s state =
+  let { fmt; _ } = state in
+  Fmt.pf fmt {|<div class="msg" onclick="toggleCollapsedIfMultiline(this)">|};
+  s |> String.trim |> String.split_on_char '\n'
+  |> List.iter (fun line ->
+         state.line_number <- state.line_number + 1;
+         Fmt.pf fmt
+           {|<pre class="line-num">%d</pre><pre class="msg-line">%s</pre>|}
+           state.line_number line);
+  Fmt.pf fmt "</div>"
+
+let print_end state =
+  let { out; fmt; phase_depth; _ } = state in
+  let pos = pos_out out in
+  for _ = 1 to phase_depth do
+    Fmt.pf fmt "</div>"
+  done;
+  log_str "" state;
+  Fmt.pf fmt "%s" html_post;
+  Fmt.flush fmt ();
+  seek_out out pos
+
+let start_phase () =
+  match !state with
+  | None -> ()
+  | Some state ->
+      Fmt.pf state.fmt
+        {|<div class="phase-button" onclick="toggleCollapsed(this)"></div><div class="phase">|};
+      state.phase_depth <- state.phase_depth + 1
+
+let end_phase () =
+  match !state with
+  | None -> ()
+  | Some state ->
+      if state.phase_depth = 0 then failwith "HORROR: phase_depth < 0";
+      Fmt.pf state.fmt "</div>";
+      state.phase_depth <- state.phase_depth - 1
+
+let accepted_types =
+  Logging_constants.Content_type.
+    [ debug; assertion; phase; cmd; unify; unify_result ]
+
+let initialize () =
+  let out = open_out filename in
+  let fmt = Format.formatter_of_out_channel out in
+  let buf = Buffer.create 16 in
+  let buf_fmt = Format.formatter_of_buffer buf in
+  Fmt.pf fmt "%s" html_pre;
+  state :=
+    Some
+      {
+        out;
+        fmt;
+        buf;
+        buf_fmt;
+        phase_depth = 0;
+        pre_div_pos = None;
+        line_number = 0;
+      }
+
+let will_log (type_ : string) = List.mem type_ accepted_types
+
+let get_report_content (report : Report.t) { buf; buf_fmt; _ } =
+  Buffer.clear buf;
+  Loggable.pp_html report.content buf_fmt;
+  Format.pp_print_flush buf_fmt ();
+  Buffer.contents buf
+
+let log (report : Report.t) : unit =
+  match !state with
+  | Some state ->
+      if will_log report.type_ then
+        let report_content = get_report_content report state in
+        log_str report_content state
+  | _ -> ()
+
+let wrap_up () =
+  match !state with
+  | Some state ->
+      print_end state;
+      close_out state.out
+  | None -> ()

--- a/GillianCore/logging/html_reporter.ml
+++ b/GillianCore/logging/html_reporter.ml
@@ -12,126 +12,6 @@ type state = {
 
 let state : state option ref = ref None
 
-let css =
-  {|
-  html {
-    --lh: 1rem;
-    --side-color: #919191;
-    line-height: var(--lh);
-  }
-
-  .container {
-    margin-left: 50px;
-    border-left: 1px solid var(--side-color);
-    padding-left: 4px;
-  }
-
-  .phase {
-    border-left: 1px solid black;
-    padding-left: 4px;
-    overflow: hidden;
-  }
-
-  .phase :nth-child(1) {
-    margin-top: 0;
-  }
-
-  .phase-button {
-    position: absolute;
-    left: 50px;
-    width: 1.2em;
-    height: 1.2em;
-    background-color: black;
-    color: white;
-    font-size: 0.8em;
-    border-radius: 100%;
-    box-sizing: border-box;
-    padding-left: 1px;
-    padding-top: 1px;
-    cursor: pointer;
-    transform: translateY(-50%);
-  }
-
-  .phase-button:has(+ .phase:empty),
-  .phase-button[collapsed] + .phase > .phase-button{
-    display: none;
-  }
-
-  .phase-button::before {
-    content: "▼";
-  }
-
-  .phase-button[collapsed] {
-    padding-top: 0px;
-    padding-left: 3px;
-  }
-
-  .phase-button[collapsed]::before {
-    content: "▶";
-  }
-
-  .phase-button:hover + .phase {
-    border-color: red !important;
-  }
-
-  .phase-button[collapsed] + .phase {
-    height: 0;
-    border-top: 1px solid black;
-  }
-
-  pre {
-    margin: 0;
-  }
-
-  .msg {
-    margin-top: 1em;
-  }
-
-  .msg:hover {
-    background-color: #f5f5f5;
-  }
-
-  .msg[collapsed] {
-    --max-lines: 1;
-    height: calc(var(--lh) * var(--max-lines));
-    overflow-y: hidden;
-    border-bottom: 1px dotted black;
-  }
-
-  .msg-line {
-    min-height: var(--lh);
-  }
-
-  .line-num {
-    position: absolute;
-    color: var(--side-color);
-    left: 5px;
-    width: 40px;
-    text-align: right;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-  }
-
-  .msg[collapsed] .line-num:not(:first-of-type),
-  .phase-button[collapsed] + .phase .line-num {
-    display: none;
-  }
-|}
-
-let js =
-  {|
-  function toggleCollapsed(e) {
-    e.toggleAttribute('collapsed');
-  }
-
-  function toggleCollapsedIfMultiline(e) {
-    if (e.querySelectorAll('.msg-line').length > 1)
-      toggleCollapsed(e);
-  }
-|}
-
 let html_pre =
   Fmt.str
     {|
@@ -145,7 +25,7 @@ let html_pre =
   <body>
     <div class="container">
 |}
-    css js
+    Html_reporter_aux.css Html_reporter_aux.js
 
 let html_post = "</div></body></html>"
 

--- a/GillianCore/logging/log.css
+++ b/GillianCore/logging/log.css
@@ -1,0 +1,104 @@
+html {
+  --lh: 1rem;
+  --side-color: #919191;
+  line-height: var(--lh);
+}
+
+.container {
+  margin-left: 50px;
+  border-left: 1px solid var(--side-color);
+  padding-left: 4px;
+}
+
+.phase {
+  border-left: 1px solid black;
+  padding-left: 4px;
+  overflow: hidden;
+}
+
+.phase :nth-child(1) {
+  margin-top: 0;
+}
+
+.phase-button {
+  position: absolute;
+  left: 50px;
+  width: 1.2em;
+  height: 1.2em;
+  background-color: black;
+  color: white;
+  font-size: 0.8em;
+  border-radius: 100%;
+  box-sizing: border-box;
+  padding-left: 1px;
+  padding-top: 1px;
+  cursor: pointer;
+  transform: translateY(-50%);
+}
+
+.phase-button:has(+ .phase:empty),
+.phase-button[collapsed] + .phase > .phase-button{
+  display: none;
+}
+
+.phase-button::before {
+  content: "▼";
+}
+
+.phase-button[collapsed] {
+  padding-top: 0px;
+  padding-left: 3px;
+}
+
+.phase-button[collapsed]::before {
+  content: "▶";
+}
+
+.phase-button:hover + .phase {
+  border-color: red !important;
+}
+
+.phase-button[collapsed] + .phase {
+  height: 0;
+  border-top: 1px solid black;
+}
+
+pre {
+  margin: 0;
+}
+
+.msg {
+  margin-top: 1em;
+}
+
+.msg:hover {
+  background-color: #f5f5f5;
+}
+
+.msg[collapsed] {
+  --max-lines: 1;
+  height: calc(var(--lh) * var(--max-lines));
+  overflow-y: hidden;
+  border-bottom: 1px dotted black;
+}
+
+.msg-line {
+  min-height: var(--lh);
+}
+
+.line-num {
+  position: absolute;
+  color: var(--side-color);
+  left: 5px;
+  width: 40px;
+  text-align: right;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.msg[collapsed] .line-num:not(:first-of-type),
+.phase-button[collapsed] + .phase .line-num {
+  display: none;
+}

--- a/GillianCore/logging/log.js
+++ b/GillianCore/logging/log.js
@@ -1,0 +1,8 @@
+function toggleCollapsed(e) {
+  e.toggleAttribute('collapsed');
+}
+
+function toggleCollapsedIfMultiline(e) {
+  if (e.querySelectorAll('.msg-line').length > 1)
+    toggleCollapsed(e);
+}

--- a/GillianCore/logging/loggable_intf.ml
+++ b/GillianCore/logging/loggable_intf.ml
@@ -4,6 +4,9 @@ module type S = sig
 
   (** Pretty printer for the type *)
   val pp : Format.formatter -> t -> unit
+
+  (** {i HTML} pretty printer for the type *)
+  val pp_html : Format.formatter -> t -> unit
 end
 
 module Types = struct
@@ -21,10 +24,12 @@ module type Intf = sig
   type t
 
   val pp : t -> Format.formatter -> unit
+  val pp_html : t -> Format.formatter -> unit
   val loggable_to_yojson : t -> Yojson.Safe.t
 
   val make :
     (Format.formatter -> 'a -> unit) ->
+    ?pp_html:(Format.formatter -> 'a -> unit) ->
     (Yojson.Safe.t -> ('a, string) result) ->
     ('a -> Yojson.Safe.t) ->
     'a ->

--- a/GillianCore/logging/logging.ml
+++ b/GillianCore/logging/logging.ml
@@ -127,9 +127,8 @@ module Phase = struct
   let tmi = start TMI
 
   let stop id =
-    if will_log_on_any_reporter Logging_constants.Content_type.phase then (
-      Report_builder.end_phase id;
-      !reporters |> List.iter Reporter.end_phase)
+    Report_builder.end_phase id;
+    if Option.is_some id then !reporters |> List.iter Reporter.end_phase
 
   let with_phase level ?title ?severity f =
     let phase = start level ?title ?severity () in

--- a/GillianCore/logging/logging.mli
+++ b/GillianCore/logging/logging.mli
@@ -48,6 +48,7 @@ module Reporter : sig
 end
 
 val database_reporter : Reporter.t
+val html_reporter : Reporter.t
 val file_reporter : Reporter.t
 
 (** @canonical Gillian.Logging.Loggable *)

--- a/GillianCore/logging/report_builder.ml
+++ b/GillianCore/logging/report_builder.ml
@@ -75,9 +75,13 @@ let make
 
 let start_phase level ?title ?severity () =
   if Mode.should_log level then (
+    let msg =
+      match title with
+      | None -> "*** Phase ***"
+      | Some title -> "*** Phase: " ^ title ^ " ***"
+    in
     let report =
-      make ?title
-        ~content:(Loggable.make_string "*** Phase ***")
+      make ?title ~content:(Loggable.make_string msg)
         ~type_:Logging_constants.Content_type.phase ?severity ()
     in
     set_parent report.id;

--- a/GillianCore/logging/reporter.ml
+++ b/GillianCore/logging/reporter.ml
@@ -12,6 +12,12 @@ module type S = sig
   (** Logs a report *)
   val log : Report.t -> unit
 
+  (** Called when a phase starts *)
+  val start_phase : unit -> unit
+
+  (** Called when a phase ends *)
+  val end_phase : unit -> unit
+
   (** Runs any clean up code *)
   val wrap_up : unit -> unit
 end
@@ -32,6 +38,14 @@ let will_log (reporter : t) (type_ : string) : bool =
 let log (reporter : t) (report : Report.t) : unit =
   let (module R) = reporter in
   R.log report
+
+let start_phase (reporter : t) : unit =
+  let (module R) = reporter in
+  R.start_phase ()
+
+let end_phase (reporter : t) : unit =
+  let (module R) = reporter in
+  R.end_phase ()
 
 (** Calls a given reporter module's `wrap_up` function *)
 let wrap_up (reporter : t) : unit =


### PR DESCRIPTION
This adds a reporter, enabled by default alongside the file reporter, that logs to an HTML file, with line numbers and folding.

![image](https://user-images.githubusercontent.com/12882644/219421235-5c5dce2e-7d3d-43b0-bb34-2d85aa5ac202.png)
