### PR TITLE
Ensure fixes are not lost when they lead to errors

### DIFF
--- a/Gillian-C/lib/CMemory.ml
+++ b/Gillian-C/lib/CMemory.ml
@@ -6,7 +6,7 @@ module Expr = Gillian.Gil_syntax.Expr
 type init_data = Global_env.t
 type vt = Values.t
 type st = Subst.t
-type err_t = unit [@@deriving show]
+type err_t = unit [@@deriving yojson, show]
 
 let pp_err _ () = ()
 

--- a/Gillian-JS/lib/Semantics/JSILCMemory.ml
+++ b/Gillian-JS/lib/Semantics/JSILCMemory.ml
@@ -13,7 +13,7 @@ module M : Memory_S with type init_data = unit = struct
   type st = Subst.t
 
   (** Errors *)
-  type err_t = unit [@@deriving show]
+  type err_t = unit [@@deriving yojson, show]
 
   type action_ret = (t * vt list, err_t) result
 

--- a/GillianCore/engine/Abstraction/PState.ml
+++ b/GillianCore/engine/Abstraction/PState.ml
@@ -67,7 +67,7 @@ module Make (State : SState.S) :
   type state_t = State.t
   type err_t = State.err_t [@@deriving yojson, show]
   type fix_t = State.fix_t
-  type m_err_t = State.m_err_t
+  type m_err_t = State.m_err_t [@@deriving yojson]
 
   exception Internal_State_Error of err_t list * t
   exception Preprocessing_Error of MP.err list

--- a/GillianCore/engine/BiAbduction/BiState.ml
+++ b/GillianCore/engine/BiAbduction/BiState.ml
@@ -2,16 +2,18 @@ open Containers
 open Literal
 module L = Logging
 
+type 'a _t = { procs : SS.t; state : 'a; af_state : 'a } [@@deriving yojson]
+
 module Make (State : SState.S) = struct
   type heap_t = State.heap_t
-  type state_t = State.t
+  type state_t = State.t [@@deriving yojson]
   type st = SVal.SESubst.t
   type vt = Expr.t [@@deriving show, yojson]
-  type t = { procs : SS.t; state : state_t; af_state : state_t }
+  type t = state_t _t [@@deriving yojson]
   type store_t = SStore.t
-  type err_t = State.err_t [@@deriving yojson, show]
+  type m_err_t = t * State.m_err_t
+  type err_t = (m_err_t, vt) StateErr.t
   type fix_t = State.fix_t
-  type m_err_t = State.m_err_t
   type variants_t = (string, Expr.t option) Hashtbl.t [@@deriving yojson]
   type init_data = State.init_data
 
@@ -23,11 +25,29 @@ module Make (State : SState.S) = struct
       =
     { procs; state; af_state = State.init init_data }
 
+  let lift_error st : State.err_t -> err_t = function
+    | StateErr.EMem e -> StateErr.EMem (st, e)
+    | StateErr.EType (v, t, t') -> StateErr.EType (v, t, t')
+    | StateErr.EPure f -> StateErr.EPure f
+    | StateErr.EVar v -> StateErr.EVar v
+    | StateErr.EAsrt (v, f, a) -> StateErr.EAsrt (v, f, a)
+    | StateErr.EOther s -> StateErr.EOther s
+
+  let unlift_error : err_t -> State.err_t = function
+    | StateErr.EMem (_, e) -> StateErr.EMem e
+    | StateErr.EType (v, t, t') -> StateErr.EType (v, t, t')
+    | StateErr.EPure f -> StateErr.EPure f
+    | StateErr.EVar v -> StateErr.EVar v
+    | StateErr.EAsrt (v, f, a) -> StateErr.EAsrt (v, f, a)
+    | StateErr.EOther s -> StateErr.EOther s
+
+  let lift_errors st = List.map (lift_error st)
+
   let eval_expr (bi_state : t) (e : Expr.t) =
     let { state; _ } = bi_state in
     try State.eval_expr state e
     with State.Internal_State_Error (errs, _) ->
-      raise (Internal_State_Error (errs, bi_state))
+      raise (Internal_State_Error (lift_errors bi_state errs, bi_state))
 
   let get_store (bi_state : t) : SStore.t =
     let { state; _ } = bi_state in
