### PR TITLE
Remove `proc_name` argument from `jump` and `step_specific` DAP commands

### DIFF
--- a/GillianCore/debugging/adapter/debug_protocol_ext.ml
+++ b/GillianCore/debugging/adapter/debug_protocol_ext.ml
@@ -99,8 +99,7 @@ module Custom_commands (Debugger : Debugger.S) = struct
     let type_ = "jump"
 
     module Arguments = struct
-      type t = { proc_name : string; [@key "procName"] id : L.Report_id.t }
-      [@@deriving yojson]
+      type t = { id : L.Report_id.t } [@@deriving yojson]
     end
 
     module Result = struct
@@ -114,7 +113,6 @@ module Custom_commands (Debugger : Debugger.S) = struct
 
     module Arguments = struct
       type t = {
-        proc_name : string; [@key "procName"]
         prev_id : L.Report_id.t; [@key "prevId"]
         branch_case : Exec_map.Packaged.branch_case option; [@key "branchCase"]
       }

--- a/GillianCore/debugging/adapter/time_travel.ml
+++ b/GillianCore/debugging/adapter/time_travel.ml
@@ -47,8 +47,8 @@ module Make (Debugger : Debugger.S) = struct
         send_stopped_events stop_reason);
     DL.set_rpc_command_handler rpc ~name:"Jump"
       (module Jump_command)
-      (fun { proc_name; id } ->
-        match dbg |> Debugger.jump_to_id proc_name id with
+      (fun { id } ->
+        match dbg |> Debugger.jump_to_id id with
         | Error e ->
             Lwt.return
               (Jump_command.Result.make ~success:false ~err:(Some e) ())
@@ -57,8 +57,8 @@ module Make (Debugger : Debugger.S) = struct
             Lwt.return (Jump_command.Result.make ~success:true ()));
     DL.set_rpc_command_handler rpc ~name:"Step specific"
       (module Step_specific_command)
-      (fun { proc_name; prev_id; branch_case } ->
-        match dbg |> Debugger.step_specific proc_name branch_case prev_id with
+      (fun { prev_id; branch_case } ->
+        match dbg |> Debugger.step_specific branch_case prev_id with
         | Error e ->
             Lwt.return
               (Step_specific_command.Result.make ~success:false ~err:(Some e) ())

--- a/GillianCore/debugging/debugger/debugger_intf.ml
+++ b/GillianCore/debugging/debugger/debugger_intf.ml
@@ -12,16 +12,12 @@ module type S = sig
   end
 
   val launch : string -> string option -> (debug_state, string) result
-
-  val jump_to_id :
-    string -> Logging.Report_id.t -> debug_state -> (unit, string) result
-
+  val jump_to_id : Logging.Report_id.t -> debug_state -> (unit, string) result
   val jump_to_start : debug_state -> unit
   val step_in : ?reverse:bool -> debug_state -> stop_reason
   val step : ?reverse:bool -> debug_state -> stop_reason
 
   val step_specific :
-    string ->
     Exec_map.Packaged.branch_case option ->
     Logging.Report_id.t ->
     debug_state ->

--- a/GillianCore/engine/general_semantics/general/g_interpreter.ml
+++ b/GillianCore/engine/general_semantics/general/g_interpreter.ml
@@ -172,6 +172,7 @@ struct
         branching : int;
         state : state_t;
         branch_case : branch_case option;
+        proc_name : string;
       }
       [@@deriving yojson, make]
 
@@ -266,7 +267,8 @@ struct
         (cs : Call_stack.t)
         (i : int)
         (b_counter : int)
-        (branch_case : branch_case option) : L.Report_id.t option =
+        (branch_case : branch_case option)
+        (proc_name : string) : L.Report_id.t option =
       let annot, cmd = cmd in
       let state_printer =
         match !Config.pbn with
@@ -278,8 +280,8 @@ struct
             State.pp_by_need pvars lvars locs
       in
       ConfigReport.log state_printer
-        (ConfigReport.make ~proc_line:i ~time:(Sys.time ()) ~cmd ~callstack:cs
-           ~annot ~branching:b_counter ~state ?branch_case ())
+        (ConfigReport.make ~proc_name ~proc_line:i ~time:(Sys.time ()) ~cmd
+           ~callstack:cs ~annot ~branching:b_counter ~state ?branch_case ())
 
     let print_lconfiguration
         (lcmd : LCmd.t)
@@ -1615,7 +1617,7 @@ struct
       (* if !Config.stats then Statistics.exec_cmds := !Statistics.exec_cmds + 1; *)
       UP.update_coverage prog proc_name i;
 
-      log_configuration annot_cmd state cs i b_counter branch_case
+      log_configuration annot_cmd state cs i b_counter branch_case proc_name
       |> Option.iter (fun report_id ->
              report_id_ref := Some report_id;
              L.Parent.set report_id);
@@ -1960,7 +1962,7 @@ struct
         } =
           cconf
         in
-        let _, annot_cmd = get_cmd prog cs i in
+        let proc_name, annot_cmd = get_cmd prog cs i in
         Printf.printf "WARNING: MAX BRANCHING STOP: %d.\n" b_counter;
         L.set_previous prev_cmd_report_id;
         L.(
@@ -1969,7 +1971,7 @@ struct
                 "Stopping Symbolic Execution due to MAX BRANCHING with %d. \
                  STOPPING CONF:\n"
                 b_counter));
