### PR TITLE
CI: Add Docker auto-push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [master]
   merge_group:
   workflow_dispatch:
+    inputs:
+      docker-tag:
+        type: string
+        description: "Docker tag; leave blank to use the branch name."
 
 env:
   NODE_VERSION: 18
@@ -335,6 +339,8 @@ jobs:
   push-docker:
     runs-on: ubuntu-latest
     if: ${{ contains(fromJSON('["push", "workflow_dispatch", "release"]'), github.event_name) }}
+    env:
+      DOCKER_TAG_PRE: ${{ github.event.inputs.docker-tag || (github.ref_name == 'master' && 'nightly' || github.ref_name) }}
     needs: build-docker
     steps:
       - name: Set up docker buildx
@@ -358,7 +364,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set docker tag
-        run: echo "DOCKER_TAG=${{ github.ref_name == 'master' && 'nightly' || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+        run: echo "DOCKER_TAG=$DOCKER_TAG_PRE" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Build and export docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   NODE_VERSION: 18
-  DOCKER_TEST_TAG: gillian:test
+  DOCKER_IMG_NAME: ghcr.io/gillianplatform/gillian
 
 jobs:
   build:
@@ -36,7 +36,7 @@ jobs:
         run: sudo pip install sphinx furo
       - name: Restore Cache
         id: restore-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
             cache-name: cache-ocaml
         with:
@@ -307,7 +307,7 @@ jobs:
           driver: docker
       - name: Restore Cache
         id: restore-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
             cache-name: cache-ocaml
         with:
@@ -320,17 +320,51 @@ jobs:
         with:
           context: .
           load: true
-          tags: ${{ env.DOCKER_TEST_TAG }}
+          tags: ${{ env.DOCKER_IMG_NAME }}:test
           target: test
       - name: Dune test
-        run: docker run --rm ${{ env.DOCKER_TEST_TAG }} opam exec -- dune test
+        run: docker run --rm ${{ env.DOCKER_IMG_NAME }}:test opam exec -- dune test
       - name: Extract cache
         if: steps.restore-cache.outputs.cache-hit != 'true'
         run: |
           rm -rf .docker_opam_cache
-          docker run --name deps ${{ env.DOCKER_TEST_TAG }} bash -c "opam clean"
+          docker run --name deps ${{ env.DOCKER_IMG_NAME }}:test bash -c "opam clean"
           docker cp deps:/home/opam/.opam/5.2 ./.docker_opam_cache
           docker rm deps
+
+  push-docker:
+    runs-on: ubuntu-latest
+    if: ${{ contains(fromJSON('["push", "workflow_dispatch", "release"]'), github.event_name) }}'
+    needs: build-docker
+    steps:
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
+      - name: Restore Cache
+        id: restore-cache
+        uses: actions/cache/restore@v4
+        env:
+            cache-name: cache-ocaml
+        with:
+          path: .docker_opam_cache
+          key: docker-${{ env.cache-name }}-ocaml-5.2.0-${{ hashFiles('**/*.opam') }}
+          restore-keys: |
+            docker-${{ env.cache-name }}-ocaml-5.2.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set docker tag
+        run: echo "DOCKER_TAG=${{ github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+      - name: Build and export docker image
+        uses: docker/build-push-action@v6
+        with:
+          tags: ${{ env.DOCKER_IMG_NAME }}:${{ env.DOCKER_TAG }}
+          push: true
+          target: run
 
   deploy-docs:
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,7 +334,7 @@ jobs:
 
   push-docker:
     runs-on: ubuntu-latest
-    if: ${{ contains(fromJSON('["push", "workflow_dispatch", "release"]'), github.event_name) }}'
+    if: ${{ contains(fromJSON('["push", "workflow_dispatch", "release"]'), github.event_name) }}
     needs: build-docker
     steps:
       - name: Set up docker buildx
@@ -358,7 +358,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set docker tag
-        run: echo "DOCKER_TAG=${{ github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
+        run: echo "DOCKER_TAG=${{ github.ref_name == 'master' && 'nightly' || github.ref_name }}" | tr "/" "-" >> "$GITHUB_ENV"
       - name: Build and export docker image
         uses: docker/build-push-action@v6
         with:
@@ -386,7 +386,7 @@ jobs:
           git config --global user.name "GitHub Actions"
           git clone https://${{ secrets.DOCS_USER }}:${{ secrets.DOCS_TOKEN }}@github.com/GillianPlatform/GillianPlatform.github.io.git docs-repo --branch master
           cd docs-repo
-          rm * -rf
+          rm ./* -rf
           cp -r ../docs/* .
           git add -A
           git commit --allow-empty -m "Deployment from $GITHUB_REPOSITORY@$GITHUB_SHA"


### PR DESCRIPTION
Adds a job to the CI to push a Gillian Docker image to the GitHub Container Registry.

An image will be pushed on:
- Pushes to `master`; images will be tagged `nightly`
- New releases; images will be tagged with the release tag name
- Manually, on [the CI Actions page](https://github.com/GillianPlatform/Gillian/actions/workflows/ci.yml); the image tag can be specified, otherwise the branch name is used

The docker image can then be used by pulling e.g. `ghcr.io/gillianplatform/gillian:nightly`