### PR TITLE
More OPLSS tweaks

### DIFF
--- a/Gillian-C2/lib/lifter/c2_lifter.ml
+++ b/Gillian-C2/lib/lifter/c2_lifter.ml
@@ -135,16 +135,16 @@ struct
     [@@deriving yojson]
 
     let ends_to_cases
-        ~is_unevaluated_funcall
+        ~is_evaluated_funcall
         ~nest_kind
         (ends : (Branch_case.case * branch_data) list) =
       let open Annot in
       let open Branch_case in
       let- () =
-        match (is_unevaluated_funcall, nest_kind, ends) with
-        | false, Some (Fun_call _), [ (Unknown, bdata) ] ->
+        match (is_evaluated_funcall, nest_kind, ends) with
+        | true, Some (Fun_call _), [ (Unknown, bdata) ] ->
             Some (Ok [ (Func_exit_placeholder, bdata) ])
-        | false, Some (Fun_call _), _ ->
+        | true, Some (Fun_call _), _ ->
             Some (Error "Unexpected branching in cmd with Fun_call nest")
         | _ -> None
       in
@@ -226,12 +226,12 @@ struct
       in
       let matches = Ext_list.to_list matches in
       let++ next_kind =
-        let is_unevaluated_funcall =
+        let is_evaluated_funcall =
           match funcall_kind with
-          | Some Unevaluated_funcall -> true
+          | Some Evaluated_funcall -> true
           | _ -> false
         in
-        let++ cases = ends_to_cases ~is_unevaluated_funcall ~nest_kind ends in
+        let++ cases = ends_to_cases ~is_evaluated_funcall ~nest_kind ends in
         match cases with
         | [] -> Zero
         | [ (Case (Unknown, _), _) ] ->

--- a/Gillian-JS/lib/Debugging/JSLifter.ml
+++ b/Gillian-JS/lib/Debugging/JSLifter.ml
@@ -319,7 +319,7 @@ struct
       { id = 3; name = "Predicates" };
     ]
 
-  let get_variables _ { store; memory; pfs; types; preds } _ =
+  let get_variables _ { store; memory; pfs; types; preds; _ } _ =
     let open Gil_lifter in
     let open Variable in
     let variables = Hashtbl.create 0 in

--- a/GillianCore/debugging/debugger/base_debugger.ml
+++ b/GillianCore/debugging/debugger/base_debugger.ml
@@ -583,35 +583,6 @@ struct
         Map_update_event_body.Current_steps.make ~primary:(Some p)
           ~secondary:(Some s) ()
 
