### PR TITLE
Fix some counterexaple production

### DIFF
--- a/GillianCore/command_line/s_interpreter_console.ml
+++ b/GillianCore/command_line/s_interpreter_console.ml
@@ -76,11 +76,13 @@ struct
       let total_time = Sys.time () -. !start_time in
       Printf.printf "Total time (Compilation + Symbolic testing): %fs\n"
         total_time;
-      if success then (
-        Fmt.pr "%a@\n@?" (Fmt.styled `Green Fmt.string) "Success!";
-        exit 0)
-      else (
-        Fmt.pr "%a@\n@?" (Fmt.styled `Red Fmt.string) "Errors occured!";
+      if success then
+        let () = Fmt.pr "%a@\n@?" (Fmt.styled `Green Fmt.string) "Success!" in
+        exit 0
+      else
+        let () =
+          Fmt.pr "%a@\n@?" (Fmt.styled `Red Fmt.string) "Errors occured!"
+        in
         let first_error =
           List.find
             (function
@@ -94,11 +96,13 @@ struct
              ~none:(Fmt.any "Couldn't produce counter-example")
              SVal.SESubst.pp)
           counter_example;
-        Fmt.pr "Here's an example of final error state: %a@\n@?"
-          (Exec_res.pp SState.pp S_interpreter.pp_state_vt
-             S_interpreter.pp_err_t)
-          first_error;
-        exit 1)
+        let () =
+          Fmt.pr "Here's an example of final error state: %a@\n@?"
+            (Exec_res.pp SState.pp S_interpreter.pp_state_vt
+               S_interpreter.pp_err_t)
+            first_error
+        in
+        exit 1
 
     let run_incr source_files prog init_data =
       (* Only re-run program if transitive callees of main proc have changed *)

--- a/GillianCore/engine/general_semantics/general/g_interpreter.ml
+++ b/GillianCore/engine/general_semantics/general/g_interpreter.ml
@@ -533,8 +533,6 @@ struct
               Fmt.(option ~none:(any "CANNOT CREATE MODEL") ESubst.pp)
               failing_model
           in
-          if not (Exec_mode.is_biabduction_exec !Config.current_exec_mode) then
-            Printf.printf "%s" msg;
           L.normal (fun m -> m "%s" msg);
           Res_list.error_with err
 

--- a/GillianCore/smt/smt.ml
+++ b/GillianCore/smt/smt.ml
@@ -988,6 +988,7 @@ let exec_sat' (fs : Formula.Set.t) (gamma : typenv) : sexp option =
           (Fmt.iter ~sep:(Fmt.any "@\n") Formula.Set.iter Formula.pp)
           fs pp_typenv gamma)
   in
+  let () = reset_solver () in
   let encoded_assertions = encode_assertions fs gamma in
   let () = if !Config.dump_smt then Dump.dump fs gamma encoded_assertions in
   let () = List.iter cmd !builtin_funcs in
@@ -1026,7 +1027,6 @@ let exec_sat' (fs : Formula.Set.t) (gamma : typenv) : sexp option =
     | Sat -> Some (get_model solver)
     | Unsat -> None
   in
-  let () = reset_solver () in
   ret
 
 let exec_sat (fs : Formula.Set.t) (gamma : typenv) : sexp option =


### PR DESCRIPTION
- `smt.ml` was inconsistent with whether it reset the solver before or after an action; fixed this
- Removed the failing model print in `G_interpreter`, enhanced the failing model print when encountering failure in `S_interpreter` to properly produce counterexamples for assertion failure.