### PR TITLE
Fix branch max on calls during ACT

### DIFF
--- a/GillianCore/engine/general_semantics/general/g_interpreter.ml
+++ b/GillianCore/engine/general_semantics/general/g_interpreter.ml
@@ -857,11 +857,11 @@ struct
                       | Error x -> Right (Exec_err.EState x))
                     ret
                 in
-                let b_counter, has_branched =
-                  match successes with
-                  | [] -> (b_counter, false)
-                  | _ -> (b_counter + 1, true)
+
+                let b_counter =
+                  Int.max 0 (List.length successes - 1) + b_counter
                 in
+                let has_branched = List.length successes > 1 in
                 let spec_name = spec.data.spec_name in
                 let success_confs =
                   successes


### PR DESCRIPTION
Fixes from in progress [LLVM support](https://github.com/trail-of-forks/Gillian/pull/1)

When executing with a spec, regardless of how many specs are matched successfully etc, the call is considered branching which causes unexpected requirements on call factors. This causes unexpected unrolling requirements on examples like: https://github.com/trail-of-forks/Gillian/blob/9db721dc9cb70c3914dd28d1ef383f6b99c98a63/Gillian-LLVM/examples/wpst/mem_test.gil#L15 where 3 is required to handle all of the calls.

The intended fix here is to just add the number of matched specs exceeding 1 call