### PR TITLE
Enhance map views in debugger interface

### DIFF
--- a/debugger-vscode-extension/package.json
+++ b/debugger-vscode-extension/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "extension:build": "webpack",
-    "extension:watch": "tsc -watch -p ./",
+    "extension:watch": "tsc --watch --preserveWatchOutput -p ./",
     "webview:build": "TAILWIND_MODE='build' snowpack build",
     "webview:watch": "nodemon --watch src/webviews/ -e 'ts,tsx,css' --exec snowpack build",
     "build": "run-s extension:build webview:build",

--- a/debugger-vscode-extension/src/WebviewPanel.ts
+++ b/debugger-vscode-extension/src/WebviewPanel.ts
@@ -3,7 +3,7 @@ import * as debug from './debug';
 
 import { getNonce } from './lib';
 import {
-  DebugState,
+  DebuggerState,
   MessageFromWebview,
   MessageToWebview,
   UnifyMap,
@@ -58,7 +58,7 @@ export class WebviewPanel {
 
   private async handleMessage(e: MessageFromWebview) {
     if (e.type === 'request_state_update') {
-      const state = await debug.getDebugState();
+      const state = await debug.getDebuggerState();
       if (state !== undefined) {
         this.updateState(state);
       }
@@ -77,7 +77,7 @@ export class WebviewPanel {
     }
   }
 
-  public updateState(state: DebugState) {
+  public updateState(state: DebuggerState) {
     console.info('Got state', state);
     this.sendMessage({ type: 'state_update', state });
   }

--- a/debugger-vscode-extension/src/debug.ts
+++ b/debugger-vscode-extension/src/debug.ts
@@ -9,7 +9,7 @@ import {
 } from 'vscode';
 
 import { startDebugging } from './commands';
-import { BranchCase, DebugState, UnifyMap } from './types';
+import { BranchCase, DebuggerState, UnifyMap } from './types';
 import { WebviewPanel } from './WebviewPanel';
 
 type LogEvent = {
@@ -33,7 +33,7 @@ function handleCustomDebugEvent({
       console.log(`<D> ${msg}`, json);
     }
   } else if (event === 'debugStateUpdate') {
-    WebviewPanel.currentPanel?.updateState(body as DebugState);
+    WebviewPanel.currentPanel?.updateState(body as DebuggerState);
   } else {
     console.error(`Unhandled custom event '${event}'`);
   }
@@ -149,10 +149,10 @@ class ConfigurationProvider implements vscode.DebugConfigurationProvider {
   }
 }
 
-export async function getDebugState() {
+export async function getDebuggerState() {
   const session = vscode.debug.activeDebugSession;
   if (session !== undefined) {
-    const state: DebugState = await session.customRequest('debuggerState');
+    const state: DebuggerState = await session.customRequest('debuggerState');
     return state;
   }
 }

--- a/debugger-vscode-extension/src/types.d.ts
+++ b/debugger-vscode-extension/src/types.d.ts
@@ -75,7 +75,7 @@ export type DebugProcState = {
   readonly procName: string;
 };
 
-export type DebugState = {
+export type DebuggerState = {
   readonly mainProc: string;
   readonly currentProc: string;
   readonly procs: Record<string, DebugProcState>;
@@ -93,18 +93,20 @@ export type UnificationState = {
 export type UnifyState = {
   readonly path: number[];
   readonly unifications: Record<number, UnificationState | undefined>;
+  readonly expandedNodes: Set<string>;
 };
 
 export type State = {
-  readonly debugState?: DebugState;
+  readonly debuggerState?: DebuggerState;
   readonly unifyState: UnifyState;
+  readonly expandedExecNodes: Set<string>;
 };
 
 // #region MessageToWebview
 
 type StateUpdateMsg = {
   readonly type: 'state_update';
-  readonly state: DebugState;
+  readonly state: DebuggerState;
 };
 
 type UnifyUpdateMsg = {

--- a/debugger-vscode-extension/src/types.d.ts
+++ b/debugger-vscode-extension/src/types.d.ts
@@ -60,10 +60,11 @@ export type UnifyKind = [
   'Postcondition' | 'Fold' | 'FunctionCall' | 'Invariant' | 'LogicCommand'
 ];
 
-export type UnifyMap = readonly [
-  UnifyKind,
-  readonly ['Direct', UnifySeg] | readonly ['Fold', UnifySeg[]]
-];
+export type UnifyMapInner =
+  | readonly ['Direct', UnifySeg]
+  | readonly ['Fold', UnifySeg[]];
+
+export type UnifyMap = readonly [UnifyKind, UnifyMapInner];
 
 // #endregion
 
@@ -86,6 +87,7 @@ export type UnifyStep =
   | readonly ['Result', number, UnifyResult];
 
 export type UnificationState = {
+  readonly id: number;
   readonly map: unknown; // TODO: fix when Immer supports recursive types
   readonly selected?: UnifyStep;
 };
@@ -93,7 +95,7 @@ export type UnificationState = {
 export type UnifyState = {
   readonly path: number[];
   readonly unifications: Record<number, UnificationState | undefined>;
-  readonly expandedNodes: Set<string>;
+  readonly expandedNodes: Set<number>;
 };
 
 export type State = {
@@ -123,7 +125,7 @@ export type MessageToWebview = StateUpdateMsg | UnifyUpdateMsg | ResetViewMsg;
 
 // #endregion
 
-// #region MessageFromWebiew
+// #region MessageFromWebview
 
 type RequestStateUpdateMsg = {
   readonly type: 'request_state_update';

--- a/debugger-vscode-extension/src/webviews/src/App.tsx
+++ b/debugger-vscode-extension/src/webviews/src/App.tsx
@@ -7,14 +7,18 @@ import VSCodeAPI from './VSCodeAPI';
 import './style.css';
 
 const App = () => {
-  const { debugState } = useStore();
+  const { debuggerState } = useStore();
 
   const refresh = () => {
     VSCodeAPI.postMessage({ type: 'request_state_update' });
   };
 
   const content =
-    debugState === undefined ? <Loading {...{ refresh }} /> : <DebuggerPanel />;
+    debuggerState === undefined ? (
+      <Loading {...{ refresh }} />
+    ) : (
+      <DebuggerPanel />
+    );
 
   return (
     <div style={{ margin: '10px', boxSizing: 'border-box' }}>{content}</div>

--- a/debugger-vscode-extension/src/webviews/src/DebuggerPanel/DebuggerPanel.tsx
+++ b/debugger-vscode-extension/src/webviews/src/DebuggerPanel/DebuggerPanel.tsx
@@ -4,16 +4,19 @@ import {
   VSCodePanelView,
 } from '@vscode/webview-ui-toolkit/react';
 import React, { useEffect, useState } from 'react';
-import { DebugState } from '../../../types';
+import { DebuggerState } from '../../../types';
 import ExecMapView from '../ExecMap/ExecMapView';
-import useStore from '../store';
+import useStore, { mutateStore } from '../store';
 import UnifyView from '../UnifyView/UnifyView';
 import * as events from '../events';
 
 import './DebuggerPanel.css';
 
 const DebuggerPanel = () => {
-  const debugState = useStore(({ debugState }) => debugState);
+  const [debuggerState, expandedExecNodes] = useStore(
+    ({ debuggerState, expandedExecNodes }) => [debuggerState, expandedExecNodes]
+  );
+  const { toggleExecNodeExpanded } = mutateStore();
   const hasUnify = useStore(
     ({ unifyState: { path } }) => path && path.length > 0
   );
@@ -56,7 +59,13 @@ const DebuggerPanel = () => {
         </VSCodePanelTab>
 
         <VSCodePanelView id="debug-exec-panel">
-          <ExecMapView {...{ state: debugState as DebugState }} />
+          <ExecMapView
+            {...{
+              state: debuggerState as DebuggerState,
+              expandedNodes: expandedExecNodes,
+              toggleNodeExpanded: toggleExecNodeExpanded,
+            }}
+          />
         </VSCodePanelView>
         <VSCodePanelView id="debug-unify-panel">
           <UnifyView />

--- a/debugger-vscode-extension/src/webviews/src/ExecMap/ExecMapNode.tsx
+++ b/debugger-vscode-extension/src/webviews/src/ExecMap/ExecMapNode.tsx
@@ -20,6 +20,8 @@ export type ExecMapNodeData = { isActive: boolean } & (
       isCurrentCmd: boolean;
       hasParent: boolean;
       jump: () => void;
+      expanded: boolean;
+      toggleExpanded?: () => void;
     }
   | {
       type: 'Empty';
@@ -72,35 +74,42 @@ const ExecMapNode = ({ data }: NodeProps<ExecMapNodeData & Dims>) => {
     );
   }
 
-  const { cmdData, isFinal, isCurrentCmd, hasParent } = data;
+  const {
+    cmdData,
+    isFinal,
+    isCurrentCmd,
+    hasParent,
+    expanded,
+    toggleExpanded,
+    jump,
+  } = data;
 
   const unifyBadge = (() => {
-    if (cmdData.unifys.length > 0) {
-      const [result] = cmdData.unifys[0].result;
-      const colorStyle = result === 'Success' ? {} : { color: 'red' };
-      return (
-        <>
-          <VSCodeBadge>
-            <div
-              style={colorStyle}
-              className={`codicon codicon-${
-                result === 'Success' ? 'pass' : 'error'
-              }`}
-            />
-            &nbsp;
-            <div style={colorStyle}>Unify</div>
-          </VSCodeBadge>
+    if (cmdData.unifys.length === 0) return <></>;
+
+    const [result] = cmdData.unifys[0].result;
+    const colorStyle = result === 'Success' ? {} : { color: 'red' };
+    return (
+      <>
+        <VSCodeBadge>
+          <div
+            style={colorStyle}
+            className={`codicon codicon-${
+              result === 'Success' ? 'pass' : 'error'
+            }`}
+          />
           &nbsp;
-        </>
-      );
-    } else {
-      return <></>;
-    }
+          <div style={colorStyle}>Unify</div>
+        </VSCodeBadge>
+        &nbsp;
+      </>
+    );
   })();
 
-  let errorTooltip = <></>;
-  if (cmdData.errors.length > 0) {
-    errorTooltip = (
+  const errorTooltip = (() => {
+    if (cmdData.errors.length === 0) return <></>;
+
+    return (
       <>
         <VSCodeDivider />
         <div className="tooltip-error">
@@ -112,7 +121,24 @@ const ExecMapNode = ({ data }: NodeProps<ExecMapNodeData & Dims>) => {
         </div>
       </>
     );
-  }
+  })();
+
+  const expandButton = (() => {
+    if (toggleExpanded === undefined) return <></>;
+
+    const icon = expanded ? 'chevron-down' : 'chevron-right';
+
+    return (
+      <VSCodeButton
+        appearance="icon"
+        aria-label="Expand / Collapse"
+        title="Expand / Collapse"
+        onClick={toggleExpanded}
+      >
+        <span className={`codicon codicon-${icon}`} />
+      </VSCodeButton>
+    );
+  })();
 
   const tooltip = (
     <div className="tooltip">
@@ -140,10 +166,11 @@ const ExecMapNode = ({ data }: NodeProps<ExecMapNodeData & Dims>) => {
           aria-label="Jump here"
           title="Jump here"
           disabled={isCurrentCmd}
-          onClick={isCurrentCmd ? undefined : data.jump}
+          onClick={isCurrentCmd ? undefined : jump}
         >
           <span className="codicon codicon-target" />
         </VSCodeButton>
+        {expandButton}
       </div>
     </NodeWrap>
   );

--- a/debugger-vscode-extension/src/webviews/src/ExecMap/ExecMapNode.tsx
+++ b/debugger-vscode-extension/src/webviews/src/ExecMap/ExecMapNode.tsx
@@ -5,7 +5,7 @@ import {
   VSCodeDivider,
 } from '@vscode/webview-ui-toolkit/react';
 import { CmdData } from '../../../types';
-import { Dims } from '../TreeMapView/TreeMapView';
+import type { Dims } from '../TreeMapView/TreeMapView';
 import NodeWrap from '../TreeMapView/NodeWrap';
 import { NodeProps } from 'react-flow-renderer';
 import { Code } from '../util';

--- a/debugger-vscode-extension/src/webviews/src/ExecMap/ExecMapView.tsx
+++ b/debugger-vscode-extension/src/webviews/src/ExecMap/ExecMapView.tsx
@@ -6,11 +6,7 @@ import TreeMapView, {
 } from '../TreeMapView/TreeMapView';
 import { execSpecific, jumpToId, startProc } from '../VSCodeAPI';
 import ExecMapNode, { ExecMapNodeData } from './ExecMapNode';
-import {
-  NODE_WIDTH,
-  NODE_HEIGHT,
-  DEFAULT_NODE_SIZE,
-} from '../TreeMapView/TreeMapView';
+import { NODE_HEIGHT, DEFAULT_NODE_SIZE } from '../TreeMapView/TreeMapView';
 
 export type Props = {
   state: DebuggerState;
@@ -40,8 +36,7 @@ const ExecMapView = ({ state, expandedNodes, toggleNodeExpanded }: Props) => {
       isActive: currentProcName === mainProcName,
     },
     nexts: [[{ procName: mainProcName }, usedExecMap]],
-    width: NODE_WIDTH,
-    height: NODE_HEIGHT,
+    ...DEFAULT_NODE_SIZE,
   };
 
   const cleanNexts = (

--- a/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyData.tsx
+++ b/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyData.tsx
@@ -29,7 +29,7 @@ const extractTargets = (seg: UnifySeg): { [key: number]: UnifyStep } => {
 };
 
 const UnifyData = ({ selectStep }: Props) => {
-  const mainProcName = useStore(store => store.debugState?.mainProc || '');
+  const mainProcName = useStore(store => store.debuggerState?.mainProc || '');
   const [{ path, unifications }, baseUnifyKind] = useStore(store => [
     store.unifyState,
     showBaseUnifyKind(store),

--- a/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyData.tsx
+++ b/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyData.tsx
@@ -10,7 +10,7 @@ import React, { useEffect, useMemo } from 'react';
 import { UnifyMap, UnifySeg, UnifyStep } from '../../../types';
 import useStore, { mutateStore } from '../store';
 import { Code, showBaseUnifyKind } from '../util';
-import VSCodeAPI from '../VSCodeAPI';
+import { requestUnification } from '../VSCodeAPI';
 
 import './UnifyData.css';
 
@@ -127,10 +127,7 @@ const UnifyData = ({ selectStep }: Props) => {
       const stepInFold = () => {
         const isInStore = pushUnification(foldId);
         if (!isInStore) {
-          VSCodeAPI.postMessage({
-            type: 'request_unification',
-            id: foldId,
-          });
+          requestUnification(foldId);
         }
       };
       stepInFoldButton = (

--- a/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyMapNode.tsx
+++ b/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyMapNode.tsx
@@ -15,6 +15,7 @@ export type UnifyMapNodeData =
       setSelected: () => void;
       expanded: boolean;
       toggleExpanded?: () => void;
+      result?: boolean;
     }
   | {
       type: 'Result';
@@ -65,8 +66,14 @@ const UnifyMapNode = ({ data }: NodeProps<UnifyMapNodeData & Dims>) => {
     );
   }
 
-  const { isSelected, setSelected, assertionData, toggleExpanded, expanded } =
-    data;
+  const {
+    isSelected,
+    setSelected,
+    assertionData,
+    toggleExpanded,
+    expanded,
+    result,
+  } = data;
 
   const { fold } = assertionData;
   const foldBadge = (() => {
@@ -108,7 +115,13 @@ const UnifyMapNode = ({ data }: NodeProps<UnifyMapNodeData & Dims>) => {
   })();
 
   return (
-    <NodeWrap selected={isSelected} width={width} height={height}>
+    <NodeWrap
+      selected={isSelected}
+      noSourceHandle={result !== undefined}
+      error={result === false}
+      width={width}
+      height={height}
+    >
       <pre>{assertionData.assertion}</pre>
       <div className="node-button-row">
         {foldBadge}

--- a/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyMapView.tsx
+++ b/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyMapView.tsx
@@ -19,13 +19,14 @@ import useStore from '../store';
 type Props = {
   unification: UnificationState;
   selectStep: (step: UnifyStep) => void;
+  expandedNodes: Set<string>;
 };
 
 type M = UnifySeg;
 type D = UnifyMapNodeData;
 type A = null;
 
-const UnifyMapView = ({ unification, selectStep }: Props) => {
+const UnifyMapView = ({ unification, selectStep, expandedNodes }: Props) => {
   const unifyMap = (unification.map as UnifyMap)[1];
   const selectedId = (() => {
     if (!unification.selected) {
@@ -92,7 +93,9 @@ const UnifyMapView = ({ unification, selectStep }: Props) => {
   };
 
   return (
-    <TreeMapView {...{ initElem, transform, nodeComponent: UnifyMapNode }} />
+    <TreeMapView
+      {...{ initElem, transform, nodeComponent: UnifyMapNode, expandedNodes }}
+    />
   );
 };
 

--- a/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyMapView.tsx
+++ b/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyMapView.tsx
@@ -127,6 +127,11 @@ const UnifyMapView = ({
         }
       : undefined;
 
+    const [nexts, result]: [[null, UnifySeg][], boolean | undefined] = (() => {
+      if (next[0] !== 'UnifyResult') return [[[null, next]], undefined];
+      if (next[2][0] === 'Success') return [[], true];
+      return [[], false];
+    })();
     return {
       id: `${id}`,
       data: {
@@ -138,8 +143,9 @@ const UnifyMapView = ({
         },
         expanded,
         toggleExpanded,
+        result,
       },
-      nexts: [[null, next]],
+      nexts,
       submap,
       ...DEFAULT_NODE_SIZE,
     };

--- a/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyMapView.tsx
+++ b/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyMapView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   UnificationState,
   UnifyMap,
+  UnifyMapInner,
   UnifySeg,
   UnifyStep,
 } from '../../../types';
@@ -19,14 +20,24 @@ import useStore from '../store';
 type Props = {
   unification: UnificationState;
   selectStep: (step: UnifyStep) => void;
-  expandedNodes: Set<string>;
+  unifications: Record<number, UnificationState | undefined>;
+  expandedNodes: Set<number>;
+  requestUnification: (id: number) => void;
+  toggleNodeExpanded: (id: number) => void;
 };
 
 type M = UnifySeg;
 type D = UnifyMapNodeData;
 type A = null;
 
-const UnifyMapView = ({ unification, selectStep, expandedNodes }: Props) => {
+const UnifyMapView = ({
+  unification,
+  selectStep,
+  expandedNodes,
+  unifications,
+  requestUnification,
+  toggleNodeExpanded,
+}: Props) => {
   const unifyMap = (unification.map as UnifyMap)[1];
   const selectedId = (() => {
     if (!unification.selected) {
@@ -41,22 +52,29 @@ const UnifyMapView = ({ unification, selectStep, expandedNodes }: Props) => {
   })();
 
   const [title, subtitle] = useStore(state => getUnifyName(state));
-  const initElem: TransformResult<M, D, A> = {
-    id: 'root',
+  const buildInitElem = (
+    id: number,
+    title: React.ReactNode,
+    subtitle: React.ReactNode = <></>,
+    map: UnifyMapInner
+  ): TransformResult<M, D, A> => ({
+    id: `root-${id}`,
     data: {
       type: 'Root',
       title,
       subtitle,
     },
     nexts: (() => {
-      if (unifyMap[0] === 'Direct') {
-        return [[null, unifyMap[1]]];
+      if (map[0] === 'Direct') {
+        return [[null, map[1]]];
       } else {
-        return unifyMap[1].map(seg => [null, seg]);
+        return map[1].map(seg => [null, seg]);
       }
     })(),
     ...DEFAULT_NODE_SIZE,
-  };
+  });
+
+  const initElem = buildInitElem(unification.id, title, subtitle, unifyMap);
 
   const transform: TransformFunc<M, D, A> = map => {
     if (map[0] === 'UnifyResult') {
@@ -76,18 +94,53 @@ const UnifyMapView = ({ unification, selectStep, expandedNodes }: Props) => {
     }
 
     const [, assertionData, next] = map;
-    const { id } = assertionData;
+    const isSelected = assertionData.id === selectedId;
+    const { id, fold } = assertionData;
+
+    const expanded = expandedNodes.has(id);
+    const [submap, hasSubmap] = (() => {
+      // No fold
+      if (fold === null) return [undefined, false];
+
+      const foldId = fold[0];
+
+      // Fold unification hasn't been requested yet
+      if (!(foldId in unifications)) {
+        requestUnification(foldId);
+        return [undefined, true];
+      }
+
+      const unification = unifications[foldId];
+
+      // Fold unification is loading or hidden
+      if (unification === undefined || !expanded) return [undefined, true];
+
+      const map = unification.map as UnifyMap;
+
+      const initElem = buildInitElem(foldId, <i>Fold</i>, undefined, map[1]);
+      return [initElem, true];
+    })();
+
+    const toggleExpanded = hasSubmap
+      ? () => {
+          toggleNodeExpanded(id);
+        }
+      : undefined;
+
     return {
       id: `${id}`,
       data: {
         type: 'Assertion',
         assertionData,
-        isSelected: id === selectedId,
+        isSelected,
         setSelected: () => {
           selectStep(['Assertion', assertionData]);
         },
+        expanded,
+        toggleExpanded,
       },
       nexts: [[null, next]],
+      submap,
       ...DEFAULT_NODE_SIZE,
     };
   };

--- a/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyView.tsx
+++ b/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyView.tsx
@@ -8,7 +8,9 @@ import UnifyData from './UnifyData';
 import UnifyMapView from './UnifyMapView';
 
 const UnifyView = () => {
-  const { path, unifications } = useStore(({ unifyState }) => unifyState);
+  const { path, unifications, expandedNodes } = useStore(
+    ({ unifyState }) => unifyState
+  );
   const selectStep = useStore(({ selectUnifyStep }) => selectUnifyStep);
 
   const hasUnify = path && path.length > 0;
@@ -35,7 +37,7 @@ const UnifyView = () => {
 
       return <Loading refresh={load} />;
     }
-    return <UnifyMapView {...{ unification, selectStep }} />;
+    return <UnifyMapView {...{ unification, selectStep, expandedNodes }} />;
   })();
 
   return (

--- a/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyView.tsx
+++ b/debugger-vscode-extension/src/webviews/src/UnifyView/UnifyView.tsx
@@ -1,9 +1,9 @@
 import { Allotment } from 'allotment';
 import React from 'react';
-import useStore from '../store';
+import useStore, { mutateStore } from '../store';
 import Hero from '../util/Hero';
 import Loading from '../util/Loading';
-import VSCodeAPI from '../VSCodeAPI';
+import { requestUnification } from '../VSCodeAPI';
 import UnifyData from './UnifyData';
 import UnifyMapView from './UnifyMapView';
 
@@ -11,7 +11,11 @@ const UnifyView = () => {
   const { path, unifications, expandedNodes } = useStore(
     ({ unifyState }) => unifyState
   );
-  const selectStep = useStore(({ selectUnifyStep }) => selectUnifyStep);
+  const {
+    selectUnifyStep: selectStep,
+    requestUnification,
+    toggleUnifyNodeExpanded: toggleNodeExpanded,
+  } = mutateStore();
 
   const hasUnify = path && path.length > 0;
 
@@ -29,15 +33,23 @@ const UnifyView = () => {
     const unification = unifications[unifyId];
     if (unification === undefined) {
       const load = () => {
-        VSCodeAPI.postMessage({
-          type: 'request_unification',
-          id: unifyId,
-        });
+        requestUnification(unifyId);
       };
 
       return <Loading refresh={load} />;
     }
-    return <UnifyMapView {...{ unification, selectStep, expandedNodes }} />;
+    return (
+      <UnifyMapView
+        {...{
+          unification,
+          selectStep,
+          expandedNodes,
+          unifications,
+          requestUnification,
+          toggleNodeExpanded,
+        }}
+      />
+    );
   })();
 
   return (

--- a/debugger-vscode-extension/src/webviews/src/VSCodeAPI.ts
+++ b/debugger-vscode-extension/src/webviews/src/VSCodeAPI.ts
@@ -54,6 +54,10 @@ export const startProc = (procName: string) => {
   VSCodeAPI.postMessage({ type: 'request_start_proc', procName });
 };
 
+export const requestUnification = (id: number) => {
+  VSCodeAPI.postMessage({ type: 'request_unification', id });
+};
+
 // Singleton to prevent multiple fetches of VsCodeAPI.
 const VSCodeAPI: VSCodeWrapper = new VSCodeWrapper();
 export default VSCodeAPI;

--- a/debugger-vscode-extension/src/webviews/src/index.tsx
+++ b/debugger-vscode-extension/src/webviews/src/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import App from './App';
 import useDebugStore from './store';
 import './vscode.css';
-import VSCodeAPI from './VSCodeAPI';
+import VSCodeAPI, { requestUnification } from './VSCodeAPI';
 import * as events from './events';
 
 VSCodeAPI.onMessage(e => {
@@ -19,10 +19,7 @@ VSCodeAPI.onMessage(e => {
       const unifyId = unifys[0].id;
       const isInStore = store.selectBaseUnification(unifyId);
       if (!isInStore) {
-        VSCodeAPI.postMessage({
-          type: 'request_unification',
-          id: unifyId,
-        });
+        requestUnification(unifyId);
       }
     } else {
       store.clearUnification();

--- a/debugger-vscode-extension/src/webviews/src/index.tsx
+++ b/debugger-vscode-extension/src/webviews/src/index.tsx
@@ -12,7 +12,7 @@ VSCodeAPI.onMessage(e => {
 
   if (message.type === 'state_update') {
     const { state } = message;
-    store.updateDebugState(state);
+    store.updateDebuggerState(state);
     const currentProcState = state.procs[state.currentProc];
     const { unifys } = currentProcState;
     if (unifys.length > 0) {

--- a/debugger-vscode-extension/src/webviews/src/util.tsx
+++ b/debugger-vscode-extension/src/webviews/src/util.tsx
@@ -39,7 +39,7 @@ export const getUnifyName = (store: Store): [ReactNode, ReactNode] => {
   const { path, unifications } = store.unifyState;
   if (path.length < 2) {
     const kind = showBaseUnifyKind(store);
-    const procName = store.debugState?.mainProc || 'unknown proc';
+    const procName = store.debuggerState?.mainProc || 'unknown proc';
     return [
       <>
         Unify <Code>{procName}</Code>


### PR DESCRIPTION
Resolves #176 
Resolves #170 

- Allow nested exec/unify maps to be collapsed
- Render unification folds as nested maps
- Absorb Success/Failure unify nodes into the previous assertion