-      let get_substs _ = []
-      (* let get_substs state = *)
-      (*   state.procs |> Hashtbl.to_seq *)
-      (*   |> Seq.map (fun (proc_name, proc) -> *)
-      (*          let+ substs = *)
-      (*            let* assertion_id, match_id = *)
-      (*              List_utils.hd_opt proc.selected_match_steps *)
-      (*            in *)
-      (*            let* match_ = *)
-      (*              Hashtbl.find_opt state.debug_state.matches match_id *)
-      (*            in *)
-      (*            let* node = Hashtbl.find_opt match_.nodes assertion_id in *)
-      (*            let* substs = *)
-      (*              match node with *)
-      (*              | Match_map.Assertion data, _, _ -> Some data.substitutions *)
-      (*              | _ -> None *)
-      (*            in *)
-      (*            let substs' = *)
-      (*              substs *)
-      (*              |> List.map @@ fun Match_map.{ assert_id; subst = a, b } -> *)
-      (*                 `List *)
-      (*                   [ `String (show_id assert_id); `String a; `String b ] *)
-      (*            in *)
-      (*            Some substs' *)
-      (*          in *)
-      (*          (show_proc_id proc_name, `List substs)) *)
-      (*   |> Seq.filter_map (fun x -> x) *)
-      (*   |> List.of_seq *)
-
       let get_status state =
         let rec aux acc proc_name =
           let acc = SS.add proc_name acc in
@@ -643,13 +614,12 @@ struct
         (finished, has_errors)
 
       let get_map_ext state : Yojson.Safe.t =
-        let substs = [ ("substs", `Assoc (get_substs state)) ] in
         let status =
           let finished, has_errors = get_status state in
           let status = `List [ `Bool finished; `Bool has_errors ] in
           [ ("status", status) ]
         in
-        `Assoc (substs @ status)
+        `Assoc status
 
       let get_map_update state =
         let nodes = get_changed_nodes ~clear:true state in

--- a/GillianCore/debugging/debugger/verification_debugger.ml
+++ b/GillianCore/debugging/debugger/verification_debugger.ml
@@ -137,17 +137,17 @@ struct
             let open L.Logging_constants.Content_type in
             let open Verification.SMatcher.Logging in
             let open Verification.SState in
-            let astate =
+            let astate, subst =
               if type_ = assertion then
                 let report =
                   of_yojson_string AssertionReport.of_yojson content
                 in
-                report.astate
+                (report.astate, Some report.subst)
               else if type_ = match_recovery then
                 let report =
                   of_yojson_string MatchRecoveryReport.of_yojson content
                 in
-                report.astate
+                (report.astate, None)
               else
                 Fmt.failwith "get_astate: report %a has unexpected type %s"
                   L.Report_id.pp id type_
@@ -157,7 +157,9 @@ struct
             let pfs = get_pfs astate.state in
             let types = get_typ_env astate.state in
             let preds = astate.preds in
-            let astate = make_astate ~store ~memory ~pfs ~types ~preds () in
+            let astate =
+              make_astate ~store ~memory ~pfs ~types ~preds ?subst ()
+            in
             Some (id, astate)
         | [] -> None
       in

--- a/GillianCore/debugging/lifter/gil_lifter.ml
+++ b/GillianCore/debugging/lifter/gil_lifter.ml
@@ -221,46 +221,56 @@ functor
 
       module Scopes = struct
         let pvars = { id = 1; name = "Store" }
-        let heap = { id = 2; name = "Memory" }
-        let preds = { id = 3; name = "Predicates" }
-        let pfs = { id = 4; name = "Pure formulae" }
-        let types = { id = 5; name = "Types" }
-        let all = [ pvars; heap; preds; pfs; types ]
+        let subst = { id = 2; name = "Substitutions" }
+        let heap = { id = 3; name = "Memory" }
+        let preds = { id = 4; name = "Predicates" }
+        let pfs = { id = 5; name = "Pure formulae" }
+        let types = { id = 6; name = "Types" }
+        let all = [ pvars; subst; heap; preds; pfs; types ]
       end
+
+      let expr_to_string = Fmt.to_to_string (Fmt.hbox Expr.pp)
 
       let get_store_vars store =
         store
-        |> List.map (fun (var, value) : Variable.t ->
-               let value = Fmt.to_to_string (Fmt.hbox Expr.pp) value in
-               { name = var; value; type_ = None; var_ref = 0 })
-        |> List.sort (fun v w -> Stdlib.compare v.name w.name)
+        |> List.map (fun (name, value) : Variable.t ->
+               let value = expr_to_string value in
+               make ~name ~value ())
+        |> List.sort compare_name
 
       let get_type_env_vars (types : Type_env.t) : Variable.t list =
         Type_env.to_list types
-        |> List.sort (fun (v, _) (w, _) -> Stdlib.compare v w)
         |> List.map (fun (name, value) ->
                let value = Type.str value in
-               { name; value; type_ = None; var_ref = 0 })
-        |> List.sort (fun v w -> Stdlib.compare v.name w.name)
+               make ~name ~value ())
+        |> List.sort compare_name
 
       let get_pred_vars (preds : Preds.t) : Variable.t list =
         preds |> Preds.to_list
         |> List.map (fun pred ->
                let value = Fmt.to_to_string (Fmt.hbox Preds.pp_pabs) pred in
-               { name = ""; value; type_ = None; var_ref = 0 })
-        |> List.sort (fun v w -> Stdlib.compare v.value w.value)
+               make ~value ())
+        |> List.sort (fun v w -> String.compare v.value w.value)
 
       let get_pure_formulae_vars (pfs : PFS.t) : Variable.t list =
         pfs |> PFS.to_list
         |> List.map (fun formula ->
-               let value = Fmt.to_to_string (Fmt.hbox Expr.pp) formula in
-               { name = ""; value; type_ = None; var_ref = 0 })
-        |> List.sort (fun v w -> Stdlib.compare v.value w.value)
+               let value = expr_to_string formula in
+               make ~value ())
+        |> List.sort compare_value
+
+      let get_subst_vars (subst : SVal.SESubst.t) : Variable.t list =
+        subst |> SVal.SESubst.to_list
+        |> List.map (fun (a, b) ->
+               let name = expr_to_string a in
+               let value = expr_to_string b in
+               make ~name ~value ())
+        |> List.sort compare_name
 
       let get_variables'
           ?add_heap_variables
           _
-          { store; memory; pfs; types; preds }
+          { store; memory; pfs; types; preds; subst }
           _ =
         let variables = Hashtbl.create 0 in
         (* Scopes and var refs share IDs; they can't clash *)
@@ -276,6 +286,15 @@ functor
         let var_groups =
           let pvars = get_store_vars store in
           (Scopes.pvars, Some pvars) :: var_groups
+        in
+
+        (* Subst *)
+        let var_groups =
+          match subst with
+          | Some subst ->
+              let subst_vars = get_subst_vars subst in
+              (Scopes.subst, Some subst_vars) :: var_groups
+          | None -> var_groups
         in
 
         (* Heap *)

--- a/GillianCore/debugging/utils/debugger_utils.ml
+++ b/GillianCore/debugging/utils/debugger_utils.ml
@@ -40,6 +40,7 @@ type 'memory astate = {
   pfs : PFS.t option;
   types : Type_env.t option;
   preds : Preds.t option;
+  subst : SVal.SESubst.t option;
 }
 [@@deriving make]
 

--- a/GillianCore/debugging/utils/variable.ml
+++ b/GillianCore/debugging/utils/variable.ml
@@ -7,7 +7,7 @@ type scope = { name : string; id : int } [@@deriving yojson]
 
 (** A variable *)
 type t = {
-  name : string;
+  name : string; [@default ""]
   value : string;
   type_ : string option;
   var_ref : int; [@default 0]
@@ -22,3 +22,6 @@ let create_leaf (name : string) (value : string) ?(type_ = None) () : t =
 
 let create_node (name : string) (var_ref : int) ?(value = "") () : t =
   { name; value; type_ = Some "object"; var_ref }
+
+let compare_name v w = String.compare v.name w.name
+let compare_value v w = String.compare v.value w.value

--- a/wisl/lib/state_ex/wislLifter.ml
+++ b/wisl/lib/state_ex/wislLifter.ml
@@ -1372,33 +1372,32 @@ struct
       open Variable
 
       let pvars = { id = 1; name = "Program store" }
-      let heap = { id = 2; name = "Heap" }
-      let preds = { id = 3; name = "Predicates" }
-      let pfs = { id = 4; name = "Pure formulae" }
-      let types = { id = 5; name = "Types" }
-      let axioms = { id = 6; name = "Axioms" }
-      let all = [ pvars; heap; pfs; types; preds; axioms ]
+      let subst = { id = 2; name = "Substitutions" }
+      let heap = { id = 3; name = "Heap" }
+      let preds = { id = 4; name = "Predicates" }
+      let pfs = { id = 5; name = "Pure formulae" }
+      let types = { id = 6; name = "Types" }
+      let axioms = { id = 7; name = "Axioms" }
+      let all = [ pvars; subst; heap; pfs; types; preds; axioms ]
     end
 
     let get_store_vars store =
       List.filter_map
         (fun (var, (value : Gil_syntax.Expr.t)) ->
-          if Str.string_match (Str.regexp "gvar") var 0 then None
-          else
-            let match_offset lst loc =
-              match lst with
-              | [ Expr.Lit (Int offset) ] ->
-                  Fmt.str "-> (%s, %d)" loc (Z.to_int offset)
-              | [ offset ] -> Fmt.str "-> (%s, %a)" loc pp_expr offset
-              | _ -> Fmt.to_to_string pp_expr value
-            in
-            let value =
-              match value with
-              | Expr.EList (Lit (Loc loc) :: rest)
-              | Expr.EList (LVar loc :: rest) -> match_offset rest loc
-              | _ -> Fmt.to_to_string pp_expr value
-            in
-            Some ({ name = var; value; type_ = None; var_ref = 0 } : Variable.t))
+          let match_offset lst loc =
+            match lst with
+            | [ Expr.Lit (Int offset) ] ->
+                Fmt.str "> (%s, %d)" loc (Z.to_int offset)
+            | [ offset ] -> Fmt.str "> (%s, %a)" loc pp_expr offset
+            | _ -> Fmt.to_to_string pp_expr value
+          in
+          let value =
+            match value with
+            | Expr.EList (Lit (Loc loc) :: rest) | Expr.EList (LVar loc :: rest)
+              -> match_offset rest loc
+            | _ -> Fmt.to_to_string pp_expr value
+          in
+          Some ({ name = var; value; type_ = None; var_ref = 0 } : Variable.t))
         store
       |> List.sort Stdlib.compare
 
@@ -1463,15 +1462,14 @@ struct
       let pfs_vars, axiom_vars =
         pfs |> PFS.to_list
         |> List.partition_map (fun formula ->
-               let var = Variable.make ~name:"" in
                match pr_list_axiom formula with
                | None ->
                    let value = Fmt.to_to_string pp_expr formula in
-                   Left (var ~value ())
-               | Some value -> Right (var ~value ()))
+                   Left (Variable.make ~value ())
+               | Some value -> Right (Variable.make ~value ()))
       in
-      let pfs_vars = List.sort Stdlib.compare pfs_vars in
-      let axiom_vars = List.sort Stdlib.compare axiom_vars in
+      let pfs_vars = List.sort Variable.compare_value pfs_vars in
+      let axiom_vars = List.sort Variable.compare_value axiom_vars in
       (pfs_vars, axiom_vars)
 
     let get_pred_vars preds =
@@ -1515,10 +1513,18 @@ struct
                else if value = Type.ObjectType then "Block identifier"
                else Type.str value
              in
-             Variable.{ name; value; type_ = None; var_ref = 0 })
-      |> List.sort Variable.(fun v w -> Stdlib.compare v.name w.name)
+             Variable.make ~name ~value ())
+      |> List.sort Variable.compare_name
 
-    let f _ { store; memory; pfs; types; preds } _ =
+    let get_subst_vars subst : Variable.t list =
+      subst |> SVal.SESubst.to_list
+      |> List.map (fun (a, b) ->
+             let name = Fmt.to_to_string pp_expr a in
+             let value = Fmt.to_to_string pp_expr b in
+             Variable.make ~name ~value ())
+      |> List.sort Variable.compare_name
+
+    let f _ { store; memory; pfs; types; preds; subst } _ =
       let variables = Hashtbl.create 0 in
       (* Scopes and var refs share IDs; they can't clash *)
       let new_var_ref =
@@ -1533,6 +1539,15 @@ struct
       let var_groups =
         let pvars = get_store_vars store in
         (Scopes.pvars, pvars) :: var_groups
+      in
+
+      (* Subst *)
+      let var_groups =
+        match subst with
+        | Some subst ->
+            let subst_vars = get_subst_vars subst in
+            (Scopes.subst, subst_vars) :: var_groups
+        | None -> var_groups
       in
 
       (* Heap *)

--- a/wisl/lib/state_ex/wislSHeap.ml
+++ b/wisl/lib/state_ex/wislSHeap.ml
@@ -23,9 +23,9 @@ module Block = struct
 
   let empty = Allocated { data = SFVL.empty; bound = None }
 
-  let is_empty t =
+  let is_empty ?(freed_is_empty = false) t =
     match t with
-    | Freed -> false
+    | Freed -> freed_is_empty
     | Allocated { data; bound } -> SFVL.is_empty data && Option.is_none bound
 
   let substitution ~partial subst block =
@@ -356,7 +356,8 @@ let to_seq heap =
          | Block.Freed -> (loc, None)
          | Allocated { data; bound } -> (loc, Some (data, bound)))
 
-let is_empty t = Hashtbl.to_seq_values t |> Seq.for_all Block.is_empty
+let is_empty ?freed_is_empty t =
+  Hashtbl.to_seq_values t |> Seq.for_all (Block.is_empty ?freed_is_empty)
 
 (***** Clean-up *****)
 

--- a/wisl/lib/state_ex/wislSHeap.mli
+++ b/wisl/lib/state_ex/wislSHeap.mli
@@ -16,7 +16,7 @@ val init : unit -> t
 val alloc : t -> int -> string
 val dispose : t -> string -> (unit, err) Delayed_result.t
 val clean_up : Expr.Set.t -> t -> Expr.Set.t * Expr.Set.t
-val is_empty : t -> bool
+val is_empty : ?freed_is_empty:bool -> t -> bool
 
 val get_cell :
   t -> string -> Expr.t -> (string * Expr.t * Expr.t, err) Delayed_result.t

--- a/wisl/lib/state_ex/wislSMemory.ml
+++ b/wisl/lib/state_ex/wislSMemory.ml
@@ -215,6 +215,6 @@ let can_fix = function
   | _ -> false
 
 let get_failing_constraint _ = Expr.true_
-let sure_is_nonempty t = not (WislSHeap.is_empty t)
+let sure_is_nonempty t = not (WislSHeap.is_empty ~freed_is_empty:true t)
 let split_further _ _ _ _ = None
 let execute_action = execute_action ?alloc_if_missing:None

--- a/wisl/lib/state_frac/wislLifter.ml
+++ b/wisl/lib/state_frac/wislLifter.ml
@@ -1473,7 +1473,7 @@ struct
              Variable.{ name; value; type_ = None; var_ref = 0 })
       |> List.sort Variable.(fun v w -> Stdlib.compare v.name w.name)
 
-    let f _ { store; memory; pfs; types; preds } _ =
+    let f _ { store; memory; pfs; types; preds; _ } _ =
       let variables = Hashtbl.create 0 in
       (* Scopes and var refs share IDs; they can't clash *)
       let new_var_ref =


### PR DESCRIPTION
- Fix `<step in>` labels that were incorrectly appearing in C2 debugging
- Instead of the bizarro sidebar in the debug UI for substitutions, they're now included alongside the rest of the state when debugging
- Fix freed memory causing a false positive in WISL's leak check
  (Resolves #372)