@@ -137,10 +157,12 @@ module Make (State : SState.S) = struct
 
   let evaluate_slcmd (prog : 'a MP.prog) (lcmd : SLCmd.t) (bi_state : t) :
       (t, err_t) Res_list.t =
-    let open Res_list.Syntax in
+    let open Syntaxes.List in
     let { state; _ } = bi_state in
-    let++ state' = State.evaluate_slcmd prog lcmd state in
-    { bi_state with state = state' }
+    let+ res = State.evaluate_slcmd prog lcmd state in
+    match res with
+    | Ok state' -> Ok { bi_state with state = state' }
+    | Error err -> Error (lift_error bi_state err)
 
   let match_invariant _ _ _ _ _ =
     raise (Failure "ERROR: match_invariant called for bi-abductive execution")
@@ -422,10 +444,10 @@ module Make (State : SState.S) = struct
     State.mem_constraints state
 
   let is_overlapping_asrt (a : string) : bool = State.is_overlapping_asrt a
-  let pp_err = State.pp_err
+  let pp_err f e = State.pp_err f (unlift_error e)
   let pp_fix = State.pp_fix
-  let get_failing_constraint = State.get_failing_constraint
-  let can_fix = State.can_fix
+  let get_failing_constraint e = State.get_failing_constraint (unlift_error e)
+  let can_fix e = State.can_fix (unlift_error e)
 
   let rec execute_action
       (action : string)
@@ -435,7 +457,8 @@ module Make (State : SState.S) = struct
     let* ret = State.execute_action action state args in
     match ret with
     | Ok (state', outs) -> [ Ok ({ procs; state = state'; af_state }, outs) ]
-    | Error err when not (State.can_fix err) -> [ Error err ]
+    | Error err when not (State.can_fix err) ->
+        [ Error (lift_error { procs; state; af_state } err) ]
     | Error err -> (
         match State.get_fixes state err with
         | [] -> [] (* No fix, we stop *)
@@ -452,11 +475,32 @@ module Make (State : SState.S) = struct
   let get_equal_values { state; _ } = State.get_equal_values state
   let get_heap { state; _ } = State.get_heap state
 
-  let of_yojson _ =
-    failwith
-      "Please implement of_yojson to enable logging this type to a database"
+  (* Sadly need to hand-implement this, because m_err_t doesn't expose a yojson interface *)
+  let err_t_to_yojson : err_t -> Yojson.Safe.t = function
+    | StateErr.EMem (s, _) as e ->
+        let s' = to_yojson s in
+        let e' = State.err_t_to_yojson (unlift_error e) in
+        `List [ `String "BSEMem"; s'; e' ]
+    | e -> State.err_t_to_yojson (unlift_error e)
 
-  let to_yojson _ =
-    failwith
-      "Please implement to_yojson to enable logging this type to a database"
+  let err_t_of_yojson :
+      Yojson.Safe.t -> err_t Ppx_deriving_yojson_runtime.error_or =
+    let open Syntaxes.Result in
+    function
+    | `List [ `String "BSEMem"; s; e ] ->
+        let* s = of_yojson s in
+        let+ e = State.err_t_of_yojson e in
+        lift_error s e
+    | e -> (
+        let* err = State.err_t_of_yojson e in
+        match err with
+        | StateErr.EMem _ -> Error "Expected a list with two elements"
+        | StateErr.EType (v, t, t') -> Ok (StateErr.EType (v, t, t'))
+        | StateErr.EPure f -> Ok (StateErr.EPure f)
+        | StateErr.EVar v -> Ok (StateErr.EVar v)
+        | StateErr.EAsrt (v, f, a) -> Ok (StateErr.EAsrt (v, f, a))
+        | StateErr.EOther s -> Ok (StateErr.EOther s))
+
+  let pp_err_t f err = State.pp_err_t f (unlift_error err)
+  let show_err_t err = State.show_err_t (unlift_error err)
 end

--- a/GillianCore/engine/BiAbduction/BiState.mli
+++ b/GillianCore/engine/BiAbduction/BiState.mli
@@ -1,10 +1,14 @@
+type 'a _t
+
 module Make (BaseState : PState.S) : sig
   include
     State.S
-      with type vt = Expr.t
+      with type t = BaseState.t _t
+       and type vt = Expr.t
        and type st = SVal.SESubst.t
        and type store_t = SStore.t
        and type init_data = BaseState.init_data
+       and type m_err_t = BaseState.t _t * BaseState.m_err_t
 
   val make : procs:SS.t -> state:BaseState.t -> init_data:init_data -> t
   val get_components : t -> BaseState.t * BaseState.t

--- a/GillianCore/engine/concrete_semantics/CMemory.ml
+++ b/GillianCore/engine/concrete_semantics/CMemory.ml
@@ -9,7 +9,7 @@ module type S = sig
   type st = CVal.CSubst.t
 
   (** Errors *)
