### PR TITLE
Only activate division check based on a CLI flag

### DIFF
--- a/Gillian-JS/lib/Compiler/JS2GIL_ParserAndCompiler.ml
+++ b/Gillian-JS/lib/Compiler/JS2GIL_ParserAndCompiler.ml
@@ -3,7 +3,12 @@ open Cmdliner
 let burn_jsil = ref false
 
 module TargetLangOptions = struct
-  type t = { jsil : bool; harness : bool; burn_jsil : bool }
+  type t = {
+    jsil : bool;
+    harness : bool;
+    burn_jsil : bool;
+    forbid_div_by_zero : bool;
+  }
 
   let term =
     let docs = Manpage.s_common_options in
@@ -13,13 +18,24 @@ module TargetLangOptions = struct
     let harness = Arg.(value & flag & info [ "harness" ] ~docs ~doc) in
     let doc = "If you want to write the intermediate JSIL file" in
     let burn_jsil = Arg.(value & flag & info [ "burn-jsil" ] ~docs ~doc) in
-    let f jsil harness burn_jsil = { jsil; harness; burn_jsil } in
-    Term.(const f $ jsil $ harness $ burn_jsil)
+    let doc =
+      "Treat division and modulo by zero as a runtime error. Division by zero \
+       is well-defined in JavaScript (it yields Infinity/NaN); this flag makes \
+       it raise an error instead, which is useful for bug-finding."
+    in
+    let forbid_div_by_zero =
+      Arg.(value & flag & info [ "forbid-div-by-zero" ] ~docs ~doc)
+    in
+    let f jsil harness burn_jsil forbid_div_by_zero =
+      { jsil; harness; burn_jsil; forbid_div_by_zero }
+    in
+    Term.(const f $ jsil $ harness $ burn_jsil $ forbid_div_by_zero)
 
-  let apply { jsil; harness; burn_jsil = conf_burn_jsil } =
+  let apply { jsil; harness; burn_jsil = conf_burn_jsil; forbid_div_by_zero } =
     burn_jsil := conf_burn_jsil;
     Javert_utils.Js_config.js := not jsil;
-    Javert_utils.Js_config.js2jsil_harnessing := harness
+    Javert_utils.Js_config.js2jsil_harnessing := harness;
+    Javert_utils.Js_config.forbid_div_by_zero := forbid_div_by_zero
 end
 
 type init_data = unit

--- a/Gillian-JS/lib/Compiler/JS2JSIL_Compiler.ml
+++ b/Gillian-JS/lib/Compiler/JS2JSIL_Compiler.ml
@@ -416,26 +416,28 @@ let translate_multiplicative_binop x1 x2 x1_v x2_v aop err =
      [Infinity], [-Infinity] or [NaN] and never raises an exception. The
      [check_nonzero] guard that turns it into an error is therefore only
      emitted when the user opts in via the [--forbid-div-by-zero] flag. *)
-  let nonzero_err, nonzero_cmd =
+  let nonzero_cmds, nonzero_errs =
     match aop with
     | (JS_Parser.Syntax.Div | JS_Parser.Syntax.Mod)
       when !Javert_utils.Js_config.forbid_div_by_zero ->
-        make_check_nonzero_call (PVar x2_n) err
-    | _ -> ("", LBasic Skip)
+        let nonzero_err, nonzero_cmd =
+          make_check_nonzero_call (PVar x2_n) err
+        in
+        (* x2_n_n := "check_nonzero"(x2_n) with err *)
+        ([ (None, nonzero_cmd) ], [ nonzero_err ])
+    | _ -> ([], [])
   in
 
   let new_cmds =
     [
       (None, cmd_tn_x1);
       (*  x1_n := i__toNumber (x1_v) with err  *)
-      (None, cmd_tn_x2);
-      (*  x2_n := i__toNumber (x2_v) with err  *)
-      (None, nonzero_cmd);
-      (* x2_n_n := "check_nonzero"(x_2_n) with elab; *)
-      (None, cmd_ass_xr) (*  x_r := x1_n * x2_n                   *);
+      (None, cmd_tn_x2) (*  x2_n := i__toNumber (x2_v) with err  *);
     ]
+    @ nonzero_cmds
+    @ [ (None, cmd_ass_xr) (*  x_r := x1_n * x2_n  *) ]
   in
-  let new_errs = [ x1_n; x2_n; nonzero_err ] in
+  let new_errs = [ x1_n; x2_n ] @ nonzero_errs in
   (new_cmds, new_errs, x_r)
 
 let translate_binop_plus x1 x2 x1_v x2_v err =

--- a/Gillian-JS/lib/Compiler/JS2JSIL_Compiler.ml
+++ b/Gillian-JS/lib/Compiler/JS2JSIL_Compiler.ml
@@ -412,9 +412,14 @@ let translate_multiplicative_binop x1 x2 x1_v x2_v aop err =
     LBasic (Assignment (x_r, BinOp (PVar x1_n, jsil_aop, PVar x2_n)))
   in
 
+  (* In JavaScript, division (and modulo) by zero is well-defined: it yields
+     [Infinity], [-Infinity] or [NaN] and never raises an exception. The
+     [check_nonzero] guard that turns it into an error is therefore only
+     emitted when the user opts in via the [--forbid-div-by-zero] flag. *)
   let nonzero_err, nonzero_cmd =
     match aop with
-    | JS_Parser.Syntax.Div | JS_Parser.Syntax.Mod ->
+    | (JS_Parser.Syntax.Div | JS_Parser.Syntax.Mod)
+      when !Javert_utils.Js_config.forbid_div_by_zero ->
         make_check_nonzero_call (PVar x2_n) err
     | _ -> ("", LBasic Skip)
   in

--- a/Gillian-JS/lib/utils/js_config.ml
+++ b/Gillian-JS/lib/utils/js_config.ml
@@ -13,6 +13,12 @@ let js2jsil_line_numbers = ref false
 let js2jsil_sep_procs = ref false
 let unfolding = ref true
 
+(** When set, compile division and modulo by zero to a runtime error. Division
+    by zero is well-defined in JavaScript (it yields [Infinity]/[NaN]), so this
+    is off by default and only enabled via [--forbid-div-by-zero] for
+    bug-finding. *)
+let forbid_div_by_zero = ref false
+
 (** {2 Legacy config that is still used} *)
 
 let cosette = ref false


### PR DESCRIPTION
#339 introduces a regression because division by zero is valid in JS. But sometimes, users may actually want to check for this. We hide the feature behind a  `--forbid-div-by-zero` flag