### PR TITLE
Some LSP tweaks for lab testing

### DIFF
--- a/GillianCore/engine/general_semantics/general/g_interpreter_intf.ml
+++ b/GillianCore/engine/general_semantics/general/g_interpreter_intf.ml
@@ -49,6 +49,7 @@ module type S = sig
       prev_cmd_report_id : Logging.Report_id.t option;
       branch_case : Branch_case.t option;
       branch_path : Branch_case.path;
+      loc : Location.t option;
     }
 
     (** Equal to conf_cont + the id of the required spec *)
@@ -72,6 +73,7 @@ module type S = sig
       branch_count : int;
       branch_path : Branch_case.path;
       prev_cmd_report_id : Logging.Report_id.t option;
+      loc : Location.t option;
     }
 
     type t =

--- a/GillianCore/utils/config.ml
+++ b/GillianCore/utils/config.ml
@@ -92,19 +92,21 @@ let set_runtime_paths, get_runtime_paths =
 
 (** @canonical Gillian.Utils.Config.Verification *)
 module Verification = struct
+  type things_to_verify = Specific | All | ProcsOnly | LemmasOnly
+
   let procs_to_verify = ref ([] : string list)
   let lemmas_to_verify = ref ([] : string list)
-  let verify_only_some_of_the_things = ref false
+  let things_to_verify = ref All
 
   let set_procs_to_verify = function
     | [] -> ()
     | a ->
         procs_to_verify := a;
-        verify_only_some_of_the_things := true
+        things_to_verify := Specific
 
   let set_lemmas_to_verify = function
     | [] -> ()
     | a ->
         lemmas_to_verify := a;
-        verify_only_some_of_the_things := true
+        things_to_verify := Specific
 end


### PR DESCRIPTION
- Change `Config.verify_only_some_of_the_things` to `Config.things_to_verify`, which can be one of
  - `All` - everything; equivalent to `false` before
  - `Specific` - specific procs and lemmas; equivalent to `true` before
  - `ProcsOnly` - verify all procs, but no lemmas
  - `LemmasOnly` - verify all lemmas, but no procs
- Add a `--procs-only` switch to verification debgger & verification language server to make use of this
- Track the "last known location" in `g_interpreter`; errors will now be attributed to the most recent location *that isn't in an internal proc*