### PR TITLE
A few tweaks for OPLSS '26

### DIFF
--- a/Gillian-C2/examples/verification/dll.c
+++ b/Gillian-C2/examples/verification/dll.c
@@ -6,28 +6,26 @@ typedef struct dln {
     struct dln *next;
 } DLL;
 
-/*@ pred DLL(+x, alpha) {
+/*@
+pred DLL(+x, alpha) {
   (x == NULL) * (alpha == nil);
 
   (x -m> struct dln {#val; #prev; #next}) *
-  DLL(#next, #beta) * (alpha == #val :: #beta) *
-  (not (#prev == NULL)) * (not (#next == NULL));
+  DLL(#next, #beta) *
+  (alpha == #val :: #beta) *
+  (not (#next == NULL)) *
+  i__is_size_t(len alpha);
 
-  (x -m> struct dln {#val; NULL; #next}) *
-  DLL(#next, #beta) * (alpha == #val :: #beta) *
-  (not (#next == NULL));
-
-  (x -m> struct dln {#val; NULL; NULL}) * (alpha == [ #val ]);
-
-  (x -m> struct dln {#val; #prev; NULL}) * (alpha == [ #val ]) *
-  (not (#prev == NULL))
-} */
+  (x -m> struct dln {#val; #prev; NULL}) *
+  (alpha == [ #val ])
+}
+*/
 
 /*@ spec makeNode(x) {
-  requires: (#x == int(#z)) * (#x == x)
+  requires: (#x == x)
   ensures:  DLL(ret, [#x])
 } */
-DLL *makeNode(int x) {
+DLL* makeNode(int x) {
     DLL *r = malloc(sizeof(DLL));
     r->data = x;
     r->next = NULL;
@@ -36,10 +34,11 @@ DLL *makeNode(int x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: (x == #x) * (y == #y) * DLL(#x, #alpha) * DLL(#y, #beta)
+  requires: (x == #x) * (y == #y) * DLL(#x, #alpha) * DLL(#y, #beta) *
+            i__is_size_t((len #alpha) + (len #beta))
   ensures:  DLL(ret, #alpha @ #beta)
 } */
-DLL *listConcat(DLL *x, DLL *y) {
+DLL* listConcat(DLL *x, DLL *y) {
     if (y == NULL) {
         return x;
     } else {
@@ -66,10 +65,10 @@ DLL *listConcat(DLL *x, DLL *y) {
 }
 
 /*@ spec listPrepend(x, v) {
-  requires: (x == #x) * (v == #v) * DLL(#x, #alpha) * (#v == int(#z))
+  requires: (x == #x) * (v == #v) * DLL(#x, #alpha) * i__is_size_t(1 + len #alpha)
   ensures:  DLL(ret, #v :: #alpha)
 } */
-DLL *listPrepend(DLL *x, int v) {
+DLL* listPrepend(DLL *x, int v) {
     DLL *node_v = makeNode(v);
     if (x == NULL) {
         return node_v;
@@ -82,16 +81,16 @@ DLL *listPrepend(DLL *x, int v) {
 }
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * (v == #v) * DLL(#x, #alpha) * (#v == int(#z))
+  requires: (x == #x) * (v == #v) * DLL(#x, #alpha) * i__is_size_t(1 + len #alpha)
   ensures:  DLL(ret, #alpha @ [ #v ])
 } */
-DLL *listAppend(DLL *x, int v) { return listConcat(x, makeNode(v)); }
+DLL* listAppend(DLL *x, int v) { return listConcat(x, makeNode(v)); }
 
 /*@ spec listCopy(x) {
   requires: (x == #x) * DLL(#x, #alpha)
   ensures:  DLL(#x, #alpha) * DLL(ret, #alpha)
 } */
-DLL *listCopy(DLL *x) {
+DLL* listCopy(DLL *x) {
     if (x == NULL) {
         return NULL;
     } else {

--- a/Gillian-C2/examples/verification/sll.c
+++ b/Gillian-C2/examples/verification/sll.c
@@ -5,18 +5,23 @@ typedef struct ln {
     struct ln *next;
 } SLL;
 
-/*@ pred sll(+p, alpha) {
-  (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
+/*@
+pred sll(+p, alpha) {
+  (p -m> struct ln { #head; #tail }) *
+  (alpha == #head::#beta) *
   sll(#tail, #beta) *
-  i__is_int(len alpha);
-  (p == NULL) * (alpha == nil)
+  i__is_size_t(len alpha);
+
+  (p == NULL) * (alpha == [])
 }
 
 pred lseg(+p, +q, alpha) {
-    ( p == q ) * (alpha == nil);
+    (p -m> struct ln { #head; #tail }) *
+    (alpha == #head::#beta) *
+    lseg(#tail, q, #beta) *
+    i__is_size_t(len alpha);
 
-    (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    lseg(#tail, q, #beta) * i__is_int(len alpha)
+    (p == q) * (alpha == [])
 }
 
 lemma lseg_to_list(p, alpha) {
@@ -33,12 +38,13 @@ lemma lseg_to_list(p, alpha) {
 }
 
 lemma lseg_append(p, q, alpha, a, end) {
-    hypothesis: lseg(#p, #q, #alpha) * (#q -m> struct ln { #a; #end }) * i__is_int(len (#alpha @ [#a]))
+    hypothesis: lseg(#p, #q, #alpha)
+                * (#q -m> struct ln { #a; #end }) * i__is_size_t(1 + len #alpha)
     conclusions: lseg(#p, #end, #alpha @ [#a])
     proof:
       unfold lseg(#p, #q, #alpha)[[bind #head: #head,
-                                           #tail: #tail,
-                                           #beta: #beta]];
+                                        #tail: #tail,
+                                        #beta: #beta]];
       if (!(#p = #q)) {
         apply lseg_append(#tail, #q, #beta, #a, #end);
         fold lseg(#p, #end, #alpha @ [#a])
@@ -47,10 +53,10 @@ lemma lseg_append(p, q, alpha, a, end) {
 */
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * sll(#x, #alpha) * (v == #v) * i__is_int(#v) * i__is_int((len #alpha) + 1)
+  requires: (x == #x) * sll(#x, #alpha) * (v == #v) * i__is_size_t(1 + len #alpha)
   ensures:  sll(ret, #alpha @ [ #v ])
 } */
-SLL *listAppend(SLL *x, int v) {
+SLL* listAppend(SLL *x, int v) {
     if (x == NULL) {
         SLL *el = malloc(sizeof(SLL));
         el->data = v;
@@ -58,9 +64,6 @@ SLL *listAppend(SLL *x, int v) {
         return el;
     } else {
         SLL *tailp = listAppend(x->next, v);
-        __GILLIAN("assert [[bind #t]] sll(tailp, #t)");
-        __GILLIAN("unfold sll(tailp, #t)");
-        __GILLIAN("fold sll(tailp, #t)");
         x->next = tailp;
         return x;
     };
@@ -71,33 +74,31 @@ SLL *listAppend(SLL *x, int v) {
             (x == #v) *
             (z == #z) *
             sll(#z, #alpha) *
-            i__is_int((len #alpha) + 1)
+            i__is_size_t(1 + len #alpha)
   ensures: sll(ret, #head::#alpha)
 } */
-SLL *listPrepend(SLL *x, SLL *z) {
-    __GILLIAN("unfold sll(#z, #alpha)");
+SLL* listPrepend(SLL *x, SLL *z) {
     x->next = z;
     return x;
 }
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * sll(#x, #alpha) * (v == #v) * i__is_int(#v) * i__is_int((len #alpha) + 1)
+  requires: (x == #x) * sll(#x, #alpha) * (v == #v) * i__is_size_t(1 + len #alpha)
   ensures: sll(ret, #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {
   SLL *el = malloc(sizeof(SLL));
   el->data = v;
-  __GILLIAN("unfold sll(#x, #alpha)");
   el->next = x;
   return el;
 }
 
 /*@ spec listLength(x) {
   requires: sll(#x, #alpha) * (x == #x)
-  ensures:  sll(#x, #alpha) * (ret == int(#r)) * (#r == len #alpha)
+  ensures:  sll(#x, #alpha) * (ret == len #alpha)
 } */
-int listLength(SLL *x) {
+size_t listLength(SLL *x) {
     if (x == NULL) {
         return 0;
     } else {
@@ -123,7 +124,7 @@ void listDispose(SLL *x) {
   requires: sll(#x, #alpha) * (x == #x)
   ensures:  sll(ret, #alpha) * sll(#x, #alpha)
 } */
-SLL *listCopy(SLL *x) {
+SLL* listCopy(SLL *x) {
     SLL *r;
     if (x == NULL) {
         r = NULL;
@@ -135,18 +136,15 @@ SLL *listCopy(SLL *x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: sll(#x, #alpha) * (x == #x) * sll(#y, #beta) * (y == #y) * i__is_int((len #alpha) + (len #beta))
+  requires: sll(#x, #alpha) * (x == #x) * sll(#y, #beta) * (y == #y) * i__is_size_t((len #alpha) + (len #beta))
   ensures:  sll(ret, #alpha @ #beta)
 } */
-SLL *listConcat(SLL *x, SLL *y) {
+SLL* listConcat(SLL *x, SLL *y) {
     SLL *r;
     if (x == NULL) {
         r = y;
     } else {
         SLL *c = listConcat(x->next, y);
-        __GILLIAN("assert [[bind #gamma]] sll(c, #gamma)");
-        __GILLIAN("unfold sll(c, #gamma)");
-        __GILLIAN("fold sll(c, #gamma)");
         x->next = c;
         r = x;
     };

--- a/Gillian-C2/lib/lifter/c2_lifter.ml
+++ b/Gillian-C2/lib/lifter/c2_lifter.ml
@@ -141,11 +141,10 @@ struct
       let open Annot in
       let open Branch_case in
       let- () =
-        match (nest_kind, ends) with
-        | Some (Fun_call _), [ (Unknown, bdata) ] ->
-            if is_unevaluated_funcall then None
-            else Some (Ok [ (Func_exit_placeholder, bdata) ])
-        | Some (Fun_call _), _ ->
+        match (is_unevaluated_funcall, nest_kind, ends) with
+        | false, Some (Fun_call _), [ (Unknown, bdata) ] ->
+            Some (Ok [ (Func_exit_placeholder, bdata) ])
+        | false, Some (Fun_call _), _ ->
             Some (Error "Unexpected branching in cmd with Fun_call nest")
         | _ -> None
       in
@@ -892,7 +891,12 @@ struct
     init_or_handle ~state ~prev_id ?gil_case exec_data
 
   let dump = to_yojson
-  let get_matches_at_id id { map; _ } = (get_exn map id).data.matches
+
+  let get_matches_at_id id { map; _ } =
+    match get map id with
+    | Some node -> node.data.matches
+    | None -> []
+
   let path_of_id id { gil_state; _ } = Gil_lifter.path_of_id id gil_state
 
   let previous_step id { map; _ } =

--- a/GillianCore/debugging/debugger/base_debugger.ml
+++ b/GillianCore/debugging/debugger/base_debugger.ml
@@ -209,9 +209,6 @@ struct
       let add_node state ?id (node : Map_node.t) =
         let id = Option.value id ~default:node.id in
         let { all_nodes; changed_nodes; _ } = state.debug_state in
-        DL.log (fun m ->
-            let s = if Hashtbl.mem all_nodes id then "updating" else "adding" in
-            m ~json:[ ("node", Map_node.to_yojson node) ] "%s node %s" s id);
         let () = Hashtbl.replace all_nodes id node in
         let () = Hashset.add changed_nodes id in
         ()

--- a/GillianCore/debugging/debugger/verification_debugger.ml
+++ b/GillianCore/debugging/debugger/verification_debugger.ml
@@ -40,10 +40,6 @@ struct
 
     let launch_proc ~proc_name (debug_state : debug_state_ext base_debug_state)
         =
-      Config.Verification.(
-        let procs_to_verify = !procs_to_verify in
-        if not (procs_to_verify |> List.mem proc_name) then
-          set_procs_to_verify (procs_to_verify @ [ proc_name ]));
       Verification.init_proc ~init_data:debug_state.init_data debug_state.prog
         proc_name
 

--- a/GillianCore/debugging/lifter/gil_lifter.ml
+++ b/GillianCore/debugging/lifter/gil_lifter.ml
@@ -195,7 +195,11 @@ functor
       let _ = consume_cmd prev_id branch_case exec_data state in
       ()
 
-    let get_matches_at_id id state = (get_exn state.map id).data.matches
+    let get_matches_at_id id state =
+      match get state.map id with
+      | Some node -> node.data.matches
+      | None -> []
+
     let path_of_id id state = (get_exn state.map id).data.branch_path
 
     let cases_at_id id state =

--- a/GillianCore/debugging/log/debugger_log.ml
+++ b/GillianCore/debugging/log/debugger_log.ml
@@ -104,7 +104,6 @@ let setup rpc =
 
 let dump_dbg : (unit -> Yojson.Safe.t) option ref = ref None
 let set_debug_state_dumper f = dump_dbg := Some f
-let reraise exc = Printexc.(raise_with_backtrace exc (get_raw_backtrace ()))
 
 let try' ~name f x =
   let err_json backtrace =
@@ -131,35 +130,30 @@ let try' ~name f x =
       let err_json = err_json backtrace in
       let json = err_json @ json in
       log_async (fun m -> m ~json "[Error] %s" e);%lwt
-      reraise (Failure e)
+      Lwt.reraise (Failure e)
   | (Failure e | Invalid_argument e) as err ->
       let backtrace = Printexc.get_backtrace () in
       let err_json = err_json backtrace in
       log_async (fun m -> m ~json:err_json "[Error] %s" e);%lwt
-      reraise err
-  | Not_found ->
+      Lwt.reraise err
+  | Effect.Unhandled _ as err ->
       let backtrace = Printexc.get_backtrace () in
       let err_json = err_json backtrace in
-      log_async (fun m -> m ~json:err_json "[Error] Not found");%lwt
-      reraise Not_found
-  | Effect.Unhandled _ as e ->
-      let backtrace = Printexc.get_backtrace () in
-      let err_json = err_json backtrace in
-      let s = Printexc.to_string e in
+      let s = Printexc.to_string err in
       log_async (fun m -> m ~json:err_json "[Error] Unhandled effect\n%s" s);%lwt
-      reraise e
-  | Gillian_result.Exc.Gillian_error g as e ->
+      Lwt.reraise err
+  | Gillian_result.Exc.Gillian_error e as err ->
       let backtrace = Printexc.get_backtrace () in
       let err_json = err_json backtrace in
       log_async (fun m ->
-          m ~json:err_json "[Error] %a" Gillian_result.Error.pp g);%lwt
-      reraise e
-  | e ->
+          m ~json:err_json "[Error] %a" Gillian_result.Error.pp e);%lwt
+      Lwt.reraise err
+  | err ->
       let backtrace = Printexc.get_backtrace () in
       let err_json = err_json backtrace in
-      let s = Printexc.to_string e in
+      let s = Printexc.to_string err in
       log_async (fun m -> m ~json:err_json "[Error] Unhandled exception\n%s" s);%lwt
-      reraise e
+      Lwt.reraise err
 
 let set_rpc_command_handler rpc ?name ?(catchall = true) module_ f =
   let f x = if catchall then try' ~name f x else f x in

--- a/docker/Dockerfile.dist
+++ b/docker/Dockerfile.dist
@@ -6,7 +6,7 @@ RUN opam exec -- dune install $packages --relocatable --prefix ./_dist
 RUN sudo mv _dist /
 
 FROM ubuntu:noble AS install
-ADD https://github.com/diffblue/cbmc/releases/download/cbmc-5.14.3/cbmc-5.14.3-Linux.deb cbmc.deb
+ADD https://github.com/diffblue/cbmc/releases/download/cbmc-6.9.0/ubuntu-24.04-cbmc-6.9.0-Linux.deb cbmc.deb
 ARG no_cbmc=
 RUN apt update \
     && apt install -y rsync z3 libsqlite3-0 $([ $no_cbmc ] || echo './cbmc.deb') \

--- a/wisl/lib/ParserAndCompiler/wisl2Gil.ml
+++ b/wisl/lib/ParserAndCompiler/wisl2Gil.ml
@@ -5,6 +5,7 @@ open WislConstants.Prefix
 open WislConstants.InternalProcs
 open WislConstants.InternalPreds
 open Gillian.Gil_syntax
+open Gillian.Utils.Generators
 module SS = Gillian.Utils.Containers.SS
 
 (* Some utility functions *)
@@ -84,7 +85,6 @@ let rec compile_val v =
 
 let rec compile_expr ?(fname = "main") ?(is_loop_prefix = false) expr :
     (WAnnot.t * string option * string Cmd.t) list * Expr.t =
-  let gen_str = Generators.gen_str fname in
   let compile_expr = compile_expr ~fname ~is_loop_prefix in
   let expr_of_string s = Expr.Lit (Literal.String s) in
   let expr_fname_of_binop b =
@@ -133,7 +133,7 @@ let rec compile_expr ?(fname = "main") ?(is_loop_prefix = false) expr :
       (cmdl1 @ cmdl2, expr)
   | BinOp (e1, b, e2) when is_internal_func b ->
       (* Operator corresponds to pointer arithmetics *)
-      let call_var = gen_str gvar in
+      let call_var = fresh_pvar () in
       let internal_func = expr_fname_of_binop b in
       let cmdl1, comp_expr1 = compile_expr e1 in
       let cmdl2, comp_expr2 = compile_expr e2 in
@@ -170,7 +170,6 @@ let rec compile_expr ?(fname = "main") ?(is_loop_prefix = false) expr :
     the string list contains the name of the variables that are generated. They are existentials. *)
 let rec compile_lexpr ?(fname = "main") (lexpr : WLExpr.t) :
     string list * Asrt.t * Expr.t =
-  let gen_str = Generators.gen_str fname in
   let compile_lexpr = compile_lexpr ~fname in
   let expr_pname_of_binop b =
     WBinOp.(
@@ -200,7 +199,7 @@ let rec compile_lexpr ?(fname = "main") (lexpr : WLExpr.t) :
     | LVar x -> ([], [], Expr.LVar x)
     | LBinOp (e1, b, e2) when is_internal_pred b ->
         (* Operator corresponds to pointer arithmetics *)
-        let lout = gen_str sgvar in
+        let lout = Utils.Generators.fresh_lvar () in
         let internal_pred = expr_pname_of_binop b in
         let gvars1, asrtl1, comp_expr1 = compile_lexpr e1 in
         let gvars2, asrtl2, comp_expr2 = compile_lexpr e2 in
@@ -257,7 +256,6 @@ let compile_lexpr_perm ?fname lexpr =
 (* compile_lassert returns the compiled assertion + the list of generated existentials *)
 let rec compile_lassert ?(fname = "main") asser : string list * Asrt.t =
   let compile_lassert = compile_lassert ~fname in
-  let gen_str = Generators.gen_str fname in
   let compile_lexpr = compile_lexpr ~fname in
   let gil_add e k =
     (* builds GIL expression that is e + k *)
@@ -289,10 +287,10 @@ let rec compile_lassert ?(fname = "main") asser : string list * Asrt.t =
           ([], [], (l, bo), expr_offset)
       | None ->
           let exs1, la1, e1 = compile_lexpr le1 in
-          let loc = gen_str sgvar in
+          let loc = fresh_lvar () in
           let offset, expr_offset =
             if not block then
-              let offset = gen_str sgvar in
+              let offset = fresh_lvar () in
               (Some offset, Expr.LVar offset)
             else (None, Expr.zero_i)
           in
@@ -570,7 +568,7 @@ let compile_inv_and_while ~fname ~while_stmt ~invariant ~loop_body_of =
         loop_body_of;
       }
   in
-  let retv = gen_str gvar in
+  let retv = fresh_pvar () in
   let call_cmd =
     Cmd.call retv (Lit (String loop_fname))
       (List.map (fun x -> Expr.PVar x) vars)
@@ -738,7 +736,7 @@ let rec compile_stmt_list
             ctnlab,
             faillab )
       in
-      let g_var = gen_str gvar in
+      let g_var = fresh_pvar () in
       let failcmd = Cmd.Fail ("InvalidBlockPointer", [ comp_e ]) in
       let cmd = Cmd.LAction (g_var, dispose, [ nth comp_e 0 ]) in
       let comp_rest, new_functions = compile_list rest in
@@ -762,7 +760,7 @@ let rec compile_stmt_list
         WAnnot.make_multi ~origin_id:sid ~origin_loc:(CodeLoc.to_location sloc)
           ()
       in
-      let v_get = gen_str gvar in
+      let v_get = fresh_pvar () in
       let faillab, ctnlab = (gen_str fail_lab, gen_str ctn_lab) in
       let checkptrcmd =
         Cmd.GuardedGoto
@@ -795,13 +793,13 @@ let rec compile_stmt_list
           x := v_get[2];
       *)
   (* Property Update *)
-  | { snode = Update (e1, e2); sloc; _ } :: rest ->
+  | { snode = Update (e1, e2); sid; sloc } :: rest ->
       let set_annot =
-        WAnnot.make_basic ~origin_loc:(CodeLoc.to_location sloc) ()
+        WAnnot.make ~origin_id:sid ~origin_loc:(CodeLoc.to_location sloc) ()
       in
       let cmdle1, comp_e1 = compile_expr e1 in
       let cmdle2, comp_e2 = compile_expr e2 in
-      let v_set = gen_str gvar in
+      let v_set = fresh_pvar () in
       let setcmd =
         Cmd.LAction (v_set, store, [ nth comp_e1 0; nth comp_e1 1; comp_e2 ])
       in

--- a/wisl/lib/ParserAndCompiler/wislConstants.ml
+++ b/wisl/lib/ParserAndCompiler/wislConstants.ml
@@ -2,8 +2,6 @@ let internal_imports = [ "wisl_pointer_arith.gil"; "wisl_core.gil" ]
 let internal_prefix = "i__"
 
 module Prefix = struct
-  let gvar = "gvar"
-  let sgvar = "#wisl__"
   let loopinv_lab = "loopinv"
   let loop_lab = "loop"
   let ctn_lab = "continue"

--- a/wisl/lib/ParserAndCompiler/wislConstants.mli
+++ b/wisl/lib/ParserAndCompiler/wislConstants.mli
@@ -4,12 +4,6 @@ module Prefix : sig
   (** This module contains the prefix for different kind of strings that are
       generated during compilation *)
 
-  (** Prefix for generated variables *)
-  val gvar : string
-
-  (** Prefix for generated symbolic variables *)
-  val sgvar : string
-
   (** Prefix for loop invariant labels *)
   val loopinv_lab : string
 

--- a/wisl/lib/state_ex/wislLifter.ml
+++ b/wisl/lib/state_ex/wislLifter.ml
@@ -88,7 +88,7 @@ struct
     matches : Match_map.matching list;
     errors : string list;
     submap : id submap;
-    loc : string * int;
+    loc : (string * int) option;
     prev : (id * Branch_case.t option) option;
     callers : id list;
     func_return_label : (string * int) option;
@@ -112,7 +112,7 @@ struct
       display : string;
       stack_info : id list * stack_direction option;
       is_loop_end : bool;
-      loc : string * int;
+      loc : (string * int) option;
     }
     [@@deriving to_yojson]
 
@@ -157,7 +157,7 @@ struct
       submap : id submap;
       callers : id list;
       stack_direction : stack_direction option;
-      loc : string * int;
+      loc : (string * int) option;
       has_return : bool;
     }
     [@@deriving yojson]
@@ -209,25 +209,62 @@ struct
     let is_loop_end ~is_loop_func ~proc_name exec_data =
       is_loop_func && get_fun_call_name exec_data = Some proc_name
 
+    let make_canonical_data_if_error
+        ~(canonical_data : canonical_cmd_data option)
+        ~ends
+        ~errors
+        ~all_ids
+        ~prev : (canonical_cmd_data * (case * branch_data) list) option =
+      let/ () = canonical_data |> Option.map (fun c -> (c, ends)) in
+      match errors with
+      | [] -> None
+      | _ ->
+          let _, _, callers = Option.get prev in
+          let stack_info = (callers, None) in
+          let c : canonical_cmd_data =
+            {
+              id = all_ids |> List.rev |> List.hd;
+              display = "<error>";
+              stack_info;
+              is_loop_end = false;
+              loc = None;
+            }
+          in
+          Some (c, [])
+
     let finish ~exec_data partial =
-      let ({ prev; all_ids; ends; nest_kind; matches; errors; has_return; _ }
+      let ({
+             prev;
+             all_ids;
+             ends;
+             nest_kind;
+             matches;
+             errors;
+             has_return;
+             canonical_data;
+             _;
+           }
             : partial_data) =
         partial
+      in
+      let errors = errors |> Ext_list.to_list in
+      let all_ids = all_ids |> Ext_list.to_list |> List.map fst in
+      let ends = Ext_list.to_list ends in
+      let canonical_data =
+        make_canonical_data_if_error ~canonical_data ~ends ~errors ~all_ids
+          ~prev
       in
       let prev =
         let+ id, branch, _ = prev in
         (id, branch)
       in
-      let** { id; display; stack_info; loc; is_loop_end } =
-        partial.canonical_data
-        |> Option.to_result
-             ~none:"Trying to finish partial with no canonical data!"
+      let** { id; display; stack_info; loc; is_loop_end }, ends =
+        Option.to_result
+          ~none:"Trying to finish partial with no canonical data!"
+          canonical_data
       in
       let callers, stack_direction = stack_info in
-      let all_ids = all_ids |> Ext_list.to_list |> List.map fst in
       let matches = matches |> Ext_list.to_list in
-      let errors = errors |> Ext_list.to_list in
-      let ends = Ext_list.to_list ends in
       let submap =
         match nest_kind with
         | Some (LoopBody p) -> Proc p
@@ -354,10 +391,12 @@ struct
             in
             let** stack_info = get_stack_info ~partial exec_data in
             let loc =
-              annot.origin_loc |> Option.get
-              |> Debugger_utils.location_to_display_location
+              Option.map
+                (fun loc ->
+                  let loc = Debugger_utils.location_to_display_location loc in
+                  (loc.loc_source, loc.loc_start.pos_line))
+                annot.origin_loc
             in
-            let loc = (loc.loc_source, loc.loc_start.pos_line) in
             partial.canonical_data <-
               Some { id; display; stack_info; is_loop_end; loc };
             Ok ()
@@ -1058,12 +1097,14 @@ struct
     | Either.Right (id, case) -> request_next state id case
 
   let is_breakpoint ~start ~current =
-    let file, line = current.data.loc in
-    let- () =
-      let file', line' = start.data.loc in
-      if file = file' && line = line' then Some false else None
-    in
-    Effect.perform (IsBreakpoint (file, [ line ]))
+    match current.data.loc with
+    | None -> false
+    | Some (file, line) ->
+        let- () =
+          let* file', line' = start.data.loc in
+          if file = file' && line = line' then Some false else None
+        in
+        Effect.perform (IsBreakpoint (file, [ line ]))
 
   let step_all ~start state id case =
     let cmd = get_exn state.map id in

--- a/wisl/lib/state_ex/wislLifter.ml
+++ b/wisl/lib/state_ex/wislLifter.ml
@@ -844,7 +844,12 @@ struct
   end
 
   let init_or_handle = Init_or_handle.f
-  let get_matches_at_id id { map; _ } = (get_exn map id).data.matches
+
+  let get_matches_at_id id { map; _ } =
+    match get map id with
+    | Some node -> node.data.matches
+    | None -> []
+
   let path_of_id id { gil_state; _ } = Gil_lifter.path_of_id id gil_state
 
   let previous_step id { map; _ } =


### PR DESCRIPTION
- Some cleanup on C2 examples
- Make WISL use Gillian's provided PVar/LVar generation; I think WISL was generating some colliding variable names
- Improve Debugger error handling
- Update the Docker image's CBMC to match current