-  type err_t [@@deriving show]
+  type err_t [@@deriving yojson, show]
 
   (** Type of GIL general states *)
   type t

--- a/GillianCore/engine/concrete_semantics/CState.ml
+++ b/GillianCore/engine/concrete_semantics/CState.ml
@@ -33,7 +33,7 @@ end = struct
   type heap_t = CMemory.t
   type t = CMemory.t * CStore.t * vt list
   type fix_t
-  type m_err_t = CMemory.err_t [@@deriving show]
+  type m_err_t = CMemory.err_t [@@deriving yojson, show]
   type err_t = (m_err_t, vt) StateErr.t [@@deriving show]
   type init_data = CMemory.init_data
   type variants_t = (string, Expr.t option) Hashtbl.t [@@deriving yojson]

--- a/GillianCore/engine/general_semantics/state.ml
+++ b/GillianCore/engine/general_semantics/state.ml
@@ -1,7 +1,7 @@
 (** @canonical Gillian.General.State
 
   Interface for GIL General States.
-  
+
   They are considered to be mutable. *)
 
 (** @canonical Gillian.General.State.S *)
@@ -21,7 +21,7 @@ module type S = sig
   type heap_t
 
   (** Errors *)
-  type m_err_t
+  type m_err_t [@@deriving yojson]
 
   type err_t = (m_err_t, vt) StateErr.t [@@deriving yojson, show]
   type fix_t

--- a/kanillian/lib/memory_model/CMemory.ml
+++ b/kanillian/lib/memory_model/CMemory.ml
@@ -3,7 +3,7 @@ open Gillian.Concrete
 type init_data = unit
 type vt = Values.t
 type st = Subst.t
-type err_t = unit [@@deriving show]
+type err_t = unit [@@deriving yojson, show]
 type t = unit
 type action_ret = (t * vt list, err_t) result
 

--- a/wisl/lib/semantics/wislCMemory.ml
+++ b/wisl/lib/semantics/wislCMemory.ml
@@ -4,7 +4,7 @@ module Literal = Gillian.Gil_syntax.Literal
 type init_data = unit
 type vt = Values.t
 type st = Subst.t
-type err_t = unit [@@deriving show]
+type err_t = unit [@@deriving yojson, show]
 type t = WislCHeap.t
 type action_ret = (t * vt list, err_t) result
 


### PR DESCRIPTION
If a bug is found in bi-abduction that happens during the same command a fix is generated, the state *before* the command was executed is used to generate the spec, which means the fix gets lost.
This PR modifies `BiState` to always include an up to date copy of the state along with every memory error. When encountering failures, `Abductor` then checks if any of the errors is a memory error, in which case it uses the attached state rather instead.

#### Example

For a state model stack `Freeable(Exclusive)`:
```
bispec test () : [[ emp  ]]
proc test() {
    gvar0 := [load]();
    ret := 0i;
    return
};
```

Generated specs diff (before/after):
```diff
BUG SPECS:
  spec test ()
    ;
-   [[ emp ]]
-   [[ emp ]]
+   [[ <freed>(; ) ]]
+   [[ <freed>(; ) ]]
    bug

ERROR SPECS:
  

SUCCESSFUL SPECS:
  spec test ()
    [[ <points_to>(; #gen__0) ]]
    [[ (ret == 0i) * <points_to>(; 6i) ]]
    normal;
```

#### Notes

A couple hacky things I did, that I don't like but don't know how to avoid (I'm happy to edit the PR with suggestions):
- Needed to extended the signature of `BiState.mli` to include information on `m_err_t`. 
  - To do that I needed to refer to `S.t`, which at that point isn't defined yet, so I need to define it explicitly, which requires me to define a `BiState._t` type (which leaks no information but must exist). 
  - I also couldn't call it simply `t`, because otherwise I need to define the `type t` in the `Make` functor as `nonrec`, and `nonrec` types don't support PPX 🫠 
  - If there is a way to refer to a type in `include State.S with type ...` without defining it, let me know as it would avoid this mess (ie. if there's a way of having `m_err_t = t * BaseState.m_err_t`)
- `SState` doesn't enforce `m_err_t` to derrive yojson/show, so I can't automatically derive yojson/show on `err_t` either. 
  - For `show` it's ok because I can unlift the error and use `SState.show`
  - For `yojson` however, I need to hand parse it which isn't super pretty -- I can't unlift it because then I lost the information on the state, which means I can't recreate the error in `err_t_of_yojson`. I would have otherwise just put an empty state, but that requires `init_data` which I have no way of extracting+parsing.