-        log_configuration annot_cmd state cs i b_counter branch_case
+        log_configuration annot_cmd state cs i b_counter branch_case proc_name
         |> Option.iter (fun report_id ->
                parent_id_ref := Some report_id;
                L.Parent.set report_id);

--- a/GillianCore/engine/general_semantics/general/g_interpreter_intf.ml
+++ b/GillianCore/engine/general_semantics/general/g_interpreter_intf.ml
@@ -109,6 +109,7 @@ module type S = sig
         branching : int;
         state : state_t;
         branch_case : BranchCase.t option;
+        proc_name : string;
       }
       [@@deriving yojson]
     end

--- a/debugger-vscode-extension/src/WebviewPanel.ts
+++ b/debugger-vscode-extension/src/WebviewPanel.ts
@@ -63,9 +63,9 @@ export class WebviewPanel {
         this.updateState(state);
       }
     } else if (e.type === 'request_jump') {
-      await debug.jumpToCmd(e.procName, e.cmdId);
+      await debug.jumpToCmd(e.cmdId);
     } else if (e.type === 'request_exec_specific') {
-      await debug.execSpecificCmd(e.procName, e.prevId, e.branchCase);
+      await debug.execSpecificCmd(e.prevId, e.branchCase);
     } else if (e.type === 'request_unification') {
       const unifyData = await debug.getUnification(e.id);
       if (unifyData !== undefined) {

--- a/debugger-vscode-extension/src/debug.ts
+++ b/debugger-vscode-extension/src/debug.ts
@@ -168,15 +168,13 @@ export async function getUnification(
   }
 }
 
-export async function jumpToCmd(procName: string, id: number) {
+export async function jumpToCmd(id: number) {
   const session = vscode.debug.activeDebugSession;
   if (session !== undefined) {
     console.log('Requesting jump', {
-      procName,
       id,
     });
     const result = await session.customRequest('jump', {
-      procName,
       id,
     });
     if (!result.success) {
@@ -186,19 +184,16 @@ export async function jumpToCmd(procName: string, id: number) {
 }
 
 export async function execSpecificCmd(
-  procName: string,
   prevId: number,
   branchCase: BranchCase | null
 ) {
   const session = vscode.debug.activeDebugSession;
   if (session !== undefined) {
     console.log('Requesting step specific', {
-      procName,
       prevId,
       branchCase,
     });
     const result = await session.customRequest('stepSpecific', {
-      procName,
       prevId,
       branchCase,
     });

--- a/debugger-vscode-extension/src/types.d.ts
+++ b/debugger-vscode-extension/src/types.d.ts
@@ -133,13 +133,11 @@ type RequestStateUpdateMsg = {
 
 type RequestJump = {
   readonly type: 'request_jump';
-  readonly procName: string;
   readonly cmdId: number;
 };
 
 type RequestExecSpecific = {
   readonly type: 'request_exec_specific';
-  readonly procName: string;
   readonly prevId: number;
   readonly branchCase: BranchCase | null;
 };

--- a/debugger-vscode-extension/src/webviews/src/ExecMap/ExecMapView.tsx
+++ b/debugger-vscode-extension/src/webviews/src/ExecMap/ExecMapView.tsx
@@ -66,7 +66,7 @@ const ExecMapView = ({ state, expandedNodes, toggleNodeExpanded }: Props) => {
           hasParent: true,
           isActive,
           exec: () => {
-            execSpecific(procName, +parent, branchCase as BranchCase);
+            execSpecific(+parent, branchCase as BranchCase);
           },
         },
         nexts: [],
@@ -152,7 +152,7 @@ const ExecMapView = ({ state, expandedNodes, toggleNodeExpanded }: Props) => {
         hasParent,
         isActive,
         jump: () => {
-          jumpToId(procName, cmdData.ids[0]);
+          jumpToId(cmdData.ids[0]);
         },
         expanded,
         toggleExpanded,

--- a/debugger-vscode-extension/src/webviews/src/VSCodeAPI.ts
+++ b/debugger-vscode-extension/src/webviews/src/VSCodeAPI.ts
@@ -33,19 +33,17 @@ class VSCodeWrapper {
   }
 }
 
-export const execSpecific = (procName: string, prevId: number, branchCase: BranchCase) => {
+export const execSpecific = (prevId: number, branchCase: BranchCase) => {
   VSCodeAPI.postMessage({
     type: 'request_exec_specific',
-    procName,
     prevId,
     branchCase,
   });
 };
 
-export const jumpToId = (procName: string, id: number) => {
+export const jumpToId = (id: number) => {
   VSCodeAPI.postMessage({
     type: 'request_jump',
-    procName,
     cmdId: id
   });
 };


### PR DESCRIPTION
I realised as I'm writing up the SDAP spec that we can just get the proc name from the report ID in the database, no real need to depend on this argument.