### PR TITLE
Change the syntax of predicates to be `pred(ins ; outs)`

### DIFF
--- a/Gillian-C/examples/amazon/allocator.c
+++ b/Gillian-C/examples/amazon/allocator.c
@@ -6,7 +6,7 @@
 #include "allocator.h"
 #include "error.h"
 
-/*@ pred default_allocator(allocator;) {
+/*@ pred default_allocator(allocator) {
   (allocator -> struct aws_allocator {
     funptr(s_default_malloc);
     funptr(s_default_free);

--- a/Gillian-C/examples/amazon/allocator.c
+++ b/Gillian-C/examples/amazon/allocator.c
@@ -6,7 +6,7 @@
 #include "allocator.h"
 #include "error.h"
 
-/*@ pred default_allocator(allocator) {
+/*@ pred default_allocator(allocator;) {
   (allocator -> struct aws_allocator {
     funptr(s_default_malloc);
     funptr(s_default_free);

--- a/Gillian-C/examples/amazon/array_list.c
+++ b/Gillian-C/examples/amazon/array_list.c
@@ -43,7 +43,7 @@
             }
     }
 
-    pred nounfold optPadding(p, sz;) {
+    pred nounfold optPadding(p, sz) {
         (sz == 0);
         (1 <=# sz) * ARRAY(p, char, sz, #fill)
     }
@@ -52,11 +52,11 @@
         (0 <# prefix_size) * (0 <# total_size) * MALLOCED(data, total_size) *
         edk_array_list_content_pref(data, prefix_size, alloc; content) *
         (prefix_size == (96 * (len content))) *
-        optPadding(data p+ prefix_size, #rest_size;) *
+        optPadding(data p+ prefix_size, #rest_size) *
         (#rest_size == (total_size - prefix_size));
 
         (0 == prefix_size) * (0 <# total_size) * MALLOCED(data, total_size) *
-        optPadding(data, total_size;) * (content == [])
+        optPadding(data, total_size) * (content == [])
     }
 
     lemma edk_array_list_data_is_freeable(data, prefix_size, total_size, alloc) {
@@ -163,7 +163,7 @@ axiomatic spec aws_array_list_ensure_capacity(list, index) {
             valid_edk_array_list(#current_size, #length, #item_size,
                                  #data, #alloc; #content) *
             (#item_size <=# 65535) * (#index <=# 65534) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
   ensures:  (((#index + 1) * #item_size) <=# #new_size) *
             (#list -> struct aws_array_list {
               #alloc; long(#new_size); long(#length);
@@ -171,7 +171,7 @@ axiomatic spec aws_array_list_ensure_capacity(list, index) {
             }) *
             valid_edk_array_list(#new_size, #length, #item_size,
                                  #new_data, #alloc; #content) *
-            default_allocator(#alloc;) *
+            default_allocator(#alloc) *
             (ret == int(0))
 }
 */
@@ -254,7 +254,7 @@ size_t aws_array_list_length(const struct aws_array_list *list) {
               (#index <=# (len #content)) *
               valid_edk_array_list_ptr(#list; #alloc, #content) *
               valid_aws_cryptosdk_edk_ptr(#val; #alloc, #edk) *
-              (#index <=# 65534) * default_allocator(#alloc;)
+              (#index <=# 65534) * default_allocator(#alloc)
     ensures:
               (#length == len #content) * (#index <# #length) *
               (#new_content == #fp @ [ #edk ] @ #sp) *
@@ -262,12 +262,12 @@ size_t aws_array_list_length(const struct aws_array_list *list) {
               (#sp == lsub(#content, #index + 1, (len #content) - #index - 1 )) *
               valid_edk_array_list_ptr(#list; #alloc, #new_content) *
               valid_aws_cryptosdk_edk_ptr(#val; #alloc, #edk) *
-              default_allocator(#alloc;) * (ret == int(0));
+              default_allocator(#alloc) * (ret == int(0));
 
               (#index == (len #content)) *
               valid_edk_array_list_ptr(#list; #alloc, #content @ [ #edk ]) *
               valid_aws_cryptosdk_edk_ptr(#val; #alloc, #edk) *
-              default_allocator(#alloc;) * (ret == int(0))
+              default_allocator(#alloc) * (ret == int(0))
 } */
 int aws_array_list_set_at(struct aws_array_list *list, const void *val,
                           size_t index) {
@@ -301,13 +301,13 @@ int aws_array_list_set_at(struct aws_array_list *list, const void *val,
 axiomatic spec aws_array_list_push_back(list, val) {
     requires: (list == #list) * (val == #val) *
               valid_edk_array_list_ptr(#list; #alloc, #content) *
-              default_allocator(#alloc;) *
+              default_allocator(#alloc) *
               valid_aws_cryptosdk_edk_ptr(#val; #alloc, #edk) *
               ((len #content) <=# 65534)
 
     ensures: (list == #list) * (val == #val) *
              valid_edk_array_list_ptr(#list; #alloc, #content @ [#edk]) *
-             default_allocator(#alloc;) *
+             default_allocator(#alloc) *
              ARRAY(#val, long, 12, #trash) *
              (ret == int(0))
 }

--- a/Gillian-C/examples/amazon/array_list.c
+++ b/Gillian-C/examples/amazon/array_list.c
@@ -20,15 +20,15 @@
     pred edk_array_list_content_pref(data, size, alloc; content) {
         (size == 0) * (content == []);
         (0 <=# (size - 96)) *
-        valid_aws_cryptosdk_edk_ptr(data, alloc, #edk) *
+        valid_aws_cryptosdk_edk_ptr(data; alloc, #edk) *
         (content == #edk :: #rest) *
         (#next == data p+ 96) *
-        edk_array_list_content_pref(#next, size - 96, alloc, #rest)
+        edk_array_list_content_pref(#next, size - 96, alloc; #rest)
     }
 
     lemma array_list_content_pref_is_array(data, size, alloc) {
         hypothesis:
-            edk_array_list_content_pref(#data, #size, #alloc, #content) * (0 <# #size)
+            edk_array_list_content_pref(#data, #size, #alloc; #content) * (0 <# #size)
 
         conclusions:
             ARRAY(#data, char, #size, #something)
@@ -50,18 +50,18 @@
 
     pred edk_array_list_data_content(data, prefix_size, total_size, alloc; content) {
         (0 <# prefix_size) * (0 <# total_size) * MALLOCED(data, total_size) *
-        edk_array_list_content_pref(data, prefix_size, alloc, content) *
+        edk_array_list_content_pref(data, prefix_size, alloc; content) *
         (prefix_size == (96 * (len content))) *
-        optPadding(data p+ prefix_size, #rest_size) *
+        optPadding(data p+ prefix_size, #rest_size;) *
         (#rest_size == (total_size - prefix_size));
 
         (0 == prefix_size) * (0 <# total_size) * MALLOCED(data, total_size) *
-        optPadding(data, total_size) * (content == [])
+        optPadding(data, total_size;) * (content == [])
     }
 
     lemma edk_array_list_data_is_freeable(data, prefix_size, total_size, alloc) {
         hypothesis:
-            edk_array_list_data_content(#data, #prefix_size, #total_size, #alloc, #content)
+            edk_array_list_data_content(#data, #prefix_size, #total_size, #alloc; #content)
 
         conclusions:
             MARRAY(#data, char, #total_size, #whatever)
@@ -79,29 +79,29 @@
         (data == NULL) * (content == []);
 
         (item_size == 96) * (0 <=# length) * (0 <# current_size) *
-        aws_mul_u64_checked(item_size, length, #required_size) *
+        aws_mul_u64_checked(item_size, length; #required_size) *
         (#required_size <=# current_size) *
         (not (data == NULL)) *
-        edk_array_list_data_content(data, #required_size, current_size, alloc, content) *
+        edk_array_list_data_content(data, #required_size, current_size, alloc; content) *
         (length == len content)
     }
 
     pred valid_edk_array_list_fields(fields; alloc, content) {
         (fields == [ alloc, long(#current_size), long(#length), long(#item_size), #data ]) *
-        valid_edk_array_list(#current_size, #length, #item_size, #data, alloc, content)
+        valid_edk_array_list(#current_size, #length, #item_size, #data, alloc; content)
     }
 
     pred empty_edk_array_list_fields(fields; alloc) {
-        valid_edk_array_list_fields(fields, alloc, [])
+        valid_edk_array_list_fields(fields; alloc, [])
     }
 
     pred nounfold valid_edk_array_list_ptr(list; alloc, content) {
         (list -> struct aws_array_list { alloc; long(#current_size); long(#length); long(#item_size); #data}) *
-        valid_edk_array_list(#current_size, #length, #item_size, #data, alloc, content)
+        valid_edk_array_list(#current_size, #length, #item_size, #data, alloc; content)
     }
 
     pred empty_edk_array_list_ptr(list; alloc) {
-        valid_edk_array_list_ptr(list, alloc, [])
+        valid_edk_array_list_ptr(list; alloc, [])
     }
 */
 
@@ -161,17 +161,17 @@ axiomatic spec aws_array_list_ensure_capacity(list, index) {
               long(#item_size); #data
             }) *
             valid_edk_array_list(#current_size, #length, #item_size,
-                                 #data, #alloc, #content) *
+                                 #data, #alloc; #content) *
             (#item_size <=# 65535) * (#index <=# 65534) *
-            default_allocator(#alloc)
+            default_allocator(#alloc;)
   ensures:  (((#index + 1) * #item_size) <=# #new_size) *
             (#list -> struct aws_array_list {
               #alloc; long(#new_size); long(#length);
               long(#item_size); #new_data
             }) *
             valid_edk_array_list(#new_size, #length, #item_size,
-                                 #new_data, #alloc, #content) *
-            default_allocator(#alloc) *
+                                 #new_data, #alloc; #content) *
+            default_allocator(#alloc;) *
             (ret == int(0))
 }
 */
@@ -221,7 +221,7 @@ int aws_array_list_ensure_capacity(struct aws_array_list *list, size_t index) {
 
         GILLIAN(
             "if (! (#length = 0)) { "
-            "   assert [[bind #x]] valid_aws_cryptosdk_edk_ptr(#data, #alloc, #x); "
+            "   assert [[bind #x]] valid_aws_cryptosdk_edk_ptr(#data; #alloc, #x); "
             "   branch (#length == 1);"
             "   unfold valid_aws_cryptosdk_edk_ptr(#data, #alloc, #x) "
             "}");
@@ -252,22 +252,22 @@ size_t aws_array_list_length(const struct aws_array_list *list) {
     requires: (list == #list) * (index == long(#index)) *
               (val == #val) * (0 <=# #index) *
               (#index <=# (len #content)) *
-              valid_edk_array_list_ptr(#list, #alloc, #content) *
-              valid_aws_cryptosdk_edk_ptr(#val, #alloc, #edk) *
-              (#index <=# 65534) * default_allocator(#alloc)
+              valid_edk_array_list_ptr(#list; #alloc, #content) *
+              valid_aws_cryptosdk_edk_ptr(#val; #alloc, #edk) *
+              (#index <=# 65534) * default_allocator(#alloc;)
     ensures:
               (#length == len #content) * (#index <# #length) *
               (#new_content == #fp @ [ #edk ] @ #sp) *
               (#fp == lsub(#content, 0, #index - 1)) *
               (#sp == lsub(#content, #index + 1, (len #content) - #index - 1 )) *
-              valid_edk_array_list_ptr(#list, #alloc, #new_content) *
-              valid_aws_cryptosdk_edk_ptr(#val, #alloc, #edk) *
-              default_allocator(#alloc) * (ret == int(0));
+              valid_edk_array_list_ptr(#list; #alloc, #new_content) *
+              valid_aws_cryptosdk_edk_ptr(#val; #alloc, #edk) *
+              default_allocator(#alloc;) * (ret == int(0));
 
               (#index == (len #content)) *
-              valid_edk_array_list_ptr(#list, #alloc, #content @ [ #edk ]) *
-              valid_aws_cryptosdk_edk_ptr(#val, #alloc, #edk) *
-              default_allocator(#alloc) * (ret == int(0))
+              valid_edk_array_list_ptr(#list; #alloc, #content @ [ #edk ]) *
+              valid_aws_cryptosdk_edk_ptr(#val; #alloc, #edk) *
+              default_allocator(#alloc;) * (ret == int(0))
 } */
 int aws_array_list_set_at(struct aws_array_list *list, const void *val,
                           size_t index) {
@@ -300,14 +300,14 @@ int aws_array_list_set_at(struct aws_array_list *list, const void *val,
 /*@
 axiomatic spec aws_array_list_push_back(list, val) {
     requires: (list == #list) * (val == #val) *
-              valid_edk_array_list_ptr(#list, #alloc, #content) *
-              default_allocator(#alloc) *
-              valid_aws_cryptosdk_edk_ptr(#val, #alloc, #edk) *
+              valid_edk_array_list_ptr(#list; #alloc, #content) *
+              default_allocator(#alloc;) *
+              valid_aws_cryptosdk_edk_ptr(#val; #alloc, #edk) *
               ((len #content) <=# 65534)
 
     ensures: (list == #list) * (val == #val) *
-             valid_edk_array_list_ptr(#list, #alloc, #content @ [#edk]) *
-             default_allocator(#alloc) *
+             valid_edk_array_list_ptr(#list; #alloc, #content @ [#edk]) *
+             default_allocator(#alloc;) *
              ARRAY(#val, long, 12, #trash) *
              (ret == int(0))
 }

--- a/Gillian-C/examples/amazon/array_list.c
+++ b/Gillian-C/examples/amazon/array_list.c
@@ -17,7 +17,7 @@
 // Various predicates for dealing with array lists of edks
 /*@
 
-    pred edk_array_list_content_pref(+data, +size, +alloc, content) {
+    pred edk_array_list_content_pref(data, size, alloc; content) {
         (size == 0) * (content == []);
         (0 <=# (size - 96)) *
         valid_aws_cryptosdk_edk_ptr(data, alloc, #edk) *
@@ -43,12 +43,12 @@
             }
     }
 
-    pred nounfold optPadding(+p, +sz) {
+    pred nounfold optPadding(p, sz;) {
         (sz == 0);
         (1 <=# sz) * ARRAY(p, char, sz, #fill)
     }
 
-    pred edk_array_list_data_content(+data, +prefix_size, +total_size, +alloc, content) {
+    pred edk_array_list_data_content(data, prefix_size, total_size, alloc; content) {
         (0 <# prefix_size) * (0 <# total_size) * MALLOCED(data, total_size) *
         edk_array_list_content_pref(data, prefix_size, alloc, content) *
         (prefix_size == (96 * (len content))) *
@@ -74,7 +74,7 @@
             unfold optPadding(#data p+ #prefix_size, #total_size - #prefix_size)
     }
 
-    pred nounfold valid_edk_array_list(+current_size, +length, +item_size, +data, +alloc, content) {
+    pred nounfold valid_edk_array_list(current_size, length, item_size, data, alloc; content) {
         (current_size == 0) * (length == 0) * (item_size == 96) *
         (data == NULL) * (content == []);
 
@@ -86,21 +86,21 @@
         (length == len content)
     }
 
-    pred valid_edk_array_list_fields(+fields, alloc, content) {
+    pred valid_edk_array_list_fields(fields; alloc, content) {
         (fields == [ alloc, long(#current_size), long(#length), long(#item_size), #data ]) *
         valid_edk_array_list(#current_size, #length, #item_size, #data, alloc, content)
     }
 
-    pred empty_edk_array_list_fields(+fields, alloc) {
+    pred empty_edk_array_list_fields(fields; alloc) {
         valid_edk_array_list_fields(fields, alloc, [])
     }
 
-    pred nounfold valid_edk_array_list_ptr(+list, alloc, content) {
+    pred nounfold valid_edk_array_list_ptr(list; alloc, content) {
         (list -> struct aws_array_list { alloc; long(#current_size); long(#length); long(#item_size); #data}) *
         valid_edk_array_list(#current_size, #length, #item_size, #data, alloc, content)
     }
 
-    pred empty_edk_array_list_ptr(+list, alloc) {
+    pred empty_edk_array_list_ptr(list; alloc) {
         valid_edk_array_list_ptr(list, alloc, [])
     }
 */

--- a/Gillian-C/examples/amazon/base.c
+++ b/Gillian-C/examples/amazon/base.c
@@ -36,11 +36,11 @@
 
     lemma optBytesConcat(lptr, llength, rptr, rlength) {
         hypothesis:
-            optBytes(#lptr, #llength, #lcont) * optBytes(#rptr, #rlength, #rcont) *
+            optBytes(#lptr, #llength; #lcont) * optBytes(#rptr, #rlength; #rcont) *
             (#rptr == #lptr p+ #llength)
 
         conclusions:
-            optBytes(#lptr, #llength + #rlength, #lcont @ #rcont)
+            optBytes(#lptr, #llength + #rlength; #lcont @ #rcont)
 
         proof:
             unfold optBytes(#lptr, #llength, #lcont);

--- a/Gillian-C/examples/amazon/base.c
+++ b/Gillian-C/examples/amazon/base.c
@@ -14,22 +14,22 @@
     Our predicate describes the valid case.
 */
 /*@
-    pred aws_add_u64_checked(+a, +b, out) {
+    pred aws_add_u64_checked(a, b; out) {
         (out == (a + b)) *
         (out <# 4611686018427387903)
     }
 
-    pred aws_mul_u64_checked(+a, +b, out) {
+    pred aws_mul_u64_checked(a, b; out) {
         (out == (a * b)) *
         (out <# 4611686018427387903)
     }
 
-    pred nounfold writable_memory(+pointer, +length, content) {
+    pred nounfold writable_memory(pointer, length; content) {
         (length == 0) * (content == []);
         (0 <# length) * ARRAY(pointer, char, length, content)
     }
 
-    pred nounfold optBytes(+bytes, +length, content) {
+    pred nounfold optBytes(bytes, length; content) {
         (length == 0) * (content == nil);
         (0 <# length) * ARRAY(bytes, char, length, content)
     }

--- a/Gillian-C/examples/amazon/bugs/EncryptionHeaderLogic.gil
+++ b/Gillian-C/examples/amazon/bugs/EncryptionHeaderLogic.gil
@@ -16,7 +16,7 @@
 *)
 pred Field(buffer : List, readPos : Int; field : List, length : Int) :
     (0i i<=# readPos) * (#rawFL == l-sub(buffer, readPos, 2i)) *
-    rawToUInt16(#rawFL, false, #fieldLength) *
+    rawToUInt16(#rawFL, false; #fieldLength) *
     (field == l-sub(buffer, (readPos i+ 2i), #fieldLength)) *
     (length == (2i i+ #fieldLength)) * ((readPos i+ length) i<=# (l-len buffer));
 
@@ -72,14 +72,14 @@ pred IElement(buffer : List, readPos : Int, fCount : Int; fList : List, eLength 
 
   (* Base case: enough data to read length of next field, but not enough data to read next field *)
   (0i i<=# readPos) * (0i i<# fCount) * ((readPos i+ 2i) i<=# (l-len buffer)) *
-    (#rawFL == l-sub(buffer, readPos, 2i)) * rawToUInt16(#rawFL, false, #fLength) *
+    (#rawFL == l-sub(buffer, readPos, 2i)) * rawToUInt16(#rawFL, false; #fLength) *
     ((l-len buffer) i<# ((readPos i+ 2i) i+ #fLength)) * (fList == {{  }}) *
     (eLength == ((l-len buffer) i- (readPos i+ 2i))),
 
   (* Recursive case: enough data to read one field, but not enough data to read the remaining ones *)
-  (0i i<=# readPos) * (1i i<# fCount) * Field(buffer, readPos, #field, #fLength) *
+  (0i i<=# readPos) * (1i i<# fCount) * Field(buffer, readPos; #field, #fLength) *
     (#restFCount == (fCount i- 1i)) * ((readPos i+ #fLength) i<=# (l-len buffer)) *
-    IElement(buffer, (readPos i+ #fLength), #restFCount, #restFList, #restELength) *
+    IElement(buffer, (readPos i+ #fLength), #restFCount; #restFList, #restELength) *
     (fList == l+ ({{ #field }}, #restFList)) *
     (eLength == (#fLength i+ #restELength));
 
@@ -127,13 +127,13 @@ pred IElements(buffer : List, readPos : Int, eCount : Int, fCount : Int;
                eList : List, esLength : Int) :
   (* Base case: single incomplete element *)
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) * (0i i<# eCount) * (0i i<# fCount) *
-    IElement(buffer, readPos, fCount, #fList, esLength) * (eList == {{  }}),
+    IElement(buffer, readPos, fCount; #fList, esLength) * (eList == {{  }}),
 
   (* Recursive case: enough data to read first element, but not enough data to read the remaining ones *)
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) * (1i i<# eCount) * (0i i<# fCount) *
-    CElement(buffer, readPos, fCount, #fList, #eLength) *
+    CElement(buffer, readPos, fCount; #fList, #eLength) *
     (#restECount == (eCount i- 1i)) *
-    IElements(buffer, (readPos i+ #eLength), #restECount, fCount, #restEList, #restESLength) *
+    IElements(buffer, (readPos i+ #eLength), #restECount, fCount; #restEList, #restESLength) *
     (eList == l+ ({{ #fList }}, #restEList)) * (esLength == (#eLength i+ #restESLength));
   facts: (0i i<=# readPos) and (readPos i<=# (l-len buffer)) and (0i i<# eCount) and (0i i<# fCount) and (0i i<=# esLength);
 
@@ -162,9 +162,9 @@ pred IElements(buffer : List, readPos : Int, eCount : Int, fCount : Int;
 pred CElement(buffer : List, readPos : Int, fCount : Int; element : List, length : Int) :
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) *
     (fCount == 0i) * (element == {{  }}) * (length == 0i),
-  (0i i<# fCount) * Field(buffer, readPos, #field, #fLength) * ((typeOf #field) == List) *
+  (0i i<# fCount) * Field(buffer, readPos; #field, #fLength) * ((typeOf #field) == List) *
     (#restFCount == (fCount i- 1i)) *
-    CElement(buffer, (readPos i+ #fLength), #restFCount, #restFields, #restLength) *
+    CElement(buffer, (readPos i+ #fLength), #restFCount; #restFields, #restLength) *
     (element == l+ ({{ #field }}, #restFields)) * (length == (#fLength i+ #restLength));
   (*
       A complete element has a non-negative number of fields
@@ -198,8 +198,8 @@ pred CElements(buffer : List, readPos : Int, eCount : Int, fCount : Int;
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) * (eCount == 0i) *
     (0i i<# fCount) * (elements == {{  }}) * (length == 0i),
   (0i i<=# readPos) * (0i i<# eCount) * (0i i<# fCount) * (0i i<# length) *
-    CElement(buffer, readPos, fCount, #element, #eLength) * (#restECount == (eCount i- 1i)) *
-    CElements(buffer, (readPos i+ #eLength), #restECount, fCount, #restElements, #restLength) *
+    CElement(buffer, readPos, fCount; #element, #eLength) * (#restECount == (eCount i- 1i)) *
+    CElements(buffer, (readPos i+ #eLength), #restECount, fCount; #restElements, #restLength) *
     (elements == l+ ({{ #element }}, #restElements)) *
     (length == (#eLength i+ #restLength));
   (*
@@ -213,35 +213,35 @@ pred CElements(buffer : List, readPos : Int, eCount : Int, fCount : Int;
 
 
 lemma CElementNonEmptyPositiveLength(buffer, readPos, fCount, fList, eLength)
-  [[  CElement(#buffer, #readPos, #fCount, #fList, #eLength) *
+  [[  CElement(#buffer, #readPos, #fCount; #fList, #eLength) *
       (0i i<# #fCount) ]]
-  [[  CElement(#buffer, #readPos, #fCount, #fList, #eLength) *
+  [[  CElement(#buffer, #readPos, #fCount; #fList, #eLength) *
       (0i i<# #eLength) ]]
   (*
   [*  unfold CElement(#buffer, #readPos, #fCount, #fList, #eLength) ;
-      sep_assert (Field(#buffer, #readPos, #field, #fLength)) [bind: #fLength];
-      sep_assert (CElement(#buffer, (#readPos i+ #fLength), (#fCount i- 1i), #restFields, #restELength)) [bind: #restELength]  *]
+      sep_assert (Field(#buffer, #readPos; #field, #fLength)) [bind: #fLength];
+      sep_assert (CElement(#buffer, (#readPos i+ #fLength), (#fCount i- 1i); #restFields, #restELength)) [bind: #restELength]  *]
   *)
 
 lemma CElementsShift(buffer, readPos, eCount, fCount, shift)
-  [[  CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
+  [[  CElements(#buffer, #readPos, #eCount, #fCount; #eList, #esLength) *
       (0i i<=# (#readPos i- #shift)) ]]
   [[  (#rBuffer == l-sub(#buffer, #shift, ((l-len #buffer) i- #shift))) *
-      CElements(#rBuffer, #readPos i- #shift, #eCount, #fCount, #eList, #esLength) ]]
+      CElements(#rBuffer, #readPos i- #shift, #eCount, #fCount; #eList, #esLength) ]]
 
 lemma IElementsShift(buffer, readPos, eCount, fCount, shift)
-  [[  IElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
+  [[  IElements(#buffer, #readPos, #eCount, #fCount; #eList, #esLength) *
       (0i i<=# (#readPos i- #shift)) ]]
   [[  (#rBuffer == l-sub(#buffer, #shift, ((l-len #buffer) i- #shift))) *
-      IElements(#rBuffer, #readPos i- #shift, #eCount, #fCount, #eList, #esLength) ]]
+      IElements(#rBuffer, #readPos i- #shift, #eCount, #fCount; #eList, #esLength) ]]
 
 
 nounfold pred Element(buffer : List, readPos : Int, fCount : Int;
                       definition : Str, fList : List, eLength : Int) :
   (definition == "Complete") *
-    CElement(buffer, readPos, fCount, fList, eLength),
+    CElement(buffer, readPos, fCount; fList, eLength),
   (definition == "Incomplete") *
-    IElement(buffer, readPos, fCount, fList, eLength);
+    IElement(buffer, readPos, fCount; fList, eLength);
 
 (****************************
  ****************************
@@ -258,15 +258,15 @@ nounfold pred Element(buffer : List, readPos : Int, fCount : Int;
 nounfold pred Elements(buffer : List, readPos : Int, eCount : Int,
                        fCount : Int; definition : Str, eList : List,
                        esLength : Int) :
-  (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
-  (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
+  (definition == "Complete") * CElements(buffer, readPos, eCount, fCount; eList, esLength),
+  (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount; eList, esLength);
   facts: (0i i<=# readPos) and (readPos i<=# (l-len buffer)) and (0i i<=# eCount) and (0i i<# fCount) and (0i i<=# esLength);
 
 lemma ElementsShift(buffer, readPos, eCount, fCount, shift)
-  [[  Elements(#buffer, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
+  [[  Elements(#buffer, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
       (0i i<=# (#readPos i- #shift)) ]]
   [[  (#rBuffer == l-sub(#buffer, #shift, ((l-len #buffer) i- #shift))) *
-      Elements(#rBuffer, #readPos i- #shift, #eCount, #fCount, #definition, #eList, #esLength) ]]
+      Elements(#rBuffer, #readPos i- #shift, #eCount, #fCount; #definition, #eList, #esLength) ]]
 
 (*****************************
  *****************************
@@ -293,8 +293,8 @@ nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Int;
                                     EDKs : List, EDKsLength : Int) :
     (0i i<=# readPos) * (readPos i<=# (l-len buffer)) *
     (#rawEC == l-sub(buffer, readPos, 2i)) *
-    rawToUInt16(#rawEC, false, #keyCount) * (0i i<# #keyCount) *
-    Elements(buffer, (readPos i+ 2i), #keyCount, 3i, "Complete", EDKs, #EDKsLength) *
+    rawToUInt16(#rawEC, false; #keyCount) * (0i i<# #keyCount) *
+    Elements(buffer, (readPos i+ 2i), #keyCount, 3i; "Complete", EDKs, #EDKsLength) *
     (0i i<# #EDKsLength) * (* This can be derived... *)
     (EDKsLength == (#EDKsLength i+ 2i));
 
@@ -306,8 +306,8 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Int;) :
 
     (* Enough data to read the number of EDKs, but not enough data to read the EDKs *)
   (0i i<=# readPos) * ((readPos i+ 2i) i<=# (l-len buffer)) * (#rawEC == l-sub(buffer, readPos, 2i)) *
-    rawToUInt16(#rawEC, false, #keyCount) * (0i i<# #keyCount) *
-    Elements(buffer, (readPos i+ 2i), #keyCount, 3i, "Incomplete", #eList, #esLength);
+    rawToUInt16(#rawEC, false; #keyCount) * (0i i<# #keyCount) *
+    Elements(buffer, (readPos i+ 2i), #keyCount, 3i; "Incomplete", #eList, #esLength);
 
 (* Broken serialised EDKs *)
 @nopath
@@ -319,16 +319,16 @@ nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Int; errorMessage :
 
     (* Zero EDKs provided *)
     (0i i<=# readPos) * ((readPos i+ 2i) i<=# (l-len buffer)) *
-    (#rawEC == l-sub(buffer, readPos, 2i)) * rawToUInt16(#rawEC, false, 0i) *
+    (#rawEC == l-sub(buffer, readPos, 2i)) * rawToUInt16(#rawEC, false; 0i) *
     (EDKs == {{ }}) * (EDKsLength == 2i) *
     (errorMessage == "Malformed Header: No EncryptedDataKey found.");
 
 (* General serialised EDKs *)
 @nopath
 nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Int; definition : Str, EDKs : List, EDKsLength : Int, errorMessage : Str) :
-  (definition == "Complete")   * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
-  (definition == "Incomplete") * (errorMessage == "") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0i),
-  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage, EDKs, EDKsLength);
+  (definition == "Complete")   * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos; EDKs, EDKsLength),
+  (definition == "Incomplete") * (errorMessage == "") * IRawEncryptedDataKeys(buffer, readPos;) * (EDKs == {{  }}) * (EDKsLength == 0i),
+  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos; errorMessage, EDKs, EDKsLength);
 
 
 (******************************
@@ -354,20 +354,20 @@ nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Int; definition : St
 nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
   (* ((l-len buffer) == 0i) * (ECKs == {{  }}), *)
   (0i i<# l-len buffer) * (#rawKC == l-sub(buffer, 0i, 2i)) *
-    rawToUInt16(#rawKC, false, #keyCount) * (0i i<# #keyCount) *
-    Elements(buffer, 2i, #keyCount, 2i, "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) *
-    Unique(#ECKeys) * ((2i i+ #ECKsLength) == (l-len buffer));
+    rawToUInt16(#rawKC, false; #keyCount) * (0i i<# #keyCount) *
+    Elements(buffer, 2i, #keyCount, 2i; "Complete", ECKs, #ECKsLength) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) *
+    Unique(#ECKeys;) * ((2i i+ #ECKsLength) == (l-len buffer));
 
 (* Broken serialised encryption context *)
 pure nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
-    rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
+    rawToUInt16({{ #kc0, #kc1 }}, false; #keyCount) *
     (0i i<# #keyCount) * (ECKs == {{ }}) *
-    Elements(buffer, 2i, #keyCount, 2i, "Incomplete", #eList, #esLength) *
-    toUtf8PairMap(#eList, #utf8EList) * FirstProj(#eList, #keys) *
-    Unique(#keys) *
+    Elements(buffer, 2i, #keyCount, 2i; "Incomplete", #eList, #esLength) *
+    toUtf8PairMap(#eList; #utf8EList) * FirstProj(#eList; #keys) *
+    Unique(#keys;) *
     (errorMessage == "decodeEncryptionContext: Underflow, not enough data."),
 
     (* Not enough data to read the key_count *)
@@ -380,26 +380,26 @@ pure nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:Lis
 
     (* Too much data provided *)
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
-    rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
+    rawToUInt16({{ #kc0, #kc1 }}, false; #keyCount) *
     (0i i<# #keyCount) *
-    Elements(buffer, 2i, #keyCount, 2i, "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Unique(#ECKeys) *
+    Elements(buffer, 2i, #keyCount, 2i; "Complete", ECKs, #ECKsLength) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Unique(#ECKeys;) *
     (! (#ECKsLength i+ 2i == l-len buffer)) *
     (errorMessage == "decodeEncryptionContext: Overflow, too much data."),
 
     (* Duplicated key in context *)
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
-    rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
+    rawToUInt16({{ #kc0, #kc1 }}, false; #keyCount) *
     (0i i<# #keyCount) *
-    Elements(buffer, 2i, #keyCount, 2i, "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Duplicated({{ }}, #ECKeys) *
+    Elements(buffer, 2i, #keyCount, 2i; "Complete", ECKs, #ECKsLength) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Duplicated({{ }}, #ECKeys;) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
 (* General serialised encryption context *)
 @nopath
 pure nounfold pred RawEncryptionContext(buffer:List; definition:Str, ECKs:List, errorMessage:Str) :
-  (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
-  (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
+  (definition == "Complete") * CRawEncryptionContext(buffer; ECKs) * (errorMessage == ""),
+  (definition == "Broken")   * BRawEncryptionContext(buffer; errorMessage, ECKs);
 
 (****************************
 *****************************
@@ -489,7 +489,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (* Incorrect version and/or type *)
     (22i i<=# l-len rawHeaderData) *
     (rawHeaderData == l+ ({{ version, type }}, #rest)) *
-    BVersionAndType(version, type, errorMessage) *
+    BVersionAndType(version, type; errorMessage) *
 
     (part_one == {{ }}) *
     (suiteId == 0i) * (messageId == {{ }}) * (ECLength == 0i) *
@@ -501,9 +501,9 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (22i i<=# l-len rawHeaderData) *
     (rawHeaderData == l+ ({{ version, type }}, #rawSuiteId, #rest)) *
     (l-len #rawSuiteId == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    BAlgorithmSuite(suiteId, errorMessage) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    BAlgorithmSuite(suiteId; errorMessage) *
 
     (part_one == {{ }}) * (messageId == {{ }}) * (ECLength == 0i) *
     (part_two == {{ }}) * (ECKs == {{ }}) * (ECDef == "") * (edkDef == "") *
@@ -518,15 +518,15 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22i i+ ECLength i<=# l-len rawHeaderData) *
     (0i i<# ECLength) *
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) * (ECDef == "Broken") * (edkDef == "") *
-    BRawEncryptionContext(#EC, errorMessage, ECKs) *
+    BRawEncryptionContext(#EC; errorMessage, ECKs) *
 
     (EDKs == {{ }}) * (contentType == 0i) * (frameLength == 0i) *
     (headerLength == 0i) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -539,16 +539,16 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22i i+ ECLength i<=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) * (ECDef == "") * (edkDef == "Broken") *
-    RawEncryptedDataKeys(rawHeaderData, 22i i+ ECLength, "Broken", EDKs, EDKsLength, errorMessage) *
+    CRawEncryptionContext(#EC; ECKs) * (ECDef == "") * (edkDef == "Broken") *
+    RawEncryptedDataKeys(rawHeaderData, 22i i+ ECLength; "Broken", EDKs, EDKsLength, errorMessage) *
 
     (contentType == 0i) * (frameLength == 0i) *
     (headerLength == 0i) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -561,19 +561,19 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22i i+ ECLength i<=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) * (ECDef == "") *
+    CRawEncryptionContext(#EC; ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, #rest)) *
-    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    RawEncryptedDataKeys(part_three, 0i; "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
-    BContentType(contentType) *
+    BContentType(contentType;) *
 
     (errorMessage == "Malformed Header: Incorrect content type.") *
     (frameLength == 0i) * (headerLength == 0i) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -586,21 +586,21 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22i i+ ECLength i<=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) * (ECDef == "") *
+    CRawEncryptionContext(#EC; ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, #rawReservedBytes, #rest)) *
-    CContentType(contentType) *
-    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    CContentType(contentType;) *
+    RawEncryptedDataKeys(part_three, 0i; "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (l-len #rawReservedBytes == 4i) *
-    rawToUInt32(#rawReservedBytes, false, #reservedBytes) *
+    rawToUInt32(#rawReservedBytes, false; #reservedBytes) *
     (! (#reservedBytes == 0i)) *
 
     (errorMessage == "Malformed Header: Reserved bytes not equal to zero.") *
@@ -614,18 +614,18 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, #ivLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, #ivLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22i i+ ECLength i<=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) * (ECDef == "") *
+    CRawEncryptionContext(#EC; ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }}, {{ headerIvLength }}, #rest)) *
-    CContentType(contentType) *
-    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    CContentType(contentType;) *
+    RawEncryptedDataKeys(part_three, 0i; "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (! (headerIvLength == #ivLength)) *
 
@@ -638,21 +638,21 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     ((l-len #rawSuiteId) == 2i) *
     ((l-len messageId) == 16i) *
-    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (part_two == l+ (#EC, part_three)) *
     ((l-len #EC) == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
-    CContentType(contentType) * (ECDef == "") *
+    CRawEncryptionContext(#EC; ECKs) *
+    CContentType(contentType;) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }},
                        {{ headerIvLength }}, #rawFrameLength, #rest)) *
-    CRawEncryptedDataKeys(part_three, 0i, EDKs, #EDKsLength) *
+    CRawEncryptedDataKeys(part_three, 0i; EDKs, #EDKsLength) *
     (edkDef == "Complete") *
     (#EDKsLength == (l-len #edks)) * ((l-len #rawFrameLength) == 4i) *
-    rawToUInt32(#rawFrameLength, false, frameLength) *
-    IncompatibleContentTypeAndFrameLength(contentType, frameLength);
+    rawToUInt32(#rawFrameLength, false; frameLength) *
+    IncompatibleContentTypeAndFrameLength(contentType, frameLength;);
     facts: (22i i<=# l-len rawHeaderData);
 
 
@@ -669,10 +669,10 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) * (edkDef == "") *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) * (edkDef == "") *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (l-len rawHeaderData i<# 22i i+ ECLength) *
 
     (ECKs == {{ }}) *
@@ -690,21 +690,21 @@ nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     ((l-len #rawSuiteId) == 2i) *
     ((l-len messageId) == 16i) *
-    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (part_two == l+ (#EC, part_three)) *
     ((l-len #EC) == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
-    CContentType(contentType) *
+    CRawEncryptionContext(#EC; ECKs) *
+    CContentType(contentType;) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }},
                        {{ headerIvLength }}, #rawFrameLength, headerIv, headerAuthTag)) *
-    CRawEncryptedDataKeys(part_three, 0i, EDKs, #EDKsLength) *
+    CRawEncryptedDataKeys(part_three, 0i; EDKs, #EDKsLength) *
     (edkDef == "Complete") *
     (#EDKsLength == (l-len #edks)) * ((l-len #rawFrameLength) == 4i) *
-    rawToUInt32(#rawFrameLength, false, frameLength) *
-    CompatibleContentTypeAndFrameLength(contentType, frameLength) *
+    rawToUInt32(#rawFrameLength, false; frameLength) *
+    CompatibleContentTypeAndFrameLength(contentType, frameLength;) *
     (headerLength == ((((((22i i+ ECLength) i+ #EDKsLength) i+ 1i) i+ 4i) i+ 1i) i+ 4i)) *
     ((l-len headerIv) == headerIvLength) *
     ((l-len headerAuthTag) == #tagLength) *
@@ -721,17 +721,17 @@ nounfold pred Header(rawHeaderData; definition, part_one, version, type,
                      errorMessage) :
   (* Complete header *)
   (definition == "Complete") *
-  CHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, edkDef) *
+  CHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, edkDef) *
   (errorMessage == ""),
 
   (* Incomplete header *)
   (definition == "Incomplete") *
-  IHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, edkDef) *
+  IHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, edkDef) *
   (errorMessage == ""),
 
   (* Broken header *)
   (definition == "Broken") *
-  BHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, #ECDef, edkDef, errorMessage);
+  BHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, #ECDef, edkDef, errorMessage);
 
 (*************************
  *************************

--- a/Gillian-C/examples/amazon/bugs/EncryptionHeaderLogic.gil
+++ b/Gillian-C/examples/amazon/bugs/EncryptionHeaderLogic.gil
@@ -236,8 +236,8 @@ lemma IElementsShift(buffer, readPos, eCount, fCount, shift)
       IElements(#rBuffer, #readPos i- #shift, #eCount, #fCount, #eList, #esLength) ]]
 
 
-nounfold pred Element(definition : Str, +buffer : List, +readPos : Int,
-                      +fCount : Int, fList : List, eLength : Int) :
+nounfold pred Element(+buffer : List, +readPos : Int, +fCount : Int,
+                      definition : Str, fList : List, eLength : Int) :
   (definition == "Complete") *
     CElement(buffer, readPos, fCount, fList, eLength),
   (definition == "Incomplete") *
@@ -255,18 +255,18 @@ nounfold pred Element(definition : Str, +buffer : List, +readPos : Int,
 
 (* A general element sequene is either a complete or an incomplete element sequence *)
 @nopath
-nounfold pred Elements(definition : Str, +buffer : List, +readPos : Int,
-                       +eCount : Int, +fCount : Int, eList : List,
+nounfold pred Elements(+buffer : List, +readPos : Int, +eCount : Int,
+                       +fCount : Int, definition : Str, eList : List,
                        esLength : Int) :
   (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
   (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
   facts: (0i i<=# readPos) and (readPos i<=# (l-len buffer)) and (0i i<=# eCount) and (0i i<# fCount) and (0i i<=# esLength);
 
 lemma ElementsShift(buffer, readPos, eCount, fCount, shift)
-  [[  Elements(#definition, #buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
+  [[  Elements(#buffer, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
       (0i i<=# (#readPos i- #shift)) ]]
   [[  (#rBuffer == l-sub(#buffer, #shift, ((l-len #buffer) i- #shift))) *
-      Elements(#definition, #rBuffer, #readPos i- #shift, #eCount, #fCount, #eList, #esLength) ]]
+      Elements(#rBuffer, #readPos i- #shift, #eCount, #fCount, #definition, #eList, #esLength) ]]
 
 (*****************************
  *****************************
@@ -294,7 +294,7 @@ nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Int,
     (0i i<=# readPos) * (readPos i<=# (l-len buffer)) *
     (#rawEC == l-sub(buffer, readPos, 2i)) *
     rawToUInt16(#rawEC, false, #keyCount) * (0i i<# #keyCount) *
-    Elements("Complete", buffer, (readPos i+ 2i), #keyCount, 3i, EDKs, #EDKsLength) *
+    Elements(buffer, (readPos i+ 2i), #keyCount, 3i, "Complete", EDKs, #EDKsLength) *
     (0i i<# #EDKsLength) * (* This can be derived... *)
     (EDKsLength == (#EDKsLength i+ 2i));
 
@@ -307,11 +307,11 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Int) :
     (* Enough data to read the number of EDKs, but not enough data to read the EDKs *)
   (0i i<=# readPos) * ((readPos i+ 2i) i<=# (l-len buffer)) * (#rawEC == l-sub(buffer, readPos, 2i)) *
     rawToUInt16(#rawEC, false, #keyCount) * (0i i<# #keyCount) *
-    Elements("Incomplete", buffer, (readPos i+ 2i), #keyCount, 3i, #eList, #esLength);
+    Elements(buffer, (readPos i+ 2i), #keyCount, 3i, "Incomplete", #eList, #esLength);
 
 (* Broken serialised EDKs *)
 @nopath
-nounfold pred BRawEncryptedDataKeys(errorMessage : Str, +buffer : List, +readPos : Int, EDKs : List, EDKsLength : Int) :
+nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Int, errorMessage : Str, EDKs : List, EDKsLength : Int) :
     (* Incorrect starting position *)
     ((readPos i<# 0i) \/ ((l-len buffer) i<# readPos)) *
     (errorMessage == "deserializeMessageHeader: startPos out of bounds.") *
@@ -325,10 +325,10 @@ nounfold pred BRawEncryptedDataKeys(errorMessage : Str, +buffer : List, +readPos
 
 (* General serialised EDKs *)
 @nopath
-nounfold pred RawEncryptedDataKeys(definition : Str, +buffer : List, +readPos : Int, EDKs : List, EDKsLength : Int, errorMessage : Str) :
+nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Int, definition : Str, EDKs : List, EDKsLength : Int, errorMessage : Str) :
   (definition == "Complete")   * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
   (definition == "Incomplete") * (errorMessage == "") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0i),
-  (definition == "Broken") * BRawEncryptedDataKeys(errorMessage, buffer, readPos, EDKs, EDKsLength);
+  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage, EDKs, EDKsLength);
 
 
 (******************************
@@ -355,17 +355,17 @@ nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
   (* ((l-len buffer) == 0i) * (ECKs == {{  }}), *)
   (0i i<# l-len buffer) * (#rawKC == l-sub(buffer, 0i, 2i)) *
     rawToUInt16(#rawKC, false, #keyCount) * (0i i<# #keyCount) *
-    Elements("Complete", buffer, 2i, #keyCount, 2i, ECKs, #ECKsLength) *
+    Elements(buffer, 2i, #keyCount, 2i, "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) *
     Unique(#ECKeys) * ((2i i+ #ECKsLength) == (l-len buffer));
 
 (* Broken serialised encryption context *)
-pure nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:List) :
+pure nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
     rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
     (0i i<# #keyCount) * (ECKs == {{ }}) *
-    Elements("Incomplete", buffer, 2i, #keyCount, 2i, #eList, #esLength) *
+    Elements(buffer, 2i, #keyCount, 2i, "Incomplete", #eList, #esLength) *
     toUtf8PairMap(#eList, #utf8EList) * FirstProj(#eList, #keys) *
     Unique(#keys) *
     (errorMessage == "decodeEncryptionContext: Underflow, not enough data."),
@@ -382,7 +382,7 @@ pure nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:Li
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
     rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
     (0i i<# #keyCount) *
-    Elements("Complete", buffer, 2i, #keyCount, 2i, ECKs, #ECKsLength) *
+    Elements(buffer, 2i, #keyCount, 2i, "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Unique(#ECKeys) *
     (! (#ECKsLength i+ 2i == l-len buffer)) *
     (errorMessage == "decodeEncryptionContext: Overflow, too much data."),
@@ -391,15 +391,15 @@ pure nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:Li
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
     rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
     (0i i<# #keyCount) *
-    Elements("Complete", buffer, 2i, #keyCount, 2i, ECKs, #ECKsLength) *
+    Elements(buffer, 2i, #keyCount, 2i, "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Duplicated({{ }}, #ECKeys) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
 (* General serialised encryption context *)
 @nopath
-pure nounfold pred RawEncryptionContext(definition:Str, +buffer:List, ECKs:List, errorMessage:Str) :
+pure nounfold pred RawEncryptionContext(+buffer:List, definition:Str, ECKs:List, errorMessage:Str) :
   (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
-  (definition == "Broken")   * BRawEncryptionContext(errorMessage, buffer, ECKs);
+  (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
 
 (****************************
 *****************************
@@ -526,7 +526,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (0i i<# ECLength) *
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) * (ECDef == "Broken") * (edkDef == "") *
-    BRawEncryptionContext(errorMessage, #EC, ECKs) *
+    BRawEncryptionContext(#EC, errorMessage, ECKs) *
 
     (EDKs == {{ }}) * (contentType == 0i) * (frameLength == 0i) *
     (headerLength == 0i) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -548,7 +548,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) * (ECDef == "") * (edkDef == "Broken") *
-    RawEncryptedDataKeys("Broken", rawHeaderData, 22i i+ ECLength, EDKs, EDKsLength, errorMessage) *
+    RawEncryptedDataKeys(rawHeaderData, 22i i+ ECLength, "Broken", EDKs, EDKsLength, errorMessage) *
 
     (contentType == 0i) * (frameLength == 0i) *
     (headerLength == 0i) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -571,7 +571,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, #rest)) *
-    RawEncryptedDataKeys("Complete", part_three, 0i, EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     BContentType(contentType) *
 
@@ -597,7 +597,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     CRawEncryptionContext(#EC, ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, #rawReservedBytes, #rest)) *
     CContentType(contentType) *
-    RawEncryptedDataKeys("Complete", part_three, 0i, EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (l-len #rawReservedBytes == 4i) *
     rawToUInt32(#rawReservedBytes, false, #reservedBytes) *
@@ -625,7 +625,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     CRawEncryptionContext(#EC, ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }}, {{ headerIvLength }}, #rest)) *
     CContentType(contentType) *
-    RawEncryptedDataKeys("Complete", part_three, 0i, EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (! (headerIvLength == #ivLength)) *
 
@@ -714,7 +714,7 @@ nounfold pred CHeader(+rawHeaderData, part_one, version, type, suiteId,
 
 
 (* General serialised header *)
-nounfold pred Header(definition, +rawHeaderData, part_one, version, type,
+nounfold pred Header(+rawHeaderData, definition, part_one, version, type,
                      suiteId, messageId, ECLength, part_two, ECKs,
                      part_three, EDKs, contentType, headerIvLength,
                      frameLength, headerLength, headerIv, headerAuthTag, edkDef,

--- a/Gillian-C/examples/amazon/bugs/EncryptionHeaderLogic.gil
+++ b/Gillian-C/examples/amazon/bugs/EncryptionHeaderLogic.gil
@@ -14,7 +14,7 @@
     ----------------||----|----|---- ... ----||----------------
                 readPos
 *)
-pred Field(+buffer : List, +readPos : Int, field : List, length : Int) :
+pred Field(buffer : List, readPos : Int; field : List, length : Int) :
     (0i i<=# readPos) * (#rawFL == l-sub(buffer, readPos, 2i)) *
     rawToUInt16(#rawFL, false, #fieldLength) *
     (field == l-sub(buffer, (readPos i+ 2i), #fieldLength)) *
@@ -64,7 +64,7 @@ pred Field(+buffer : List, +readPos : Int, field : List, length : Int) :
                 readPos
 *)
 @nopath
-pred IElement(+buffer : List, +readPos : Int, +fCount : Int, fList : List, eLength : Int) :
+pred IElement(buffer : List, readPos : Int, fCount : Int; fList : List, eLength : Int) :
   (* Base case: not enough data to read length of next field *)
   (0i i<=# readPos) * (0i i<# fCount) * (readPos i<=# (l-len buffer)) *
     ((l-len buffer) i<# (readPos i+ 2i)) * (fList == {{  }}) *
@@ -123,7 +123,7 @@ pred IElement(+buffer : List, +readPos : Int, +fCount : Int, fList : List, eLeng
                 readPos
 *)
 @nopath
-pred IElements(+buffer : List, +readPos : Int, +eCount : Int, +fCount : Int,
+pred IElements(buffer : List, readPos : Int, eCount : Int, fCount : Int;
                eList : List, esLength : Int) :
   (* Base case: single incomplete element *)
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) * (0i i<# eCount) * (0i i<# fCount) *
@@ -159,7 +159,7 @@ pred IElements(+buffer : List, +readPos : Int, +eCount : Int, +fCount : Int,
                 readPos
 *)
 @nopath
-pred CElement(+buffer : List, +readPos : Int, +fCount : Int, element : List, length : Int) :
+pred CElement(buffer : List, readPos : Int, fCount : Int; element : List, length : Int) :
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) *
     (fCount == 0i) * (element == {{  }}) * (length == 0i),
   (0i i<# fCount) * Field(buffer, readPos, #field, #fLength) * ((typeOf #field) == List) *
@@ -193,7 +193,7 @@ pred CElement(+buffer : List, +readPos : Int, +fCount : Int, element : List, len
     ----------------||-------| ... |-------||----------------
                  readPos
 *)
-pred CElements(+buffer : List, +readPos : Int, +eCount : Int, +fCount : Int,
+pred CElements(buffer : List, readPos : Int, eCount : Int, fCount : Int;
                elements : List, length : Int) :
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) * (eCount == 0i) *
     (0i i<# fCount) * (elements == {{  }}) * (length == 0i),
@@ -236,7 +236,7 @@ lemma IElementsShift(buffer, readPos, eCount, fCount, shift)
       IElements(#rBuffer, #readPos i- #shift, #eCount, #fCount, #eList, #esLength) ]]
 
 
-nounfold pred Element(+buffer : List, +readPos : Int, +fCount : Int,
+nounfold pred Element(buffer : List, readPos : Int, fCount : Int;
                       definition : Str, fList : List, eLength : Int) :
   (definition == "Complete") *
     CElement(buffer, readPos, fCount, fList, eLength),
@@ -255,8 +255,8 @@ nounfold pred Element(+buffer : List, +readPos : Int, +fCount : Int,
 
 (* A general element sequene is either a complete or an incomplete element sequence *)
 @nopath
-nounfold pred Elements(+buffer : List, +readPos : Int, +eCount : Int,
-                       +fCount : Int, definition : Str, eList : List,
+nounfold pred Elements(buffer : List, readPos : Int, eCount : Int,
+                       fCount : Int; definition : Str, eList : List,
                        esLength : Int) :
   (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
   (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
@@ -289,7 +289,7 @@ lemma ElementsShift(buffer, readPos, eCount, fCount, shift)
 
 (* Complete serialised EDKs *)
 @nopath
-nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Int,
+nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Int;
                                     EDKs : List, EDKsLength : Int) :
     (0i i<=# readPos) * (readPos i<=# (l-len buffer)) *
     (#rawEC == l-sub(buffer, readPos, 2i)) *
@@ -300,7 +300,7 @@ nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Int,
 
 (* Incomplete serialised EDKs *)
 @nopath
-nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Int) :
+nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Int;) :
   (* Not enough data to read the number of EDKs *)
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) * ((l-len buffer) i<# (readPos i+ 2i)),
 
@@ -311,7 +311,7 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Int) :
 
 (* Broken serialised EDKs *)
 @nopath
-nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Int, errorMessage : Str, EDKs : List, EDKsLength : Int) :
+nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Int; errorMessage : Str, EDKs : List, EDKsLength : Int) :
     (* Incorrect starting position *)
     ((readPos i<# 0i) \/ ((l-len buffer) i<# readPos)) *
     (errorMessage == "deserializeMessageHeader: startPos out of bounds.") *
@@ -325,7 +325,7 @@ nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Int, errorMessage
 
 (* General serialised EDKs *)
 @nopath
-nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Int, definition : Str, EDKs : List, EDKsLength : Int, errorMessage : Str) :
+nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Int; definition : Str, EDKs : List, EDKsLength : Int, errorMessage : Str) :
   (definition == "Complete")   * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
   (definition == "Incomplete") * (errorMessage == "") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0i),
   (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage, EDKs, EDKsLength);
@@ -351,7 +351,7 @@ nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Int, definition : 
 
 (* Complete serialised encryption context *)
 @nopath
-nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
+nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
   (* ((l-len buffer) == 0i) * (ECKs == {{  }}), *)
   (0i i<# l-len buffer) * (#rawKC == l-sub(buffer, 0i, 2i)) *
     rawToUInt16(#rawKC, false, #keyCount) * (0i i<# #keyCount) *
@@ -360,7 +360,7 @@ nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
     Unique(#ECKeys) * ((2i i+ #ECKsLength) == (l-len buffer));
 
 (* Broken serialised encryption context *)
-pure nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:List) :
+pure nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
     rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
@@ -397,7 +397,7 @@ pure nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:Li
 
 (* General serialised encryption context *)
 @nopath
-pure nounfold pred RawEncryptionContext(+buffer:List, definition:Str, ECKs:List, errorMessage:Str) :
+pure nounfold pred RawEncryptionContext(buffer:List; definition:Str, ECKs:List, errorMessage:Str) :
   (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
   (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
 
@@ -412,7 +412,7 @@ pure nounfold pred RawEncryptionContext(+buffer:List, definition:Str, ECKs:List,
 
 (* Correctly formed algorithm suite *)
 @nopath
-nounfold pred CAlgorithmSuite(+numId, stringId, ivLength, tagLength) :
+nounfold pred CAlgorithmSuite(numId; stringId, ivLength, tagLength) :
   (numId == 20i)   * (stringId == "ALG_AES128_GCM_IV12_TAG16_NO_KDF")                 * (ivLength == 12i) * (tagLength == 16i),
   (numId == 70i)   * (stringId == "ALG_AES192_GCM_IV12_TAG16_NO_KDF")                 * (ivLength == 12i) * (tagLength == 16i),
   (numId == 120i)  * (stringId == "ALG_AES256_GCM_IV12_TAG16_NO_KDF")                 * (ivLength == 12i) * (tagLength == 16i),
@@ -429,7 +429,7 @@ facts: (ivLength == 12i) and (tagLength == 16i);
 
 (* Broken algorithm suite *)
 @nopath
-pred BAlgorithmSuite(+numId, errorMessage) :
+pred BAlgorithmSuite(numId; errorMessage) :
   (! (numId == 20i)) * (! (numId == 70i)) * (! (numId == 120i)) * (! (numId == 276i)) * (! (numId == 326i)) * (! (numId == 376i)) *
   (! (numId == 532i)) * (! (numId == 838i)) * (! (numId == 888i)) * (! (numId == 1144i)) * (! (numId == 1400i)) *
   (errorMessage == "Malformed Header: Unsupported algorithm suite.");
@@ -445,19 +445,19 @@ pred BAlgorithmSuite(+numId, errorMessage) :
 
 (* Correctly formed algorithm suite *)
 @nopath
-pred CContentType(+contentType: Int) :
+pred CContentType(contentType: Int;) :
   (contentType == 1i) \/ (contentType == 2i);
 
 (* Broken algorithm suite *)
 @nopath
-pred BContentType(+contentType) :
+pred BContentType(contentType;) :
   (! (contentType == 1i)) * (! (contentType == 2i));
 
 (* If type is NONFRAMED (i.e. = 1i), frame_len has to be 0i, otherwise, if type is FRAMED (i.e = 2i), frame_len has to be > 0i *)
-pred CompatibleContentTypeAndFrameLength(+contentType: Int, +frameLength: Int):
+pred CompatibleContentTypeAndFrameLength(contentType: Int, frameLength: Int;):
   ((contentType == 1i) /\ (frameLength == 0i)) \/ ((contentType == 2i) /\ (0i i<# frameLength));
 
-pred IncompatibleContentTypeAndFrameLength(+contentType, +frameLength):
+pred IncompatibleContentTypeAndFrameLength(contentType, frameLength;):
   ((contentType == 1i) /\ (0i i<# frameLength)) \/ ((contentType == 2i) /\ (frameLength == 0i));
 
 
@@ -472,18 +472,18 @@ pred IncompatibleContentTypeAndFrameLength(+contentType, +frameLength):
 
 (* The correct version and type *)
 @nopath
-pred CVersionAndType(version, type) :
+pred CVersionAndType(version, type;) :
   (version == 1i) * (type == 128i);
 
 (* Broken version and type *)
-nounfold pred BVersionAndType(+version:Int, +type:Int, errorMessage:Str) :
+nounfold pred BVersionAndType(version:Int, type:Int; errorMessage:Str) :
     (version == 65i) * (type == 89i) * (errorMessage == "Malformed Header: This blob may be base64 encoded."),
     (! (version == 1i) \/ ! (type == 128i)) * (! (version == 65i) \/ ! (type == 89i)) * (errorMessage == "Malformed Header: Unsupported version and/or type.");
 
 
 
 (* Broken serialised header *)
-nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageId, ECLength,
+nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength,
                                       part_two, ECKs,
                                       part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, ECDef, edkDef, errorMessage) :
     (* Incorrect version and/or type *)
@@ -657,7 +657,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
 
 
 (* Serialised incomplete header *)
-nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageId, ECLength,
+nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength,
                                       part_two, ECKs,
                                       part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, edkDef) :
 
@@ -681,7 +681,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
 
 (* Serialised complete header *)
 @nopath
-nounfold pred CHeader(+rawHeaderData, part_one, version, type, suiteId,
+nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
                       messageId, ECLength, part_two, ECKs, part_three, EDKs,
                       contentType, headerIvLength, frameLength, headerLength,
                       headerIv, headerAuthTag, edkDef) :
@@ -714,7 +714,7 @@ nounfold pred CHeader(+rawHeaderData, part_one, version, type, suiteId,
 
 
 (* General serialised header *)
-nounfold pred Header(+rawHeaderData, definition, part_one, version, type,
+nounfold pred Header(rawHeaderData; definition, part_one, version, type,
                      suiteId, messageId, ECLength, part_two, ECKs,
                      part_three, EDKs, contentType, headerIvLength,
                      frameLength, headerLength, headerIv, headerAuthTag, edkDef,

--- a/Gillian-C/examples/amazon/bugs/base.c
+++ b/Gillian-C/examples/amazon/bugs/base.c
@@ -36,11 +36,11 @@
 
     lemma optBytesConcat(lptr, llength, rptr, rlength) {
         hypothesis:
-            optBytes(#lptr, #llength, #lcont) * optBytes(#rptr, #rlength, #rcont) *
+            optBytes(#lptr, #llength; #lcont) * optBytes(#rptr, #rlength; #rcont) *
             (#rptr == #lptr p+ #llength)
 
         conclusions:
-            optBytes(#lptr, #llength + #rlength, #lcont @ #rcont)
+            optBytes(#lptr, #llength + #rlength; #lcont @ #rcont)
 
         proof:
             unfold optBytes(#lptr, #llength, #lcont);

--- a/Gillian-C/examples/amazon/bugs/base.c
+++ b/Gillian-C/examples/amazon/bugs/base.c
@@ -14,22 +14,22 @@
     Our predicate describes the valid case.
 */
 /*@
-    pred aws_add_u64_checked(+a, +b, out) {
+    pred aws_add_u64_checked(a, b; out) {
         (out == (a + b)) *
         (out <# 18446744073709551615)
     }
 
-    pred aws_mul_u64_checked(+a, +b, out) {
+    pred aws_mul_u64_checked(a, b; out) {
         (out == (a * b)) *
         (out <# 18446744073709551615)
     }
 
-    pred nounfold writable_memory(+pointer, +length, content) {
+    pred nounfold writable_memory(pointer, length; content) {
         (length == 0) * (content == []);
         (0 <# length) * ARRAY(pointer, char, length, content)
     }
 
-    pred nounfold optBytes(+bytes, +length, content) {
+    pred nounfold optBytes(bytes, length; content) {
         (length == 0) * (content == nil);
         (0 <# length) * ARRAY(bytes, char, length, content)
     }

--- a/Gillian-C/examples/amazon/bugs/byte_buf.c
+++ b/Gillian-C/examples/amazon/bugs/byte_buf.c
@@ -26,15 +26,15 @@ pred nounfold valid_aws_byte_cursor_ptr(cur; length, buffer: List, alpha) {
 spec aws_byte_cursor_advance(_res, cursor, length) {
   requires: (_res == #res) * (cursor == #cursor) * (length == long(#length)) *
             (0 <=# #length) * ARRAY(#res, long, 2, #trash) *
-            valid_aws_byte_cursor_ptr(#cursor, #cur_len, #buffer, #content)
+            valid_aws_byte_cursor_ptr(#cursor; #cur_len, #buffer, #content)
 
-  ensures: invalid_read(#length, #cur_len) *
-           valid_aws_byte_cursor_ptr(#res, 0, NULL, nil) *
-           valid_aws_byte_cursor_ptr(#cursor, #cur_len, #buffer, #content);
+  ensures: invalid_read(#length, #cur_len;) *
+           valid_aws_byte_cursor_ptr(#res; 0, NULL, nil) *
+           valid_aws_byte_cursor_ptr(#cursor; #cur_len, #buffer, #content);
 
-           valid_read(#length, #cur_len) *
-           valid_aws_byte_cursor_ptr(#res, #length, #buffer, #data) *
-           valid_aws_byte_cursor_ptr(#cursor, #rest_len,
+           valid_read(#length, #cur_len;) *
+           valid_aws_byte_cursor_ptr(#res; #length, #buffer, #data) *
+           valid_aws_byte_cursor_ptr(#cursor; #rest_len,
                                      #buffer p+ #length, #rest) *
            (#length == len #data) *
            (#content == #data @ #rest) *

--- a/Gillian-C/examples/amazon/bugs/byte_buf.c
+++ b/Gillian-C/examples/amazon/bugs/byte_buf.c
@@ -2,19 +2,19 @@
 
 /*@
 
-pure pred invalid_read(read_len, cursor_len) {
+pure pred invalid_read(read_len, cursor_len;) {
   cursor_len <# read_len;
   2147483647 <# read_len;
   2147483647 <# cursor_len
 }
 
-pure pred valid_read(read_len, cursor_len) {
+pure pred valid_read(read_len, cursor_len;) {
   (read_len <=# cursor_len) *
   (read_len <=# 2147483647) *
   (cursor_len <=# 2147483647)
 }
 
-pred nounfold valid_aws_byte_cursor_ptr(+cur, length, buffer: List, alpha) {
+pred nounfold valid_aws_byte_cursor_ptr(cur; length, buffer: List, alpha) {
   (cur -> struct aws_byte_cursor { long(0); buffer }) *
   (length == 0) * (alpha == nil);
 

--- a/Gillian-C/examples/amazon/bugs/byte_buf.c
+++ b/Gillian-C/examples/amazon/bugs/byte_buf.c
@@ -2,13 +2,13 @@
 
 /*@
 
-pure pred invalid_read(read_len, cursor_len;) {
+pure pred invalid_read(read_len, cursor_len) {
   cursor_len <# read_len;
   2147483647 <# read_len;
   2147483647 <# cursor_len
 }
 
-pure pred valid_read(read_len, cursor_len;) {
+pure pred valid_read(read_len, cursor_len) {
   (read_len <=# cursor_len) *
   (read_len <=# 2147483647) *
   (cursor_len <=# 2147483647)
@@ -28,11 +28,11 @@ spec aws_byte_cursor_advance(_res, cursor, length) {
             (0 <=# #length) * ARRAY(#res, long, 2, #trash) *
             valid_aws_byte_cursor_ptr(#cursor; #cur_len, #buffer, #content)
 
-  ensures: invalid_read(#length, #cur_len;) *
+  ensures: invalid_read(#length, #cur_len) *
            valid_aws_byte_cursor_ptr(#res; 0, NULL, nil) *
            valid_aws_byte_cursor_ptr(#cursor; #cur_len, #buffer, #content);
 
-           valid_read(#length, #cur_len;) *
+           valid_read(#length, #cur_len) *
            valid_aws_byte_cursor_ptr(#res; #length, #buffer, #data) *
            valid_aws_byte_cursor_ptr(#cursor; #rest_len,
                                      #buffer p+ #length, #rest) *

--- a/Gillian-C/examples/amazon/bugs/header.c
+++ b/Gillian-C/examples/amazon/bugs/header.c
@@ -23,7 +23,7 @@
 
 // Optional value or null
 /*@
-pred or_NULL(x, x_opt;) {
+pred or_NULL(x, x_opt) {
     x_opt == x;
     x_opt == NULL
 }
@@ -44,8 +44,8 @@ pred nounfold any_valid_aws_cryptosdk_hdr(hdr; allocator) {
     #auth_len
   }) *
   (not (allocator == NULL)) *
-  valid_aws_byte_buf_fields(#iv; #len_iv, #cap_iv, #buf_iv, #iv_alloc, #content_iv) * or_NULL(allocator, #iv_alloc;) *
-  valid_aws_byte_buf_fields(#auth_tag; #len_auth_tag, #cap_auth_tag, #buf_auth_tag, #auth_tag_alloc, #content_auth_tag) * or_NULL(allocator, #auth_tag_alloc;) *
+  valid_aws_byte_buf_fields(#iv; #len_iv, #cap_iv, #buf_iv, #iv_alloc, #content_iv) * or_NULL(allocator, #iv_alloc) *
+  valid_aws_byte_buf_fields(#auth_tag; #len_auth_tag, #cap_auth_tag, #buf_auth_tag, #auth_tag_alloc, #content_auth_tag) * or_NULL(allocator, #auth_tag_alloc) *
   valid_hash_table_fields(#enc_ctx; allocator, #ctx_content, #ctx_content_utf8) *
   valid_edk_array_list_fields(#edk_list; allocator, #edk_content)
 }
@@ -66,8 +66,8 @@ pred nounfold empty_aws_cryptosdk_hdr(hdr; allocator) {
     long(0)
   }) *
   (not (allocator == NULL)) *
-  empty_aws_byte_buf_fields(#iv;) *
-  empty_aws_byte_buf_fields(#auth_tag;) *
+  empty_aws_byte_buf_fields(#iv) *
+  empty_aws_byte_buf_fields(#auth_tag) *
   empty_hash_table_fields(#enc_ctx; allocator) *
   empty_edk_array_list_fields(#edk_list; allocator)
 }
@@ -107,8 +107,8 @@ pred nounfold header_struct(hdr; allocator, alg_id, message_id, enc_ctx_content,
             (content_type == int(#ct))
 
         ensures:
-            CContentType(#ct;) * (ret == TRUE);
-            BContentType(#ct;) * (ret == FALSE)
+            CContentType(#ct) * (ret == TRUE);
+            BContentType(#ct) * (ret == FALSE)
     }
 */
 int is_known_type(uint8_t content_type) {
@@ -242,11 +242,11 @@ int aws_cryptosdk_algorithm_taglen(uint16_t alg_id) {
         requires:
             (hdr == #hdr) *
             any_valid_aws_cryptosdk_hdr(#hdr; #alloc) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
 
         ensures:
             empty_aws_cryptosdk_hdr(#hdr; #alloc) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
     }
 */
 void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
@@ -277,11 +277,11 @@ void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
     spec parse_edk(allocator, edk, cur) {
         requires:
             (allocator == #alloc) * (edk == #edk) * (cur == #cur) *
-            default_allocator(#alloc;) *
+            default_allocator(#alloc) *
             Element(#content, 0, 3; #definition, #edk_content, #element_length) *
             valid_aws_byte_cursor_ptr(#cur; #total_length, #buffer, #content) *
             (not (#buffer == NULL)) *
-            any_aws_last_error(;) *
+            any_aws_last_error() *
             ARRAY(#edk, long, 12, #trash) *
 
             (#content == #edk_raw_content @ #rest) *
@@ -289,24 +289,24 @@ void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
             (len #rest == #total_length - #element_length)
 
         ensures:
-            default_allocator(#alloc;) *
+            default_allocator(#alloc) *
             (#definition == `Complete`) *
             valid_aws_byte_cursor_ptr(#cur; #total_length - #element_length, #buffer p+ #element_length, #rest) *
             valid_aws_cryptosdk_edk_ptr(#edk; #alloc, #edk_content) *
             ARRAY(#buffer, char, #element_length, #edk_raw_content) *
-            any_aws_last_error(;) *
+            any_aws_last_error() *
             (ret == int(0));
 
-            default_allocator(#alloc;) *
+            default_allocator(#alloc) *
             (#definition == `Incomplete`) *
             valid_aws_byte_cursor_ptr(#cur; #left_length, #new_buffer, #restAfterConsuming) *
             (0 <=# #consumed_length) *
             (#consumed_length == #total_length - #left_length) *
             (#new_buffer == #buffer p+ #consumed_length) *
-            empty_aws_cryptosdk_edk_ptr(#edk;) *
+            empty_aws_cryptosdk_edk_ptr(#edk) *
             optBytes(#buffer, #consumed_length; #consumed_data) *
             (#content == #consumed_data @ #restAfterConsuming) *
-            aws_last_error_is_SHORT_BUF(;) *
+            aws_last_error_is_SHORT_BUF() *
             (ret == int(-1))
 }
 */
@@ -405,8 +405,8 @@ MEM_ERR:
             (#length == len #data) *
             (#length <# 2147483647) *
             any_valid_aws_cryptosdk_hdr(#hdr; #alloc) *
-            default_allocator(#alloc;) *
-            any_aws_last_error(;) *
+            default_allocator(#alloc) *
+            any_aws_last_error() *
             (#definition == `Incomplete`)
 
         ensures:
@@ -414,22 +414,22 @@ MEM_ERR:
             ARRAY(#buffer, char, #length, #data) *
             valid_aws_byte_cursor_ptr(#pcursor; 0, #end_buffer, []) *
             header_struct(#hdr; #alloc, #suiteId, #messageId, #ECKs, #EDKs, #frameLength, #headerLength, #headerIv, #headerAuthTag) *
-            default_allocator(#alloc;) *
-            any_aws_last_error(;) *
+            default_allocator(#alloc) *
+            any_aws_last_error() *
             (ret == int(0));
 
             (#definition == `Incomplete`) *
             valid_aws_byte_cursor_ptr(#pcursor; #length, #buffer, #data) *
             empty_aws_cryptosdk_hdr(#hdr; #alloc) *
-            default_allocator(#alloc;) *
-            aws_last_error_is_SHORT_BUF(;) *
+            default_allocator(#alloc) *
+            aws_last_error_is_SHORT_BUF() *
             (ret == int(-1));
 
             (#definition == `Broken`) *
             valid_aws_byte_cursor_ptr(#pcursor; #length, #buffer, #data) *
             empty_aws_cryptosdk_hdr(#hdr; #alloc) *
-            default_allocator(#alloc;) *
-            aws_last_error_is_BAD_CIPHERTEXT(;) *
+            default_allocator(#alloc) *
+            aws_last_error_is_BAD_CIPHERTEXT() *
             (ret == int(-1))
   }
 */
@@ -584,8 +584,8 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
         "invariant: \
             [[bind i, #i, #cbptr, #readLength, #readEDKs, #leftEDKs, #restEDKsAndRest, \
                    #acc, #rest_count, #restEDKs, #restEDKLength, #restLength, #trash]] \
-            any_aws_last_error(;) * \
-            (i == int(#i)) * default_allocator(#alloc;) * \
+            any_aws_last_error() * \
+            (i == int(#i)) * default_allocator(#alloc) * \
             (#hdr -> ptr(#all, #alo)) * (#alloc == ptr(#all, #alo)) * \
             optBytes(#bptr, #readLength; #readEDKs) * \
             (#readLength == len #readEDKs) * \

--- a/Gillian-C/examples/amazon/bugs/header.c
+++ b/Gillian-C/examples/amazon/bugs/header.c
@@ -278,7 +278,7 @@ void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
         requires:
             (allocator == #alloc) * (edk == #edk) * (cur == #cur) *
             default_allocator(#alloc) *
-            Element(#definition, #content, 0, 3, #edk_content, #element_length) *
+            Element(#content, 0, 3, #definition, #edk_content, #element_length) *
             valid_aws_byte_cursor_ptr(#cur, #total_length, #buffer, #content) *
             (not (#buffer == NULL)) *
             any_aws_last_error() *
@@ -318,7 +318,7 @@ int parse_edk(struct aws_allocator *allocator, struct aws_cryptosdk_edk *edk,
     memset(edk, 0, sizeof(*edk));
 
     GILLIAN("apply valid_aws_byte_cursor_ptr_facts(#cur, #total_length, #buffer, #content)");
-    GILLIAN("unfold Element(#definition, #content, 0, 3, #edk_content, #element_length)");
+    GILLIAN("unfold Element(#content, 0, 3, #definition, #edk_content, #element_length)");
     GILLIAN(
         "if (#definition = `Complete`) { \
             unfold CElement(#content, 0, 3, #edk_content, #element_length) \
@@ -399,7 +399,7 @@ MEM_ERR:
         requires:
             (hdr == #hdr) * (pcursor == #pcursor) *
             valid_aws_byte_cursor_ptr(#pcursor, #length, #buffer, #data) *
-            Header(#definition, #data, #part_one, #version, #type, #suiteId, #messageId,
+            Header(#data, #definition, #part_one, #version, #type, #suiteId, #messageId,
                    #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength,
                    #frameLength, #headerLength, #headerIv, #headerAuthTag, #edkDef, #errorMessage) *
             (#length == len #data) *
@@ -437,7 +437,7 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
                             struct aws_byte_cursor *pcursor) {
 
     GILLIAN(
-        "unfold Header(#definition, #data, #part_one, #version, #type, \
+        "unfold Header(#data, #definition, #part_one, #version, #type, \
             #suiteId, #messageId, #ECLength, #part_two, #ECKs, \
             #part_three, #EDKs, #contentType, #headerIvLength, \
             #frameLength, #headerLength, #headerIv, #headerAuthTag, #edkDef, #errorMessage) \
@@ -511,7 +511,7 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
 
     GILLIAN("unfold_all Elements");
     if (aad_len) {
-        GILLIAN("if (#definition = `Broken`) { if (#ECDef = `Broken`) { unfold BRawEncryptionContext(#errorMessage, #BEC, #ECKs) } }");
+        GILLIAN("if (#definition = `Broken`) { if (#ECDef = `Broken`) { unfold BRawEncryptionContext(#BEC, #errorMessage, #ECKs) } }");
         struct aws_byte_cursor aad = aws_byte_cursor_advance(&cur, aad_len);
         // Note that, even if this fails with SHORT_BUF, we report a parse
         // error, since we know we have enough data (according to the aad
@@ -593,7 +593,7 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
             valid_aws_byte_cursor_ptr(#cur, #restLength, #cbptr, #restEDKsAndRest) * \
             valid_edk_array_list_ptr(#edk_al, #alloc, #acc) * \
             (len #acc == #i) * (#eList == #acc @ #restEDKs) * \
-            Elements(#edkDef, #restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength) * \
+            Elements(#restEDKsAndRest, 0, #rest_count, 3, #edkDef, #restEDKs, #restEDKLength) * \
             (#restLength == len #restEDKsAndRest) * \
             (#rest_count == (#edk_count - #i)) * \
             (#restLength == (#atEDKs - #readLength)) * \
@@ -610,7 +610,7 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
 
         GILLIAN("unfold_all i__ptr");
         GILLIAN("unfold_all i__ptr_add");
-        GILLIAN("unfold Elements(#edkDef, #restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength)");
+        GILLIAN("unfold Elements(#restEDKsAndRest, 0, #rest_count, 3, #edkDef, #restEDKs, #restEDKLength)");
         GILLIAN(
             "if (#edkDef = `Complete`) { \
                 unfold CElements(#restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength) \
@@ -645,12 +645,12 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
     GILLIAN("assert (len #acc == #edk_count)");
     GILLIAN(
         "if (#edkDef = `Incomplete`) { \
-            unfold Elements(#edkDef, #restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength); \
+            unfold Elements(#restEDKsAndRest, 0, #rest_count, 3, #edkDef, #restEDKs, #restEDKLength); \
             unfold IElements(#restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength) \
         }");
     GILLIAN("assert (len #restEDKs == 0) ");
     GILLIAN("assert (#rest_count == 0) * (#EDKs == #acc) ");
-    GILLIAN("unfold Elements(#edkDef, #restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength)");
+    GILLIAN("unfold Elements(#restEDKsAndRest, 0, #rest_count, 3, #edkDef, #restEDKs, #restEDKLength)");
     GILLIAN("unfold CElements(#restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength)");
     GILLIAN("assert (len #leftEDKs == 0)");
 

--- a/Gillian-C/examples/amazon/bugs/header.c
+++ b/Gillian-C/examples/amazon/bugs/header.c
@@ -44,10 +44,10 @@ pred nounfold any_valid_aws_cryptosdk_hdr(hdr; allocator) {
     #auth_len
   }) *
   (not (allocator == NULL)) *
-  valid_aws_byte_buf_fields(#iv, #len_iv, #cap_iv, #buf_iv, #iv_alloc, #content_iv) * or_NULL(allocator, #iv_alloc) *
-  valid_aws_byte_buf_fields(#auth_tag, #len_auth_tag, #cap_auth_tag, #buf_auth_tag, #auth_tag_alloc, #content_auth_tag) * or_NULL(allocator, #auth_tag_alloc) *
-  valid_hash_table_fields(#enc_ctx, allocator, #ctx_content, #ctx_content_utf8) *
-  valid_edk_array_list_fields(#edk_list, allocator, #edk_content)
+  valid_aws_byte_buf_fields(#iv; #len_iv, #cap_iv, #buf_iv, #iv_alloc, #content_iv) * or_NULL(allocator, #iv_alloc;) *
+  valid_aws_byte_buf_fields(#auth_tag; #len_auth_tag, #cap_auth_tag, #buf_auth_tag, #auth_tag_alloc, #content_auth_tag) * or_NULL(allocator, #auth_tag_alloc;) *
+  valid_hash_table_fields(#enc_ctx; allocator, #ctx_content, #ctx_content_utf8) *
+  valid_edk_array_list_fields(#edk_list; allocator, #edk_content)
 }
 */
 
@@ -66,10 +66,10 @@ pred nounfold empty_aws_cryptosdk_hdr(hdr; allocator) {
     long(0)
   }) *
   (not (allocator == NULL)) *
-  empty_aws_byte_buf_fields(#iv) *
-  empty_aws_byte_buf_fields(#auth_tag) *
-  empty_hash_table_fields(#enc_ctx, allocator) *
-  empty_edk_array_list_fields(#edk_list, allocator)
+  empty_aws_byte_buf_fields(#iv;) *
+  empty_aws_byte_buf_fields(#auth_tag;) *
+  empty_hash_table_fields(#enc_ctx; allocator) *
+  empty_edk_array_list_fields(#edk_list; allocator)
 }
 */
 
@@ -88,12 +88,12 @@ pred nounfold header_struct(hdr; allocator, alg_id, message_id, enc_ctx_content,
     long(auth_len)
   }) *
   (not (allocator == NULL)) *
-  valid_aws_byte_buf_fields(#iv, len iv, len iv, #iv_buf, allocator, iv) *
+  valid_aws_byte_buf_fields(#iv; len iv, len iv, #iv_buf, allocator, iv) *
   (0 <# len iv) * (not (#iv_buf == NULL)) *
-  valid_aws_byte_buf_fields(#auth_tag, len auth_tag, len auth_tag, #auth_buf, allocator, auth_tag) *
+  valid_aws_byte_buf_fields(#auth_tag; len auth_tag, len auth_tag, #auth_buf, allocator, auth_tag) *
   (0 <# len auth_tag) * (not (#auth_buf == NULL)) *
-  valid_hash_table_fields(#enc_ctx, allocator, enc_ctx_content, #enc_ctx_utf8) *
-  valid_edk_array_list_fields(#edk_list, allocator, edk_content)
+  valid_hash_table_fields(#enc_ctx; allocator, enc_ctx_content, #enc_ctx_utf8) *
+  valid_edk_array_list_fields(#edk_list; allocator, edk_content)
 }
 */
 
@@ -107,8 +107,8 @@ pred nounfold header_struct(hdr; allocator, alg_id, message_id, enc_ctx_content,
             (content_type == int(#ct))
 
         ensures:
-            CContentType(#ct) * (ret == TRUE);
-            BContentType(#ct) * (ret == FALSE)
+            CContentType(#ct;) * (ret == TRUE);
+            BContentType(#ct;) * (ret == FALSE)
     }
 */
 int is_known_type(uint8_t content_type) {
@@ -129,20 +129,20 @@ int is_known_type(uint8_t content_type) {
     spec aws_cryptosdk_algorithm_is_known(alg_id) {
         requires:
             (alg_id == int(#alg_id)) *
-            CAlgorithmSuite(#alg_id, #stringId, #ivLength, #tagLength)
+            CAlgorithmSuite(#alg_id; #stringId, #ivLength, #tagLength)
 
         ensures:
-            CAlgorithmSuite(#alg_id, #stringId, #ivLength, #tagLength) *
+            CAlgorithmSuite(#alg_id; #stringId, #ivLength, #tagLength) *
             (ret == TRUE)
 
     OR
 
         requires:
             (alg_id == int(#alg_id)) *
-            BAlgorithmSuite(#alg_id, #errorMessage)
+            BAlgorithmSuite(#alg_id; #errorMessage)
 
         ensures:
-            BAlgorithmSuite(#alg_id, #errorMessage) *
+            BAlgorithmSuite(#alg_id; #errorMessage) *
             (ret == FALSE)
     }
 */
@@ -173,20 +173,20 @@ int aws_cryptosdk_algorithm_is_known(uint16_t alg_id) {
     spec aws_cryptosdk_algorithm_ivlen(alg_id) {
         requires:
             (alg_id == int(#alg_id)) *
-            CAlgorithmSuite(#alg_id, #stringId, #ivLength, #tagLength)
+            CAlgorithmSuite(#alg_id; #stringId, #ivLength, #tagLength)
 
         ensures:
-            CAlgorithmSuite(#alg_id, #stringId, #ivLength, #tagLength) *
+            CAlgorithmSuite(#alg_id; #stringId, #ivLength, #tagLength) *
             (ret == int(#ivLength))
 
     OR
 
         requires:
             (alg_id == int(#alg_id)) *
-            BAlgorithmSuite(#alg_id, #errorMessage)
+            BAlgorithmSuite(#alg_id; #errorMessage)
 
         ensures:
-            BAlgorithmSuite(#alg_id, #errorMessage) *
+            BAlgorithmSuite(#alg_id; #errorMessage) *
             (ret == int(-1))
     }
 */
@@ -208,20 +208,20 @@ int aws_cryptosdk_algorithm_ivlen(uint16_t alg_id) {
     spec aws_cryptosdk_algorithm_taglen(alg_id) {
         requires:
             (alg_id == int(#alg_id)) *
-            CAlgorithmSuite(#alg_id, #stringId, #ivLength, #tagLength)
+            CAlgorithmSuite(#alg_id; #stringId, #ivLength, #tagLength)
 
         ensures:
-            CAlgorithmSuite(#alg_id, #stringId, #ivLength, #tagLength) *
+            CAlgorithmSuite(#alg_id; #stringId, #ivLength, #tagLength) *
             (ret == int(#tagLength))
 
     OR
 
         requires:
             (alg_id == int(#alg_id)) *
-            BAlgorithmSuite(#alg_id, #errorMessage)
+            BAlgorithmSuite(#alg_id; #errorMessage)
 
         ensures:
-            BAlgorithmSuite(#alg_id, #errorMessage) *
+            BAlgorithmSuite(#alg_id; #errorMessage) *
             (ret == int(-1))
     }
 */
@@ -241,12 +241,12 @@ int aws_cryptosdk_algorithm_taglen(uint16_t alg_id) {
     spec aws_cryptosdk_hdr_clear(hdr) {
         requires:
             (hdr == #hdr) *
-            any_valid_aws_cryptosdk_hdr(#hdr, #alloc) *
-            default_allocator(#alloc)
+            any_valid_aws_cryptosdk_hdr(#hdr; #alloc) *
+            default_allocator(#alloc;)
 
         ensures:
-            empty_aws_cryptosdk_hdr(#hdr, #alloc) *
-            default_allocator(#alloc)
+            empty_aws_cryptosdk_hdr(#hdr; #alloc) *
+            default_allocator(#alloc;)
     }
 */
 void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
@@ -277,11 +277,11 @@ void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
     spec parse_edk(allocator, edk, cur) {
         requires:
             (allocator == #alloc) * (edk == #edk) * (cur == #cur) *
-            default_allocator(#alloc) *
-            Element(#content, 0, 3, #definition, #edk_content, #element_length) *
-            valid_aws_byte_cursor_ptr(#cur, #total_length, #buffer, #content) *
+            default_allocator(#alloc;) *
+            Element(#content, 0, 3; #definition, #edk_content, #element_length) *
+            valid_aws_byte_cursor_ptr(#cur; #total_length, #buffer, #content) *
             (not (#buffer == NULL)) *
-            any_aws_last_error() *
+            any_aws_last_error(;) *
             ARRAY(#edk, long, 12, #trash) *
 
             (#content == #edk_raw_content @ #rest) *
@@ -289,24 +289,24 @@ void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
             (len #rest == #total_length - #element_length)
 
         ensures:
-            default_allocator(#alloc) *
+            default_allocator(#alloc;) *
             (#definition == `Complete`) *
-            valid_aws_byte_cursor_ptr(#cur, #total_length - #element_length, #buffer p+ #element_length, #rest) *
-            valid_aws_cryptosdk_edk_ptr(#edk, #alloc, #edk_content) *
+            valid_aws_byte_cursor_ptr(#cur; #total_length - #element_length, #buffer p+ #element_length, #rest) *
+            valid_aws_cryptosdk_edk_ptr(#edk; #alloc, #edk_content) *
             ARRAY(#buffer, char, #element_length, #edk_raw_content) *
-            any_aws_last_error() *
+            any_aws_last_error(;) *
             (ret == int(0));
 
-            default_allocator(#alloc) *
+            default_allocator(#alloc;) *
             (#definition == `Incomplete`) *
-            valid_aws_byte_cursor_ptr(#cur, #left_length, #new_buffer, #restAfterConsuming) *
+            valid_aws_byte_cursor_ptr(#cur; #left_length, #new_buffer, #restAfterConsuming) *
             (0 <=# #consumed_length) *
             (#consumed_length == #total_length - #left_length) *
             (#new_buffer == #buffer p+ #consumed_length) *
-            empty_aws_cryptosdk_edk_ptr(#edk) *
-            optBytes(#buffer, #consumed_length, #consumed_data) *
+            empty_aws_cryptosdk_edk_ptr(#edk;) *
+            optBytes(#buffer, #consumed_length; #consumed_data) *
             (#content == #consumed_data @ #restAfterConsuming) *
-            aws_last_error_is_SHORT_BUF() *
+            aws_last_error_is_SHORT_BUF(;) *
             (ret == int(-1))
 }
 */
@@ -398,38 +398,38 @@ MEM_ERR:
     spec aws_cryptosdk_hdr_parse(hdr, pcursor) {
         requires:
             (hdr == #hdr) * (pcursor == #pcursor) *
-            valid_aws_byte_cursor_ptr(#pcursor, #length, #buffer, #data) *
-            Header(#data, #definition, #part_one, #version, #type, #suiteId, #messageId,
+            valid_aws_byte_cursor_ptr(#pcursor; #length, #buffer, #data) *
+            Header(#data; #definition, #part_one, #version, #type, #suiteId, #messageId,
                    #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength,
                    #frameLength, #headerLength, #headerIv, #headerAuthTag, #edkDef, #errorMessage) *
             (#length == len #data) *
             (#length <# 2147483647) *
-            any_valid_aws_cryptosdk_hdr(#hdr, #alloc) *
-            default_allocator(#alloc) *
-            any_aws_last_error() *
+            any_valid_aws_cryptosdk_hdr(#hdr; #alloc) *
+            default_allocator(#alloc;) *
+            any_aws_last_error(;) *
             (#definition == `Incomplete`)
 
         ensures:
             (#definition == `Complete`) *
             ARRAY(#buffer, char, #length, #data) *
-            valid_aws_byte_cursor_ptr(#pcursor, 0, #end_buffer, []) *
-            header_struct(#hdr, #alloc, #suiteId, #messageId, #ECKs, #EDKs, #frameLength, #headerLength, #headerIv, #headerAuthTag) *
-            default_allocator(#alloc) *
-            any_aws_last_error() *
+            valid_aws_byte_cursor_ptr(#pcursor; 0, #end_buffer, []) *
+            header_struct(#hdr; #alloc, #suiteId, #messageId, #ECKs, #EDKs, #frameLength, #headerLength, #headerIv, #headerAuthTag) *
+            default_allocator(#alloc;) *
+            any_aws_last_error(;) *
             (ret == int(0));
 
             (#definition == `Incomplete`) *
-            valid_aws_byte_cursor_ptr(#pcursor, #length, #buffer, #data) *
-            empty_aws_cryptosdk_hdr(#hdr, #alloc) *
-            default_allocator(#alloc) *
-            aws_last_error_is_SHORT_BUF() *
+            valid_aws_byte_cursor_ptr(#pcursor; #length, #buffer, #data) *
+            empty_aws_cryptosdk_hdr(#hdr; #alloc) *
+            default_allocator(#alloc;) *
+            aws_last_error_is_SHORT_BUF(;) *
             (ret == int(-1));
 
             (#definition == `Broken`) *
-            valid_aws_byte_cursor_ptr(#pcursor, #length, #buffer, #data) *
-            empty_aws_cryptosdk_hdr(#hdr, #alloc) *
-            default_allocator(#alloc) *
-            aws_last_error_is_BAD_CIPHERTEXT() *
+            valid_aws_byte_cursor_ptr(#pcursor; #length, #buffer, #data) *
+            empty_aws_cryptosdk_hdr(#hdr; #alloc) *
+            default_allocator(#alloc;) *
+            aws_last_error_is_BAD_CIPHERTEXT(;) *
             (ret == int(-1))
   }
 */
@@ -562,8 +562,8 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
                 (#eList == #EDKs) * \
                 (#EDKsAndRest == lsub(#part_three, 2, (len #part_three) - 2)) * \
                 (#EDKsAndRest == #justEDKs @ #restOfHeader) * \
-                CElements(#EDKsAndRest, 0, #edk_count, 3, #eList, #totalEDKLength) * \
-                valid_aws_byte_cursor_ptr(#cur, #atEDKs, #bptr, #EDKsAndRest) \
+                CElements(#EDKsAndRest, 0, #edk_count, 3; #eList, #totalEDKLength) * \
+                valid_aws_byte_cursor_ptr(#cur; #atEDKs, #bptr, #EDKsAndRest) \
         } else { \
             if (#edkDef = `Incomplete`) { \
                 assert [[bind #edk_al, #edkLenb0, #edkLenb1, #justEDKs, #EDKsAndRest, #restOfHeader, #totalEDKLength, #atEDKs, #bptr, #eList]] \
@@ -571,8 +571,8 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
                     (#edks == ([ #edkLenb0, #edkLenb1 ] @ #justEDKs)) * \
                     (#EDKsAndRest == lsub(#part_three, 2, (len #part_three) - 2)) * \
                     (#EDKsAndRest == #justEDKs @ #restOfHeader) * \
-                    IElements(#EDKsAndRest, 0, #edk_count, 3, #eList, #totalEDKLength) * \
-                    valid_aws_byte_cursor_ptr(#cur, #atEDKs, #bptr, #EDKsAndRest) \
+                    IElements(#EDKsAndRest, 0, #edk_count, 3; #eList, #totalEDKLength) * \
+                    valid_aws_byte_cursor_ptr(#cur; #atEDKs, #bptr, #EDKsAndRest) \
             } else { \
                 assert False \
             } \
@@ -584,16 +584,16 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
         "invariant: \
             [[bind i, #i, #cbptr, #readLength, #readEDKs, #leftEDKs, #restEDKsAndRest, \
                    #acc, #rest_count, #restEDKs, #restEDKLength, #restLength, #trash]] \
-            any_aws_last_error() * \
-            (i == int(#i)) * default_allocator(#alloc) * \
+            any_aws_last_error(;) * \
+            (i == int(#i)) * default_allocator(#alloc;) * \
             (#hdr -> ptr(#all, #alo)) * (#alloc == ptr(#all, #alo)) * \
-            optBytes(#bptr, #readLength, #readEDKs) * \
+            optBytes(#bptr, #readLength; #readEDKs) * \
             (#readLength == len #readEDKs) * \
             (len #data == 22 + #ECLength + 2 + #readLength + #restLength) * \
-            valid_aws_byte_cursor_ptr(#cur, #restLength, #cbptr, #restEDKsAndRest) * \
-            valid_edk_array_list_ptr(#edk_al, #alloc, #acc) * \
+            valid_aws_byte_cursor_ptr(#cur; #restLength, #cbptr, #restEDKsAndRest) * \
+            valid_edk_array_list_ptr(#edk_al; #alloc, #acc) * \
             (len #acc == #i) * (#eList == #acc @ #restEDKs) * \
-            Elements(#restEDKsAndRest, 0, #rest_count, 3, #edkDef, #restEDKs, #restEDKLength) * \
+            Elements(#restEDKsAndRest, 0, #rest_count, 3; #edkDef, #restEDKs, #restEDKLength) * \
             (#restLength == len #restEDKsAndRest) * \
             (#rest_count == (#edk_count - #i)) * \
             (#restLength == (#atEDKs - #readLength)) * \

--- a/Gillian-C/examples/amazon/bugs/header.c
+++ b/Gillian-C/examples/amazon/bugs/header.c
@@ -23,7 +23,7 @@
 
 // Optional value or null
 /*@
-pred or_NULL(+x, +x_opt) {
+pred or_NULL(x, x_opt;) {
     x_opt == x;
     x_opt == NULL
 }
@@ -31,7 +31,7 @@ pred or_NULL(+x, +x_opt) {
 
 // Any valid header
 /*@
-pred nounfold any_valid_aws_cryptosdk_hdr(+hdr, allocator) {
+pred nounfold any_valid_aws_cryptosdk_hdr(hdr; allocator) {
   (hdr -> struct aws_cryptosdk_hdr {
     allocator;
     #alg_id;
@@ -53,7 +53,7 @@ pred nounfold any_valid_aws_cryptosdk_hdr(+hdr, allocator) {
 
 // Empty header
 /*@
-pred nounfold empty_aws_cryptosdk_hdr(+hdr, allocator) {
+pred nounfold empty_aws_cryptosdk_hdr(hdr; allocator) {
   (hdr -> struct aws_cryptosdk_hdr {
     allocator;
     int(0);
@@ -75,7 +75,7 @@ pred nounfold empty_aws_cryptosdk_hdr(+hdr, allocator) {
 
 // Deserialised header
 /*@
-pred nounfold header_struct(+hdr, allocator, alg_id, message_id, enc_ctx_content, edk_content, frame_len, auth_len, iv, auth_tag) {
+pred nounfold header_struct(hdr; allocator, alg_id, message_id, enc_ctx_content, edk_content, frame_len, auth_len, iv, auth_tag) {
   (hdr -> struct aws_cryptosdk_hdr {
     allocator;
     int(alg_id);

--- a/Gillian-C/examples/amazon/bugs/string.c
+++ b/Gillian-C/examples/amazon/bugs/string.c
@@ -8,7 +8,7 @@ import `../logic/StringStruct`;
 */
 
 /*@
-  pred valid_aws_string_ptr(+str, alloc, content) {
+  pred valid_aws_string_ptr(str; alloc, content) {
     m_struct_aws_string_exposing_pointer(str, alloc, long(#len), #bytes) *
     (0 <=# #len) *
     ARRAY(#bytes, char, #len + 1, #bytes_content) *
@@ -18,7 +18,7 @@ import `../logic/StringStruct`;
   }
 */
 
-/*@ pred nounfold optBytes(+bytes, +length, content) {
+/*@ pred nounfold optBytes(bytes, length; content) {
   (length == 0) * (content == nil);
   (0 <# length) * ARRAY(bytes, char, length, content)
 }

--- a/Gillian-C/examples/amazon/bugs/string.c
+++ b/Gillian-C/examples/amazon/bugs/string.c
@@ -9,12 +9,12 @@ import `../logic/StringStruct`;
 
 /*@
   pred valid_aws_string_ptr(str; alloc, content) {
-    m_struct_aws_string_exposing_pointer(str, alloc, long(#len), #bytes) *
+    m_struct_aws_string_exposing_pointer(str; alloc, long(#len), #bytes) *
     (0 <=# #len) *
     ARRAY(#bytes, char, #len + 1, #bytes_content) *
     (#rawContent == lsub(#bytes_content, 0, #len)) *
     (#bytes_content == #rawContent @ [ 0 ]) *
-    toUtf8(#rawContent, content)
+    toUtf8(#rawContent; content)
   }
 */
 
@@ -29,12 +29,12 @@ import `../logic/StringStruct`;
   requires: (allocator == #alloc) *
             (bytes == #bytes) * (length == long(#len)) *
             (#len <=# 65535) *
-            optBytes(#bytes, #len, #rawContent) *
-            toUtf8(#rawContent, #strContent) *
-            default_allocator(#alloc)
-  ensures:  valid_aws_string_ptr(ret, #alloc, #strContent) *
-            optBytes(#bytes, #len, #rawContent) *
-            default_allocator(#alloc)
+            optBytes(#bytes, #len; #rawContent) *
+            toUtf8(#rawContent; #strContent) *
+            default_allocator(#alloc;)
+  ensures:  valid_aws_string_ptr(ret; #alloc, #strContent) *
+            optBytes(#bytes, #len; #rawContent) *
+            default_allocator(#alloc;)
 }
 */
 struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator,
@@ -64,9 +64,9 @@ struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator,
 }
 
 /*@ spec aws_string_destroy(str) {
-    requires: valid_aws_string_ptr(str, #alloc, #strContent) *
-              default_allocator(#alloc)
-    ensures: default_allocator(#alloc)
+    requires: valid_aws_string_ptr(str; #alloc, #strContent) *
+              default_allocator(#alloc;)
+    ensures: default_allocator(#alloc;)
 
     OR
 

--- a/Gillian-C/examples/amazon/bugs/string.c
+++ b/Gillian-C/examples/amazon/bugs/string.c
@@ -31,10 +31,10 @@ import `../logic/StringStruct`;
             (#len <=# 65535) *
             optBytes(#bytes, #len; #rawContent) *
             toUtf8(#rawContent; #strContent) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
   ensures:  valid_aws_string_ptr(ret; #alloc, #strContent) *
             optBytes(#bytes, #len; #rawContent) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
 }
 */
 struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator,
@@ -65,8 +65,8 @@ struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator,
 
 /*@ spec aws_string_destroy(str) {
     requires: valid_aws_string_ptr(str; #alloc, #strContent) *
-              default_allocator(#alloc;)
-    ensures: default_allocator(#alloc;)
+              default_allocator(#alloc)
+    ensures: default_allocator(#alloc)
 
     OR
 

--- a/Gillian-C/examples/amazon/byte_buf.c
+++ b/Gillian-C/examples/amazon/byte_buf.c
@@ -48,7 +48,7 @@
         (not (allocator == NULL))
     }
 
-    pred empty_aws_byte_buf(length, capacity, buffer, allocator;) {
+    pred empty_aws_byte_buf(length, capacity, buffer, allocator) {
         (length == 0) * (capacity == 0) * (buffer == NULL) *
         (allocator == NULL)
     }
@@ -58,19 +58,19 @@
         valid_aws_byte_buf(length, capacity, buffer, allocator; content)
     }
 
-    pred empty_aws_byte_buf_fields(fields;) {
+    pred empty_aws_byte_buf_fields(fields) {
         (fields ==  [ long(length), buffer, long(capacity), allocator ]) *
-        empty_aws_byte_buf(length, capacity, buffer, allocator;)
+        empty_aws_byte_buf(length, capacity, buffer, allocator)
     }
 
-    pred empty_aws_byte_buf_ptr(buf;) {
+    pred empty_aws_byte_buf_ptr(buf) {
         (buf -> struct aws_byte_buf {
             long(#length);
             #buffer;
             long(#capacity);
             #allocator
         }) *
-        empty_aws_byte_buf(#length, #capacity, #buffer, #allocator;)
+        empty_aws_byte_buf(#length, #capacity, #buffer, #allocator)
     }
 
     pred nounfold valid_aws_byte_buf_ptr(buf; length, capacity, buffer, allocator, content) {
@@ -92,11 +92,11 @@
             (buf == #buf) * (allocator == #allocator) *
             (capacity == long(#capacity)) *
             (0 <=# #capacity) *
-            empty_aws_byte_buf_ptr(#buf;) * default_allocator(#allocator;)
+            empty_aws_byte_buf_ptr(#buf) * default_allocator(#allocator)
 
         ensures:
             valid_aws_byte_buf_ptr(#buf; 0, #capacity, #buffer, #allocator, []) *
-            default_allocator(#allocator;) *
+            default_allocator(#allocator) *
             (ret == int(0))
     }
 */
@@ -126,11 +126,11 @@ int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator,
         requires:
             (buf == #buf) *
             valid_aws_byte_buf_ptr(#buf; #length, #capacity, #buffer, #allocator, #content) *
-            default_allocator(#allocator;)
+            default_allocator(#allocator)
 
         ensures:
-            empty_aws_byte_buf_ptr(#buf;) *
-            default_allocator(#allocator;)
+            empty_aws_byte_buf_ptr(#buf) *
+            default_allocator(#allocator)
 
     OR
 
@@ -139,7 +139,7 @@ int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator,
             valid_aws_byte_buf_ptr(#buf; #length, #capacity, #buffer, NULL, #content)
 
         ensures:
-            empty_aws_byte_buf_ptr(#buf;)
+            empty_aws_byte_buf_ptr(#buf)
     }
 */
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
@@ -156,13 +156,13 @@ void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
 // Predicates describing what it means for a byte
 // buffer read to be valid or invalid
 /*@
-    pure pred valid_read(read_len, cursor_len;) {
+    pure pred valid_read(read_len, cursor_len) {
         (read_len <=# cursor_len) *
         (read_len <=# 2147483647) *
         (cursor_len <=# 2147483647)
     }
 
-    pure pred invalid_read(read_len, cursor_len;) {
+    pure pred invalid_read(read_len, cursor_len) {
         cursor_len <# read_len;
         2147483647 <# read_len;
         2147483647 <# cursor_len
@@ -190,11 +190,11 @@ void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
             ((0 <# #length) || (not (#buffer == NULL)))
 
         ensures:
-            invalid_read(#length, #cur_len;) *
+            invalid_read(#length, #cur_len) *
             valid_aws_byte_cursor_ptr(#res; 0, NULL, nil) *
             valid_aws_byte_cursor_ptr(#cursor; #cur_len, #buffer, #content);
 
-            valid_read(#length, #cur_len;) *
+            valid_read(#length, #cur_len) *
             valid_aws_byte_cursor_ptr(#res; #length, #buffer, #data) *
             valid_aws_byte_cursor_ptr(#cursor; #rest_len, #buffer p+ #length, #rest) *
             (#length == len #data) *
@@ -238,7 +238,7 @@ aws_byte_cursor_advance(struct aws_byte_cursor *const cursor,
             (ret == TRUE);
 
             (0 <# #length) *
-            valid_read(#length, #cur_length;) *
+            valid_read(#length, #cur_length) *
             ARRAY(#buffer, char, #length, #data) *
             valid_aws_byte_cursor_ptr(#cur; len #rest, #buffer p+ #length, #rest) *
             ARRAY(#dest, char, #length, #data) *
@@ -248,7 +248,7 @@ aws_byte_cursor_advance(struct aws_byte_cursor *const cursor,
             (ret == TRUE);
 
             (0 <# #length) *
-            invalid_read(#length, #cur_length;) *
+            invalid_read(#length, #cur_length) *
             valid_aws_byte_cursor_ptr(#cur; #cur_length, #buffer, #content) *
             writable_memory(#dest, #length; #trash) *
             (ret == FALSE)
@@ -290,17 +290,17 @@ bool aws_byte_cursor_read(struct aws_byte_cursor *cur, void *dest,
             writable_memory(#var, 1; #trash)
 
         ensures:
-            invalid_read(1, #cur_length;) *
+            invalid_read(1, #cur_length) *
             valid_aws_byte_cursor_ptr(#cur; #cur_length, #buffer, #content) *
             writable_memory(#var, 1; #trash) *
             (ret == FALSE);
 
-            valid_read(1, #cur_length;) *
+            valid_read(1, #cur_length) *
             (#content == [ #u ] @ #rest) *
             ARRAY(#buffer, char, 1, [ #u ]) *
             valid_aws_byte_cursor_ptr(#cur; len #rest, #buffer p+ 1, #rest) *
             ARRAY(#var, char, 1, [ #u ]) *
-            isByte(#u;) *
+            isByte(#u) *
             (ret == TRUE)
     }
 */
@@ -328,17 +328,17 @@ bool aws_byte_cursor_read_u8(struct aws_byte_cursor *cur, uint8_t *var) {
             writable_memory(#var, 2; #trash)
 
         ensures:
-            invalid_read(2, #cur_length;) *
+            invalid_read(2, #cur_length) *
             valid_aws_byte_cursor_ptr(#cur; #cur_length, #buffer, #content) *
             writable_memory(#var, 2; #trash) *
             (ret == FALSE);
 
-            valid_read(2, #cur_length;) *
+            valid_read(2, #cur_length) *
             (#content == [ #b0, #b1 ] @ #rest) *
             ARRAY(#buffer, char, 2, [ #b0, #b1 ]) *
             valid_aws_byte_cursor_ptr(#cur; len #rest, #buffer p+ 2, #rest) *
             (#read_value == (#b0 * 256) + #b1) *
-            isByte(#b0;) * isByte(#b1;) *
+            isByte(#b0) * isByte(#b1) *
             ARRAY(#var, int16, 1, [ #read_value ]) *
             (ret == TRUE)
     }
@@ -372,18 +372,18 @@ bool aws_byte_cursor_read_be16(struct aws_byte_cursor *cur, uint16_t *var) {
             writable_memory(#var, 4; #trash)
 
         ensures:
-            invalid_read(4, #cur_length;) *
+            invalid_read(4, #cur_length) *
             valid_aws_byte_cursor_ptr(#cur; #cur_length, #buffer, #content) *
             writable_memory(#var, 4; #trash) *
             (ret == FALSE);
 
-            valid_read(4, #cur_length;) *
+            valid_read(4, #cur_length) *
             (#content == [ #b0, #b1, #b2, #b3 ] @ #rest) *
             ARRAY(#buffer, char, 4, [ #b0, #b1, #b2, #b3 ]) *
             (#rest_len == #cur_length - 4) *
             valid_aws_byte_cursor_ptr(#cur; #rest_len, #buffer p+ 4, #rest) *
             (#read_value == (#b0 * 16777216) + (#b1 * 65536) + (#b2 * 256) + #b3) *
-            isByte(#b0;) * isByte(#b1;) * isByte(#b2;) * isByte(#b3;) *
+            isByte(#b0) * isByte(#b1) * isByte(#b2) * isByte(#b3) *
             (#var -> int(#read_value)) * (ret == TRUE)
     }
 */
@@ -421,7 +421,7 @@ bool aws_byte_cursor_read_be32(struct aws_byte_cursor *cur, uint32_t *var) {
             (ret == TRUE);
 
             (0 <# #dest_capacity) *
-            valid_read(#dest_capacity, #cur_length;) *
+            valid_read(#dest_capacity, #cur_length) *
             (#cur_content == #consumed @ #rest) *
             (len #consumed == #dest_capacity) *
             (len #rest == #cur_length - #dest_capacity) *
@@ -431,7 +431,7 @@ bool aws_byte_cursor_read_be32(struct aws_byte_cursor *cur, uint32_t *var) {
             (ret == TRUE);
 
             (0 <# #dest_capacity) *
-            invalid_read(#dest_capacity, #cur_length;) *
+            invalid_read(#dest_capacity, #cur_length) *
             valid_aws_byte_cursor_ptr(#cur; #cur_length, #cur_buffer, #cur_content) *
             valid_aws_byte_buf_ptr(#dest; #dest_length, #dest_capacity, #dest_buffer, #dest_alloc, #dest_content) *
             (ret == FALSE)

--- a/Gillian-C/examples/amazon/byte_buf.c
+++ b/Gillian-C/examples/amazon/byte_buf.c
@@ -24,10 +24,10 @@
 
     lemma valid_aws_byte_cursor_ptr_facts(cur, length, buffer, alpha) {
         hypothesis:
-            valid_aws_byte_cursor_ptr(#cur, #length, #buffer, #alpha)
+            valid_aws_byte_cursor_ptr(#cur; #length, #buffer, #alpha)
 
         conclusions:
-            valid_aws_byte_cursor_ptr(#cur, #length, #buffer, #alpha) *
+            valid_aws_byte_cursor_ptr(#cur; #length, #buffer, #alpha) *
             (#length == len #alpha) * (#length <=# 2147483647)
 
         proof:
@@ -55,12 +55,12 @@
 
     pred valid_aws_byte_buf_fields(fields; length, capacity, buffer, allocator, content) {
         (fields == [ long(length), buffer, long(capacity), allocator ]) *
-        valid_aws_byte_buf(length, capacity, buffer, allocator, content)
+        valid_aws_byte_buf(length, capacity, buffer, allocator; content)
     }
 
     pred empty_aws_byte_buf_fields(fields;) {
         (fields ==  [ long(length), buffer, long(capacity), allocator ]) *
-        empty_aws_byte_buf(length, capacity, buffer, allocator)
+        empty_aws_byte_buf(length, capacity, buffer, allocator;)
     }
 
     pred empty_aws_byte_buf_ptr(buf;) {
@@ -70,7 +70,7 @@
             long(#capacity);
             #allocator
         }) *
-        empty_aws_byte_buf(#length, #capacity, #buffer, #allocator)
+        empty_aws_byte_buf(#length, #capacity, #buffer, #allocator;)
     }
 
     pred nounfold valid_aws_byte_buf_ptr(buf; length, capacity, buffer, allocator, content) {
@@ -80,7 +80,7 @@
             long(capacity);
             allocator
         }) *
-        valid_aws_byte_buf(length, capacity, buffer, allocator, content)
+        valid_aws_byte_buf(length, capacity, buffer, allocator; content)
     }
 */
 
@@ -92,11 +92,11 @@
             (buf == #buf) * (allocator == #allocator) *
             (capacity == long(#capacity)) *
             (0 <=# #capacity) *
-            empty_aws_byte_buf_ptr(#buf) * default_allocator(#allocator)
+            empty_aws_byte_buf_ptr(#buf;) * default_allocator(#allocator;)
 
         ensures:
-            valid_aws_byte_buf_ptr(#buf, 0, #capacity, #buffer, #allocator, []) *
-            default_allocator(#allocator) *
+            valid_aws_byte_buf_ptr(#buf; 0, #capacity, #buffer, #allocator, []) *
+            default_allocator(#allocator;) *
             (ret == int(0))
     }
 */
@@ -125,21 +125,21 @@ int aws_byte_buf_init(struct aws_byte_buf *buf, struct aws_allocator *allocator,
     spec aws_byte_buf_clean_up(buf) {
         requires:
             (buf == #buf) *
-            valid_aws_byte_buf_ptr(#buf, #length, #capacity, #buffer, #allocator, #content) *
-            default_allocator(#allocator)
+            valid_aws_byte_buf_ptr(#buf; #length, #capacity, #buffer, #allocator, #content) *
+            default_allocator(#allocator;)
 
         ensures:
-            empty_aws_byte_buf_ptr(#buf) *
-            default_allocator(#allocator)
+            empty_aws_byte_buf_ptr(#buf;) *
+            default_allocator(#allocator;)
 
     OR
 
         requires:
             (buf == #buf) *
-            valid_aws_byte_buf_ptr(#buf, #length, #capacity, #buffer, NULL, #content)
+            valid_aws_byte_buf_ptr(#buf; #length, #capacity, #buffer, NULL, #content)
 
         ensures:
-            empty_aws_byte_buf_ptr(#buf)
+            empty_aws_byte_buf_ptr(#buf;)
     }
 */
 void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
@@ -186,17 +186,17 @@ void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
         requires:
             (_res == #res) * (cursor == #cursor) * (length == long(#length)) *
             (0 <=# #length) * ARRAY(#res, long, 2, #trash) *
-            valid_aws_byte_cursor_ptr(#cursor, #cur_len, #buffer, #content) *
+            valid_aws_byte_cursor_ptr(#cursor; #cur_len, #buffer, #content) *
             ((0 <# #length) || (not (#buffer == NULL)))
 
         ensures:
-            invalid_read(#length, #cur_len) *
-            valid_aws_byte_cursor_ptr(#res, 0, NULL, nil) *
-            valid_aws_byte_cursor_ptr(#cursor, #cur_len, #buffer, #content);
+            invalid_read(#length, #cur_len;) *
+            valid_aws_byte_cursor_ptr(#res; 0, NULL, nil) *
+            valid_aws_byte_cursor_ptr(#cursor; #cur_len, #buffer, #content);
 
-            valid_read(#length, #cur_len) *
-            valid_aws_byte_cursor_ptr(#res, #length, #buffer, #data) *
-            valid_aws_byte_cursor_ptr(#cursor, #rest_len, #buffer p+ #length, #rest) *
+            valid_read(#length, #cur_len;) *
+            valid_aws_byte_cursor_ptr(#res; #length, #buffer, #data) *
+            valid_aws_byte_cursor_ptr(#cursor; #rest_len, #buffer p+ #length, #rest) *
             (#length == len #data) *
             (#content == #data @ #rest) *
             (#rest_len == (#cur_len - #length))
@@ -228,19 +228,19 @@ aws_byte_cursor_advance(struct aws_byte_cursor *const cursor,
     spec aws_byte_cursor_read(cur, dest, length) {
         requires:
             (cur == #cur) * (dest == #dest) * (length == long(#length)) *
-            valid_aws_byte_cursor_ptr(#cur, #cur_length, #buffer, #content) *
-            writable_memory(#dest, #length, #trash)
+            valid_aws_byte_cursor_ptr(#cur; #cur_length, #buffer, #content) *
+            writable_memory(#dest, #length; #trash)
 
         ensures:
             (#length == 0) *
-            valid_aws_byte_cursor_ptr(#cur, #cur_length, #buffer, #content) *
-            writable_memory(#dest, 0, []) * (#trash == []) *
+            valid_aws_byte_cursor_ptr(#cur; #cur_length, #buffer, #content) *
+            writable_memory(#dest, 0; []) * (#trash == []) *
             (ret == TRUE);
 
             (0 <# #length) *
-            valid_read(#length, #cur_length) *
+            valid_read(#length, #cur_length;) *
             ARRAY(#buffer, char, #length, #data) *
-            valid_aws_byte_cursor_ptr(#cur, len #rest, #buffer p+ #length, #rest) *
+            valid_aws_byte_cursor_ptr(#cur; len #rest, #buffer p+ #length, #rest) *
             ARRAY(#dest, char, #length, #data) *
             (#length == len #data) *
             (#content == #data @ #rest) *
@@ -248,9 +248,9 @@ aws_byte_cursor_advance(struct aws_byte_cursor *const cursor,
             (ret == TRUE);
 
             (0 <# #length) *
-            invalid_read(#length, #cur_length) *
-            valid_aws_byte_cursor_ptr(#cur, #cur_length, #buffer, #content) *
-            writable_memory(#dest, #length, #trash) *
+            invalid_read(#length, #cur_length;) *
+            valid_aws_byte_cursor_ptr(#cur; #cur_length, #buffer, #content) *
+            writable_memory(#dest, #length; #trash) *
             (ret == FALSE)
     }
 */
@@ -286,21 +286,21 @@ bool aws_byte_cursor_read(struct aws_byte_cursor *cur, void *dest,
     spec aws_byte_cursor_read_u8(cur, var) {
         requires:
             (cur == #cur) * (var == #var) *
-            valid_aws_byte_cursor_ptr(#cur, #cur_length, #buffer, #content) *
-            writable_memory(#var, 1, #trash)
+            valid_aws_byte_cursor_ptr(#cur; #cur_length, #buffer, #content) *
+            writable_memory(#var, 1; #trash)
 
         ensures:
-            invalid_read(1, #cur_length) *
-            valid_aws_byte_cursor_ptr(#cur, #cur_length, #buffer, #content) *
-            writable_memory(#var, 1, #trash) *
+            invalid_read(1, #cur_length;) *
+            valid_aws_byte_cursor_ptr(#cur; #cur_length, #buffer, #content) *
+            writable_memory(#var, 1; #trash) *
             (ret == FALSE);
 
-            valid_read(1, #cur_length) *
+            valid_read(1, #cur_length;) *
             (#content == [ #u ] @ #rest) *
             ARRAY(#buffer, char, 1, [ #u ]) *
-            valid_aws_byte_cursor_ptr(#cur, len #rest, #buffer p+ 1, #rest) *
+            valid_aws_byte_cursor_ptr(#cur; len #rest, #buffer p+ 1, #rest) *
             ARRAY(#var, char, 1, [ #u ]) *
-            isByte(#u) *
+            isByte(#u;) *
             (ret == TRUE)
     }
 */
@@ -324,21 +324,21 @@ bool aws_byte_cursor_read_u8(struct aws_byte_cursor *cur, uint8_t *var) {
     spec aws_byte_cursor_read_be16(cur, var) {
         requires:
             (cur == #cur) * (var == #var) *
-            valid_aws_byte_cursor_ptr(#cur, #cur_length, #buffer, #content) *
-            writable_memory(#var, 2, #trash)
+            valid_aws_byte_cursor_ptr(#cur; #cur_length, #buffer, #content) *
+            writable_memory(#var, 2; #trash)
 
         ensures:
-            invalid_read(2, #cur_length) *
-            valid_aws_byte_cursor_ptr(#cur, #cur_length, #buffer, #content) *
-            writable_memory(#var, 2, #trash) *
+            invalid_read(2, #cur_length;) *
+            valid_aws_byte_cursor_ptr(#cur; #cur_length, #buffer, #content) *
+            writable_memory(#var, 2; #trash) *
             (ret == FALSE);
 
-            valid_read(2, #cur_length) *
+            valid_read(2, #cur_length;) *
             (#content == [ #b0, #b1 ] @ #rest) *
             ARRAY(#buffer, char, 2, [ #b0, #b1 ]) *
-            valid_aws_byte_cursor_ptr(#cur, len #rest, #buffer p+ 2, #rest) *
+            valid_aws_byte_cursor_ptr(#cur; len #rest, #buffer p+ 2, #rest) *
             (#read_value == (#b0 * 256) + #b1) *
-            isByte(#b0) * isByte(#b1) *
+            isByte(#b0;) * isByte(#b1;) *
             ARRAY(#var, int16, 1, [ #read_value ]) *
             (ret == TRUE)
     }
@@ -368,22 +368,22 @@ bool aws_byte_cursor_read_be16(struct aws_byte_cursor *cur, uint16_t *var) {
     spec aws_byte_cursor_read_be32(cur, var) {
         requires:
             (cur == #cur) * (var == #var) *
-            valid_aws_byte_cursor_ptr(#cur, #cur_length, #buffer, #content) *
-            writable_memory(#var, 4, #trash)
+            valid_aws_byte_cursor_ptr(#cur; #cur_length, #buffer, #content) *
+            writable_memory(#var, 4; #trash)
 
         ensures:
-            invalid_read(4, #cur_length) *
-            valid_aws_byte_cursor_ptr(#cur, #cur_length, #buffer, #content) *
-            writable_memory(#var, 4, #trash) *
+            invalid_read(4, #cur_length;) *
+            valid_aws_byte_cursor_ptr(#cur; #cur_length, #buffer, #content) *
+            writable_memory(#var, 4; #trash) *
             (ret == FALSE);
 
-            valid_read(4, #cur_length) *
+            valid_read(4, #cur_length;) *
             (#content == [ #b0, #b1, #b2, #b3 ] @ #rest) *
             ARRAY(#buffer, char, 4, [ #b0, #b1, #b2, #b3 ]) *
             (#rest_len == #cur_length - 4) *
-            valid_aws_byte_cursor_ptr(#cur, #rest_len, #buffer p+ 4, #rest) *
+            valid_aws_byte_cursor_ptr(#cur; #rest_len, #buffer p+ 4, #rest) *
             (#read_value == (#b0 * 16777216) + (#b1 * 65536) + (#b2 * 256) + #b3) *
-            isByte(#b0) * isByte(#b1) * isByte(#b2) * isByte(#b3) *
+            isByte(#b0;) * isByte(#b1;) * isByte(#b2;) * isByte(#b3;) *
             (#var -> int(#read_value)) * (ret == TRUE)
     }
 */
@@ -411,29 +411,29 @@ bool aws_byte_cursor_read_be32(struct aws_byte_cursor *cur, uint32_t *var) {
     spec aws_byte_cursor_read_and_fill_buffer(cur, dest) {
         requires:
             (cur == #cur) * (dest == #dest) *
-            valid_aws_byte_cursor_ptr(#cur, #cur_length, #cur_buffer, #cur_content) *
-            valid_aws_byte_buf_ptr(#dest, #dest_length, #dest_capacity, #dest_buffer, #dest_alloc, #dest_content)
+            valid_aws_byte_cursor_ptr(#cur; #cur_length, #cur_buffer, #cur_content) *
+            valid_aws_byte_buf_ptr(#dest; #dest_length, #dest_capacity, #dest_buffer, #dest_alloc, #dest_content)
 
         ensures:
             (#dest_capacity == 0) *
-            valid_aws_byte_buf_ptr(#dest, 0, 0, NULL, #dest_alloc, []) *
-            valid_aws_byte_cursor_ptr(#cur, #cur_length, #cur_buffer, #cur_content) *
+            valid_aws_byte_buf_ptr(#dest; 0, 0, NULL, #dest_alloc, []) *
+            valid_aws_byte_cursor_ptr(#cur; #cur_length, #cur_buffer, #cur_content) *
             (ret == TRUE);
 
             (0 <# #dest_capacity) *
-            valid_read(#dest_capacity, #cur_length) *
+            valid_read(#dest_capacity, #cur_length;) *
             (#cur_content == #consumed @ #rest) *
             (len #consumed == #dest_capacity) *
             (len #rest == #cur_length - #dest_capacity) *
-            valid_aws_byte_buf_ptr(#dest, #dest_capacity, #dest_capacity, #dest_buffer, #dest_alloc, #consumed) *
-            valid_aws_byte_cursor_ptr(#cur, len #rest, #cur_buffer p+ #dest_capacity, #rest) *
+            valid_aws_byte_buf_ptr(#dest; #dest_capacity, #dest_capacity, #dest_buffer, #dest_alloc, #consumed) *
+            valid_aws_byte_cursor_ptr(#cur; len #rest, #cur_buffer p+ #dest_capacity, #rest) *
             ARRAY(#cur_buffer, char, #dest_capacity, #consumed) *
             (ret == TRUE);
 
             (0 <# #dest_capacity) *
-            invalid_read(#dest_capacity, #cur_length) *
-            valid_aws_byte_cursor_ptr(#cur, #cur_length, #cur_buffer, #cur_content) *
-            valid_aws_byte_buf_ptr(#dest, #dest_length, #dest_capacity, #dest_buffer, #dest_alloc, #dest_content) *
+            invalid_read(#dest_capacity, #cur_length;) *
+            valid_aws_byte_cursor_ptr(#cur; #cur_length, #cur_buffer, #cur_content) *
+            valid_aws_byte_buf_ptr(#dest; #dest_length, #dest_capacity, #dest_buffer, #dest_alloc, #dest_content) *
             (ret == FALSE)
 
     }

--- a/Gillian-C/examples/amazon/byte_buf.c
+++ b/Gillian-C/examples/amazon/byte_buf.c
@@ -13,7 +13,7 @@
 // A valid byte cursor is a structure that contains { len; ptr },
 // where ptr points to an array of size len (and types uint8_t)
 /*@
-    pred nounfold valid_aws_byte_cursor_ptr(+cur, length, buffer: List, alpha) {
+    pred nounfold valid_aws_byte_cursor_ptr(cur; length, buffer: List, alpha) {
         (cur -> struct aws_byte_cursor { long(0); buffer }) *
         (length == 0) * (alpha == nil);
 
@@ -37,7 +37,7 @@
 
 // Valid byte buffers
 /*@
-    pred valid_aws_byte_buf(+length, +capacity, +buffer, +allocator, content) {
+    pred valid_aws_byte_buf(length, capacity, buffer, allocator; content) {
         (length == 0) * (capacity == 0) * (buffer == NULL) * (content == []);
 
         (0 <# capacity) * (length <=# capacity) * (0 <=# length) *
@@ -48,22 +48,22 @@
         (not (allocator == NULL))
     }
 
-    pred empty_aws_byte_buf(+length, +capacity, +buffer, +allocator) {
+    pred empty_aws_byte_buf(length, capacity, buffer, allocator;) {
         (length == 0) * (capacity == 0) * (buffer == NULL) *
         (allocator == NULL)
     }
 
-    pred valid_aws_byte_buf_fields(+fields, length, capacity, buffer, allocator, content) {
+    pred valid_aws_byte_buf_fields(fields; length, capacity, buffer, allocator, content) {
         (fields == [ long(length), buffer, long(capacity), allocator ]) *
         valid_aws_byte_buf(length, capacity, buffer, allocator, content)
     }
 
-    pred empty_aws_byte_buf_fields(+fields) {
+    pred empty_aws_byte_buf_fields(fields;) {
         (fields ==  [ long(length), buffer, long(capacity), allocator ]) *
         empty_aws_byte_buf(length, capacity, buffer, allocator)
     }
 
-    pred empty_aws_byte_buf_ptr(+buf) {
+    pred empty_aws_byte_buf_ptr(buf;) {
         (buf -> struct aws_byte_buf {
             long(#length);
             #buffer;
@@ -73,7 +73,7 @@
         empty_aws_byte_buf(#length, #capacity, #buffer, #allocator)
     }
 
-    pred nounfold valid_aws_byte_buf_ptr(+buf, length, capacity, buffer, allocator, content) {
+    pred nounfold valid_aws_byte_buf_ptr(buf; length, capacity, buffer, allocator, content) {
         (buf -> struct aws_byte_buf {
             long(length);
             buffer;
@@ -156,13 +156,13 @@ void aws_byte_buf_clean_up(struct aws_byte_buf *buf) {
 // Predicates describing what it means for a byte
 // buffer read to be valid or invalid
 /*@
-    pure pred valid_read(read_len, cursor_len) {
+    pure pred valid_read(read_len, cursor_len;) {
         (read_len <=# cursor_len) *
         (read_len <=# 2147483647) *
         (cursor_len <=# 2147483647)
     }
 
-    pure pred invalid_read(read_len, cursor_len) {
+    pure pred invalid_read(read_len, cursor_len;) {
         cursor_len <# read_len;
         2147483647 <# read_len;
         2147483647 <# cursor_len

--- a/Gillian-C/examples/amazon/ec.c
+++ b/Gillian-C/examples/amazon/ec.c
@@ -78,7 +78,7 @@ void aws_cryptosdk_enc_ctx_clear(struct aws_hash_table *enc_ctx) {
             (0 <# #aad_len) *
             (not (#buffer == NULL)) *
             (#definition == `Broken`) * (#errorMessage == `decodeEncryptionContext: Overflow, too much data.`) *
-            BRawEncryptionContext(#errorMessage, #buffer_content, #ECKs) *
+            BRawEncryptionContext(#buffer_content, #errorMessage, #ECKs) *
             any_aws_last_error()
 
         ensures:
@@ -104,7 +104,7 @@ void aws_cryptosdk_enc_ctx_clear(struct aws_hash_table *enc_ctx) {
             (not (#buffer == NULL)) *
             (#definition == `Broken`) *
             (not (#errorMessage == `decodeEncryptionContext: Overflow, too much data.`)) *
-            BRawEncryptionContext(#errorMessage, #buffer_content, #ECKs) *
+            BRawEncryptionContext(#buffer_content, #errorMessage, #ECKs) *
             any_aws_last_error()
 
         ensures:
@@ -137,8 +137,8 @@ int aws_cryptosdk_enc_ctx_deserialize(struct aws_allocator *alloc,
         return aws_raise_error(AWS_CRYPTOSDK_ERR_BAD_CIPHERTEXT);
 
     GILLIAN("assert [[bind #l_ec, #elem_count]] (elem_count == [#l_ec, 2]) * ARRAY(ptr(#l_ec, 0), int16, 1, [ #elem_count ]) ");
-    GILLIAN("assert [[bind #elementsDef, #elements, #esLength]] Elements(#elementsDef, #buffer_content, 2, #elem_count, 2, #elements, #esLength)");
-    GILLIAN("unfold Elements(#elementsDef, #buffer_content, 2, #elem_count, 2, #ECKS, #esLength)");
+    GILLIAN("assert [[bind #elementsDef, #elements, #esLength]] Elements(#buffer_content, 2, #elem_count, 2, #elementsDef, #elements, #esLength)");
+    GILLIAN("unfold Elements(#buffer_content, 2, #elem_count, 2, #elementsDef, #ECKS, #esLength)");
     GILLIAN("assert [[bind #lengthPtr]] (length == [#l, 2]) * (#lengthPtr == ptr(#l, 0))");
     GILLIAN(
         "assert [[bind #l_res_1, #l_res, #l_k_cursor, #l_v_cursor]] \
@@ -176,7 +176,7 @@ int aws_cryptosdk_enc_ctx_deserialize(struct aws_allocator *alloc,
             // They are unique, so they can be put safely in the hashtable
             // The UTF8 condition is necessary for the hashtable strings to work
             // That information is required for the hash_table_put to work
-            "Elements(#elementsDef, #buffer_content, 2 + #consumedLength, #togo, 2, #restElements, #restEsLength) * \
+            "Elements(#buffer_content, 2 + #consumedLength, #togo, 2, #elementsDef, #restElements, #restEsLength) * \
             FirstProj(#elements, #keys) * \
             FirstProj(#consumedElements, #consumedKeys) * \
             FirstProj(#restElements, #restKeys) * \
@@ -201,7 +201,7 @@ int aws_cryptosdk_enc_ctx_deserialize(struct aws_allocator *alloc,
             (was_created == [#l_wc, 4]) * ARRAY(ptr(#l_wc, 0), int, 1, [#wc_trash])");
     for (uint16_t i = 0; i < elem_count; i++) {
         uint16_t length;
-        GILLIAN("unfold Elements(#elementsDef, #buffer_content, 2 + #consumedLength, #togo, 2, #restElements, #restEsLength)");
+        GILLIAN("unfold Elements(#buffer_content, 2 + #consumedLength, #togo, 2, #elementsDef, #restElements, #restEsLength)");
         GILLIAN(
             "if (#elementsDef = `Complete`) {"
             "  unfold CElements(#buffer_content, 2 + #consumedLength, #togo, 2, #restElements, #restLength)"
@@ -307,7 +307,7 @@ int aws_cryptosdk_enc_ctx_deserialize(struct aws_allocator *alloc,
     }
 
     GILLIAN("assert #togo == 0");
-    GILLIAN("unfold Elements(#elementsDef, #buffer_content, (2 + #consumedLength), #togo, 2, #restElements, #restEsLength)");
+    GILLIAN("unfold Elements(#buffer_content, (2 + #consumedLength), #togo, 2, #elementsDef, #restElements, #restEsLength)");
     GILLIAN("unfold CElements(#buffer_content, (2 + #consumedLength), #togo, 2, #restElements, #restEsLength)");
 
     GILLIAN(

--- a/Gillian-C/examples/amazon/ec.c
+++ b/Gillian-C/examples/amazon/ec.c
@@ -8,39 +8,39 @@ void aws_cryptosdk_enc_ctx_clear(struct aws_hash_table *enc_ctx) {
 
 // A predicate that allows us to connect JS and C error messages
 /*@
-    pred nounfold ECErrorCodeOfJSErrorMessage(errorMessage;) {
-        (errorMessage == `decodeEncryptionContext: Underflow, not enough data.`) * aws_last_error_is_SHORT_BUF(;);
-        (errorMessage == `decodeEncryptionContext: Not enough data to read key count.`) * aws_last_error_is_SHORT_BUF(;);
-        (errorMessage == `decodeEncryptionContext: Key Count is 0.`) * aws_last_error_is_BAD_CIPHERTEXT(;);
-        (errorMessage == `decodeEncryptionContext: Duplicate encryption context key value.`) * aws_last_error_is_BAD_CIPHERTEXT(;)
+    pred nounfold ECErrorCodeOfJSErrorMessage(errorMessage) {
+        (errorMessage == `decodeEncryptionContext: Underflow, not enough data.`) * aws_last_error_is_SHORT_BUF();
+        (errorMessage == `decodeEncryptionContext: Not enough data to read key count.`) * aws_last_error_is_SHORT_BUF();
+        (errorMessage == `decodeEncryptionContext: Key Count is 0.`) * aws_last_error_is_BAD_CIPHERTEXT();
+        (errorMessage == `decodeEncryptionContext: Duplicate encryption context key value.`) * aws_last_error_is_BAD_CIPHERTEXT()
     }
 */
 
 // Auxiliary predicates for capturing the loop invariant of the EC deserialisation
 /*@
-    pred enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys;) {
+    pred enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys) {
         (ECKS == elements) * (keys == consumedKeys @ restKeys)
     }
 
     pred nounfold enc_ctx_deser_invariant_cases(definition, elementsDef, aad_len, esLength, restEsLength, restLength, ECKs, elements, consumedElements, restElements, keys, consumedKeys, restKeys; errorMessage) {
         (definition == `Complete`) * (elementsDef == `Complete`) *
         (aad_len == 2 + esLength) *
-        enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys;) *
+        enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys) *
         (restEsLength == restLength) *
-        Unique(keys;) * (errorMessage == ``);
+        Unique(keys) * (errorMessage == ``);
 
         (definition == `Broken`) * (elementsDef == `Complete`) *
-        enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys;) *
-        Duplicated(consumedKeys, restKeys;) *
+        enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys) *
+        Duplicated(consumedKeys, restKeys) *
         (errorMessage == `decodeEncryptionContext: Duplicate encryption context key value.`);
 
         (definition == `Broken`) * (elementsDef == `Complete`) *
         (not (aad_len == 2 + esLength)) *
-        enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys;) *
-        Unique(keys;) * (errorMessage == `decodeEncryptionContext: Overflow, too much data.`);
+        enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys) *
+        Unique(keys) * (errorMessage == `decodeEncryptionContext: Overflow, too much data.`);
 
         (definition == `Broken`) * (elementsDef == `Incomplete`) *
-        Unique(keys;) * (errorMessage == `decodeEncryptionContext: Underflow, not enough data.`)
+        Unique(keys) * (errorMessage == `decodeEncryptionContext: Underflow, not enough data.`)
     }
 */
 
@@ -51,38 +51,38 @@ void aws_cryptosdk_enc_ctx_clear(struct aws_hash_table *enc_ctx) {
     spec aws_cryptosdk_enc_ctx_deserialize(alloc, enc_ctx, cursor) {
         requires:
             (alloc == #alloc) * (enc_ctx == #enc_ctx) * (cursor == #cursor) *
-            default_allocator(#alloc;) *
+            default_allocator(#alloc) *
             empty_hash_table_ptr(#enc_ctx; #alloc) *
             valid_aws_byte_cursor_ptr(#cursor; #aad_len, #buffer, #buffer_content) *
             (0 <# #aad_len) *
             (not (#buffer == NULL)) *
             (#definition == `Complete`) * (#errorMessage == ``) *
             CRawEncryptionContext(#buffer_content; #ECKs) *
-            any_aws_last_error(;)
+            any_aws_last_error()
 
         ensures:
-            default_allocator(#alloc;) *
+            default_allocator(#alloc) *
             valid_hash_table_ptr(#enc_ctx; #alloc, #ECKs, #utf8ECKs) *
             valid_aws_byte_cursor_ptr(#cursor; 0, #buffer p+ #aad_len, []) *
             ARRAY(#buffer, char, #aad_len, #buffer_content) *
-            any_aws_last_error(;) *
+            any_aws_last_error() *
             (ret == int(0))
 
     OR
 
         requires:
             (alloc == #alloc) * (enc_ctx == #enc_ctx) * (cursor == #cursor) *
-            default_allocator(#alloc;) *
+            default_allocator(#alloc) *
             empty_hash_table_ptr(#enc_ctx; #alloc) *
             valid_aws_byte_cursor_ptr(#cursor; #aad_len, #buffer, #buffer_content) *
             (0 <# #aad_len) *
             (not (#buffer == NULL)) *
             (#definition == `Broken`) * (#errorMessage == `decodeEncryptionContext: Overflow, too much data.`) *
             BRawEncryptionContext(#buffer_content; #errorMessage, #ECKs) *
-            any_aws_last_error(;)
+            any_aws_last_error()
 
         ensures:
-            default_allocator(#alloc;) *
+            default_allocator(#alloc) *
             valid_hash_table_ptr(#enc_ctx; #alloc, #ECKs, #utf8ECKs) *
             valid_aws_byte_cursor_ptr(#cursor; #rest_len, #new_buffer, #rest_buffer) *
             (#new_buffer == #buffer p+ #consumed_len) *
@@ -90,14 +90,14 @@ void aws_cryptosdk_enc_ctx_clear(struct aws_hash_table *enc_ctx) {
             (0 <# #consumed_len) *
             (0 <# #rest_len) *
             ARRAY(#buffer, char, #consumed_len, #consumed_content) *
-            any_aws_last_error(;) *
+            any_aws_last_error() *
             (ret == int(0))
 
     OR
 
         requires:
             (alloc == #alloc) * (enc_ctx == #enc_ctx) * (cursor == #cursor) *
-            default_allocator(#alloc;) *
+            default_allocator(#alloc) *
             empty_hash_table_ptr(#enc_ctx; #alloc) *
             valid_aws_byte_cursor_ptr(#cursor; #aad_len, #buffer, #buffer_content) *
             (0 <# #aad_len) *
@@ -105,17 +105,17 @@ void aws_cryptosdk_enc_ctx_clear(struct aws_hash_table *enc_ctx) {
             (#definition == `Broken`) *
             (not (#errorMessage == `decodeEncryptionContext: Overflow, too much data.`)) *
             BRawEncryptionContext(#buffer_content; #errorMessage, #ECKs) *
-            any_aws_last_error(;)
+            any_aws_last_error()
 
         ensures:
-            default_allocator(#alloc;) *
+            default_allocator(#alloc) *
             empty_hash_table_ptr(#enc_ctx; #alloc) *
             valid_aws_byte_cursor_ptr(#cursor; #rest_len, #new_buffer, #rest_buffer) *
             (#new_buffer == #buffer p+ #consumed_len) *
             (#buffer_content ==  #consumed_content @ #rest_buffer) *
             (#consumed_len == (#aad_len - #rest_len)) *
             optBytes(#buffer, #consumed_len; #consumed_content) *
-            ECErrorCodeOfJSErrorMessage(#errorMessage;) *
+            ECErrorCodeOfJSErrorMessage(#errorMessage) *
             (ret == int(-1))
     }
 */
@@ -153,8 +153,8 @@ int aws_cryptosdk_enc_ctx_deserialize(struct aws_allocator *alloc,
                         #consumedElements, #restElements, \
                         #res_1_trash, #res_trash, #k_trash, #v_trash, #wc_trash, #b1, #b2]] "
             // The allocator and error global variable
-            "   default_allocator(#alloc;) * \
-                any_aws_last_error(;) * "
+            "   default_allocator(#alloc) * \
+                any_aws_last_error() * "
             // i is the number of ECKs parsed
             "(i == int(#i)) * \
             (#i <=# #elem_count) * \

--- a/Gillian-C/examples/amazon/ec.c
+++ b/Gillian-C/examples/amazon/ec.c
@@ -8,7 +8,7 @@ void aws_cryptosdk_enc_ctx_clear(struct aws_hash_table *enc_ctx) {
 
 // A predicate that allows us to connect JS and C error messages
 /*@
-    pred nounfold ECErrorCodeOfJSErrorMessage(errorMessage) {
+    pred nounfold ECErrorCodeOfJSErrorMessage(errorMessage;) {
         (errorMessage == `decodeEncryptionContext: Underflow, not enough data.`) * aws_last_error_is_SHORT_BUF();
         (errorMessage == `decodeEncryptionContext: Not enough data to read key count.`) * aws_last_error_is_SHORT_BUF();
         (errorMessage == `decodeEncryptionContext: Key Count is 0.`) * aws_last_error_is_BAD_CIPHERTEXT();
@@ -18,11 +18,11 @@ void aws_cryptosdk_enc_ctx_clear(struct aws_hash_table *enc_ctx) {
 
 // Auxiliary predicates for capturing the loop invariant of the EC deserialisation
 /*@
-    pred enc_ctx_complete_case_equality(+ECKs, +elements, +restElements, +consumedElements, +keys, +consumedKeys, +restKeys) {
+    pred enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys;) {
         (ECKS == elements) * (keys == consumedKeys @ restKeys)
     }
 
-    pred nounfold enc_ctx_deser_invariant_cases(+definition, +elementsDef, +aad_len, +esLength, +restEsLength, +restLength, +ECKs, +elements, +consumedElements, +restElements, +keys, +consumedKeys, +restKeys, errorMessage) {
+    pred nounfold enc_ctx_deser_invariant_cases(definition, elementsDef, aad_len, esLength, restEsLength, restLength, ECKs, elements, consumedElements, restElements, keys, consumedKeys, restKeys; errorMessage) {
         (definition == `Complete`) * (elementsDef == `Complete`) *
         (aad_len == 2 + esLength) *
         enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys) *

--- a/Gillian-C/examples/amazon/ec.c
+++ b/Gillian-C/examples/amazon/ec.c
@@ -9,10 +9,10 @@ void aws_cryptosdk_enc_ctx_clear(struct aws_hash_table *enc_ctx) {
 // A predicate that allows us to connect JS and C error messages
 /*@
     pred nounfold ECErrorCodeOfJSErrorMessage(errorMessage;) {
-        (errorMessage == `decodeEncryptionContext: Underflow, not enough data.`) * aws_last_error_is_SHORT_BUF();
-        (errorMessage == `decodeEncryptionContext: Not enough data to read key count.`) * aws_last_error_is_SHORT_BUF();
-        (errorMessage == `decodeEncryptionContext: Key Count is 0.`) * aws_last_error_is_BAD_CIPHERTEXT();
-        (errorMessage == `decodeEncryptionContext: Duplicate encryption context key value.`) * aws_last_error_is_BAD_CIPHERTEXT()
+        (errorMessage == `decodeEncryptionContext: Underflow, not enough data.`) * aws_last_error_is_SHORT_BUF(;);
+        (errorMessage == `decodeEncryptionContext: Not enough data to read key count.`) * aws_last_error_is_SHORT_BUF(;);
+        (errorMessage == `decodeEncryptionContext: Key Count is 0.`) * aws_last_error_is_BAD_CIPHERTEXT(;);
+        (errorMessage == `decodeEncryptionContext: Duplicate encryption context key value.`) * aws_last_error_is_BAD_CIPHERTEXT(;)
     }
 */
 
@@ -25,22 +25,22 @@ void aws_cryptosdk_enc_ctx_clear(struct aws_hash_table *enc_ctx) {
     pred nounfold enc_ctx_deser_invariant_cases(definition, elementsDef, aad_len, esLength, restEsLength, restLength, ECKs, elements, consumedElements, restElements, keys, consumedKeys, restKeys; errorMessage) {
         (definition == `Complete`) * (elementsDef == `Complete`) *
         (aad_len == 2 + esLength) *
-        enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys) *
+        enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys;) *
         (restEsLength == restLength) *
-        Unique(keys) * (errorMessage == ``);
+        Unique(keys;) * (errorMessage == ``);
 
         (definition == `Broken`) * (elementsDef == `Complete`) *
-        enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys) *
-        Duplicated(consumedKeys, restKeys) *
+        enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys;) *
+        Duplicated(consumedKeys, restKeys;) *
         (errorMessage == `decodeEncryptionContext: Duplicate encryption context key value.`);
 
         (definition == `Broken`) * (elementsDef == `Complete`) *
         (not (aad_len == 2 + esLength)) *
-        enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys) *
-        Unique(keys) * (errorMessage == `decodeEncryptionContext: Overflow, too much data.`);
+        enc_ctx_complete_case_equality(ECKs, elements, restElements, consumedElements, keys, consumedKeys, restKeys;) *
+        Unique(keys;) * (errorMessage == `decodeEncryptionContext: Overflow, too much data.`);
 
         (definition == `Broken`) * (elementsDef == `Incomplete`) *
-        Unique(keys) * (errorMessage == `decodeEncryptionContext: Underflow, not enough data.`)
+        Unique(keys;) * (errorMessage == `decodeEncryptionContext: Underflow, not enough data.`)
     }
 */
 
@@ -51,71 +51,71 @@ void aws_cryptosdk_enc_ctx_clear(struct aws_hash_table *enc_ctx) {
     spec aws_cryptosdk_enc_ctx_deserialize(alloc, enc_ctx, cursor) {
         requires:
             (alloc == #alloc) * (enc_ctx == #enc_ctx) * (cursor == #cursor) *
-            default_allocator(#alloc) *
-            empty_hash_table_ptr(#enc_ctx, #alloc) *
-            valid_aws_byte_cursor_ptr(#cursor, #aad_len, #buffer, #buffer_content) *
+            default_allocator(#alloc;) *
+            empty_hash_table_ptr(#enc_ctx; #alloc) *
+            valid_aws_byte_cursor_ptr(#cursor; #aad_len, #buffer, #buffer_content) *
             (0 <# #aad_len) *
             (not (#buffer == NULL)) *
             (#definition == `Complete`) * (#errorMessage == ``) *
-            CRawEncryptionContext(#buffer_content, #ECKs) *
-            any_aws_last_error()
+            CRawEncryptionContext(#buffer_content; #ECKs) *
+            any_aws_last_error(;)
 
         ensures:
-            default_allocator(#alloc) *
-            valid_hash_table_ptr(#enc_ctx, #alloc, #ECKs, #utf8ECKs) *
-            valid_aws_byte_cursor_ptr(#cursor, 0, #buffer p+ #aad_len, []) *
+            default_allocator(#alloc;) *
+            valid_hash_table_ptr(#enc_ctx; #alloc, #ECKs, #utf8ECKs) *
+            valid_aws_byte_cursor_ptr(#cursor; 0, #buffer p+ #aad_len, []) *
             ARRAY(#buffer, char, #aad_len, #buffer_content) *
-            any_aws_last_error() *
+            any_aws_last_error(;) *
             (ret == int(0))
 
     OR
 
         requires:
             (alloc == #alloc) * (enc_ctx == #enc_ctx) * (cursor == #cursor) *
-            default_allocator(#alloc) *
-            empty_hash_table_ptr(#enc_ctx, #alloc) *
-            valid_aws_byte_cursor_ptr(#cursor, #aad_len, #buffer, #buffer_content) *
+            default_allocator(#alloc;) *
+            empty_hash_table_ptr(#enc_ctx; #alloc) *
+            valid_aws_byte_cursor_ptr(#cursor; #aad_len, #buffer, #buffer_content) *
             (0 <# #aad_len) *
             (not (#buffer == NULL)) *
             (#definition == `Broken`) * (#errorMessage == `decodeEncryptionContext: Overflow, too much data.`) *
-            BRawEncryptionContext(#buffer_content, #errorMessage, #ECKs) *
-            any_aws_last_error()
+            BRawEncryptionContext(#buffer_content; #errorMessage, #ECKs) *
+            any_aws_last_error(;)
 
         ensures:
-            default_allocator(#alloc) *
-            valid_hash_table_ptr(#enc_ctx, #alloc, #ECKs, #utf8ECKs) *
-            valid_aws_byte_cursor_ptr(#cursor, #rest_len, #new_buffer, #rest_buffer) *
+            default_allocator(#alloc;) *
+            valid_hash_table_ptr(#enc_ctx; #alloc, #ECKs, #utf8ECKs) *
+            valid_aws_byte_cursor_ptr(#cursor; #rest_len, #new_buffer, #rest_buffer) *
             (#new_buffer == #buffer p+ #consumed_len) *
             (#buffer_content ==  #consumed_content @ #rest_buffer) *
             (0 <# #consumed_len) *
             (0 <# #rest_len) *
             ARRAY(#buffer, char, #consumed_len, #consumed_content) *
-            any_aws_last_error() *
+            any_aws_last_error(;) *
             (ret == int(0))
 
     OR
 
         requires:
             (alloc == #alloc) * (enc_ctx == #enc_ctx) * (cursor == #cursor) *
-            default_allocator(#alloc) *
-            empty_hash_table_ptr(#enc_ctx, #alloc) *
-            valid_aws_byte_cursor_ptr(#cursor, #aad_len, #buffer, #buffer_content) *
+            default_allocator(#alloc;) *
+            empty_hash_table_ptr(#enc_ctx; #alloc) *
+            valid_aws_byte_cursor_ptr(#cursor; #aad_len, #buffer, #buffer_content) *
             (0 <# #aad_len) *
             (not (#buffer == NULL)) *
             (#definition == `Broken`) *
             (not (#errorMessage == `decodeEncryptionContext: Overflow, too much data.`)) *
-            BRawEncryptionContext(#buffer_content, #errorMessage, #ECKs) *
-            any_aws_last_error()
+            BRawEncryptionContext(#buffer_content; #errorMessage, #ECKs) *
+            any_aws_last_error(;)
 
         ensures:
-            default_allocator(#alloc) *
-            empty_hash_table_ptr(#enc_ctx, #alloc) *
-            valid_aws_byte_cursor_ptr(#cursor, #rest_len, #new_buffer, #rest_buffer) *
+            default_allocator(#alloc;) *
+            empty_hash_table_ptr(#enc_ctx; #alloc) *
+            valid_aws_byte_cursor_ptr(#cursor; #rest_len, #new_buffer, #rest_buffer) *
             (#new_buffer == #buffer p+ #consumed_len) *
             (#buffer_content ==  #consumed_content @ #rest_buffer) *
             (#consumed_len == (#aad_len - #rest_len)) *
-            optBytes(#buffer, #consumed_len, #consumed_content) *
-            ECErrorCodeOfJSErrorMessage(#errorMessage) *
+            optBytes(#buffer, #consumed_len; #consumed_content) *
+            ECErrorCodeOfJSErrorMessage(#errorMessage;) *
             (ret == int(-1))
     }
 */
@@ -137,7 +137,7 @@ int aws_cryptosdk_enc_ctx_deserialize(struct aws_allocator *alloc,
         return aws_raise_error(AWS_CRYPTOSDK_ERR_BAD_CIPHERTEXT);
 
     GILLIAN("assert [[bind #l_ec, #elem_count]] (elem_count == [#l_ec, 2]) * ARRAY(ptr(#l_ec, 0), int16, 1, [ #elem_count ]) ");
-    GILLIAN("assert [[bind #elementsDef, #elements, #esLength]] Elements(#buffer_content, 2, #elem_count, 2, #elementsDef, #elements, #esLength)");
+    GILLIAN("assert [[bind #elementsDef, #elements, #esLength]] Elements(#buffer_content, 2, #elem_count, 2; #elementsDef, #elements, #esLength)");
     GILLIAN("unfold Elements(#buffer_content, 2, #elem_count, 2, #elementsDef, #ECKS, #esLength)");
     GILLIAN("assert [[bind #lengthPtr]] (length == [#l, 2]) * (#lengthPtr == ptr(#l, 0))");
     GILLIAN(
@@ -145,7 +145,7 @@ int aws_cryptosdk_enc_ctx_deserialize(struct aws_allocator *alloc,
             (_res__1 == [#l_res_1, 16]) * (_res == [#l_res, 16]) * \
             (k_cursor == [#l_k_cursor, 16]) * (v_cursor == [#l_v_cursor, 16]) * \
             (was_created == [#l_wc, 4])");
-    GILLIAN("assert [[bind #keys]] FirstProj(#elements, #keys)");
+    GILLIAN("assert [[bind #keys]] FirstProj(#elements; #keys)");
     GILLIAN(
         "invariant: [[bind i, #i, #togo, #trash, #restBuffer, #restLength, \
                         #cbptr, #consumedLength, #consumedBuffer, #restEsLength, \
@@ -153,8 +153,8 @@ int aws_cryptosdk_enc_ctx_deserialize(struct aws_allocator *alloc,
                         #consumedElements, #restElements, \
                         #res_1_trash, #res_trash, #k_trash, #v_trash, #wc_trash, #b1, #b2]] "
             // The allocator and error global variable
-            "   default_allocator(#alloc) * \
-                any_aws_last_error() * "
+            "   default_allocator(#alloc;) * \
+                any_aws_last_error(;) * "
             // i is the number of ECKs parsed
             "(i == int(#i)) * \
             (#i <=# #elem_count) * \
@@ -167,8 +167,8 @@ int aws_cryptosdk_enc_ctx_deserialize(struct aws_allocator *alloc,
             (#consumedBuffer == lsub(#buffer_content, 2, #consumedLength)) * \
             (#buffer_content == [ #b1, #b2 ] @ #consumedBuffer @ #restBuffer) * \
             (#esLength == #consumedLength + #restEsLength) * \
-            optBytes(#buffer p+ 2, #consumedLength, #consumedBuffer) * \
-            valid_aws_byte_cursor_ptr(#cursor, #restLength, #cbptr, #restBuffer) * \
+            optBytes(#buffer p+ 2, #consumedLength; #consumedBuffer) * \
+            valid_aws_byte_cursor_ptr(#cursor; #restLength, #cbptr, #restBuffer) * \
             ((len #buffer_content) == #aad_len) * (len #restBuffer == #restLength) * \
             (0 <# #elem_count) * "
             // Spacial information about the table
@@ -176,18 +176,18 @@ int aws_cryptosdk_enc_ctx_deserialize(struct aws_allocator *alloc,
             // They are unique, so they can be put safely in the hashtable
             // The UTF8 condition is necessary for the hashtable strings to work
             // That information is required for the hash_table_put to work
-            "Elements(#buffer_content, 2 + #consumedLength, #togo, 2, #elementsDef, #restElements, #restEsLength) * \
-            FirstProj(#elements, #keys) * \
-            FirstProj(#consumedElements, #consumedKeys) * \
-            FirstProj(#restElements, #restKeys) * \
-            toUtf8PairMap(#consumedElements, #consumedUtf8Elements) * \
-            FirstProj(#consumedUtf8Elements, #consumedUtf8Keys) * \
-            toUtf8PairMap(#restElements, #restUtf8Elements) * \
-            valid_hash_table_ptr(#enc_ctx, #alloc, #consumedElements, #consumedUtf8Elements) * "
+            "Elements(#buffer_content, 2 + #consumedLength, #togo, 2; #elementsDef, #restElements, #restEsLength) * \
+            FirstProj(#elements; #keys) * \
+            FirstProj(#consumedElements; #consumedKeys) * \
+            FirstProj(#restElements; #restKeys) * \
+            toUtf8PairMap(#consumedElements; #consumedUtf8Elements) * \
+            FirstProj(#consumedUtf8Elements; #consumedUtf8Keys) * \
+            toUtf8PairMap(#restElements; #restUtf8Elements) * \
+            valid_hash_table_ptr(#enc_ctx; #alloc, #consumedElements, #consumedUtf8Elements) * "
             // The different cases represented in the invariant
             "enc_ctx_deser_invariant_cases( \
                 #definition, #elementsDef, #aad_len, #esLength, #restEsLength, #restLength, #ECKs, \
-                #elements, #consumedElements, #restElements, #keys, #consumedKeys, #restKeys, #errorMessage \
+                #elements, #consumedElements, #restElements, #keys, #consumedKeys, #restKeys; #errorMessage \
             ) * "
             // Csharpminor trickery, variable that are defined inside the loop
             // still need to be in the invariant because they are hoisted and treated as
@@ -259,7 +259,7 @@ int aws_cryptosdk_enc_ctx_deserialize(struct aws_allocator *alloc,
             aws_string_new_from_array(alloc, v_cursor.ptr, v_cursor.len);
 
         GILLIAN("apply ProduceListToSet(#consumedKeys)");
-        GILLIAN("assert [[bind #consumedKeySet]] ListToSet(#consumedKeys, #consumedKeySet)");
+        GILLIAN("assert [[bind #consumedKeySet]] ListToSet(#consumedKeys; #consumedKeySet)");
         GILLIAN("apply FirstProjConcatSplit(#elements, #consumedElements, #restElements)");
         GILLIAN("unfold FirstProj(#restElements, #restKeys)");
         GILLIAN("apply FirstProjToUtf8MapPairCompat(#consumedElements)");
@@ -300,8 +300,8 @@ int aws_cryptosdk_enc_ctx_deserialize(struct aws_allocator *alloc,
         GILLIAN("apply FirstProjAppendPair(#consumedElements, #consumedKeys, #this_key, #this_value)");
         GILLIAN("apply toUtf8PairMapAppendPair(#consumedElements, #consumedUtf8Elements, #this_key, #this_value)");
         GILLIAN("assert [[bind #utf8Key, #utf8Value]] \
-                    toUtf8(#this_key, #utf8Key) * \
-                    toUtf8(#this_value, #utf8Value)");
+                    toUtf8(#this_key; #utf8Key) * \
+                    toUtf8(#this_value; #utf8Value)");
         GILLIAN("apply FirstProjAppendPair(#consumedUtf8Elements, #consumedUtf8Keys, #utf8Key, #utf8Value)");
         GILLIAN("apply FirstProjToUtf8MapPairCompat(#consumedElements @ [ [#this_key, #this_value] ])");
     }

--- a/Gillian-C/examples/amazon/edk.c
+++ b/Gillian-C/examples/amazon/edk.c
@@ -4,7 +4,7 @@ void __for_edk_struct_to_appear(struct aws_cryptosdk_edk edk) { (void)edk; }
 
 // Predicates describing pointers to valid and empty EDKs
 /*@
-    pred nounfold valid_aws_cryptosdk_edk_ptr(+edk, alloc, edk_content) {
+    pred nounfold valid_aws_cryptosdk_edk_ptr(edk; alloc, edk_content) {
         (edk -> struct aws_cryptosdk_edk {
             #provider_id;
             #provider_info;
@@ -16,7 +16,7 @@ void __for_edk_struct_to_appear(struct aws_cryptosdk_edk edk) { (void)edk; }
         (edk_content == [#prov_id_content, #prov_info_content, #ct_content])
     }
 
-    pred nounfold empty_aws_cryptosdk_edk_ptr(+edk) {
+    pred nounfold empty_aws_cryptosdk_edk_ptr(edk;) {
         (edk -> struct aws_cryptosdk_edk {
             #provider_id;
             #provider_info;

--- a/Gillian-C/examples/amazon/edk.c
+++ b/Gillian-C/examples/amazon/edk.c
@@ -16,15 +16,15 @@ void __for_edk_struct_to_appear(struct aws_cryptosdk_edk edk) { (void)edk; }
         (edk_content == [#prov_id_content, #prov_info_content, #ct_content])
     }
 
-    pred nounfold empty_aws_cryptosdk_edk_ptr(edk;) {
+    pred nounfold empty_aws_cryptosdk_edk_ptr(edk) {
         (edk -> struct aws_cryptosdk_edk {
             #provider_id;
             #provider_info;
             #cipher_text
         }) *
-        empty_aws_byte_buf_fields(#provider_id;) *
-        empty_aws_byte_buf_fields(#provider_info;) *
-        empty_aws_byte_buf_fields(#ciphertext;)
+        empty_aws_byte_buf_fields(#provider_id) *
+        empty_aws_byte_buf_fields(#provider_info) *
+        empty_aws_byte_buf_fields(#ciphertext)
     }
 */
 
@@ -45,11 +45,11 @@ void aws_cryptosdk_edk_clean_up(struct aws_cryptosdk_edk *edk) {
         requires:
             (edk_list == #edk_list) *
             valid_edk_array_list_ptr(#edk_list; #alloc, #content) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
 
         ensures:
             empty_edk_array_list_ptr(#edk_list; #alloc) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
     }
 */
 void aws_cryptosdk_edk_list_clear(struct aws_array_list *edk_list) {

--- a/Gillian-C/examples/amazon/edk.c
+++ b/Gillian-C/examples/amazon/edk.c
@@ -10,9 +10,9 @@ void __for_edk_struct_to_appear(struct aws_cryptosdk_edk edk) { (void)edk; }
             #provider_info;
             #ciphertext
         }) *
-        valid_aws_byte_buf_fields(#provider_id, len #prov_id_content, len #prov_id_content, #prov_id_buffer, alloc, #prov_id_content) *
-        valid_aws_byte_buf_fields(#provider_info, len #prov_info_content, len #prov_info_content, #prov_info_buffer, alloc, #prov_info_content) *
-        valid_aws_byte_buf_fields(#ciphertext, len #ct_content, len #ct_content, #ct_buffer, alloc, #ct_content) *
+        valid_aws_byte_buf_fields(#provider_id; len #prov_id_content, len #prov_id_content, #prov_id_buffer, alloc, #prov_id_content) *
+        valid_aws_byte_buf_fields(#provider_info; len #prov_info_content, len #prov_info_content, #prov_info_buffer, alloc, #prov_info_content) *
+        valid_aws_byte_buf_fields(#ciphertext; len #ct_content, len #ct_content, #ct_buffer, alloc, #ct_content) *
         (edk_content == [#prov_id_content, #prov_info_content, #ct_content])
     }
 
@@ -22,9 +22,9 @@ void __for_edk_struct_to_appear(struct aws_cryptosdk_edk edk) { (void)edk; }
             #provider_info;
             #cipher_text
         }) *
-        empty_aws_byte_buf_fields(#provider_id) *
-        empty_aws_byte_buf_fields(#provider_info) *
-        empty_aws_byte_buf_fields(#ciphertext)
+        empty_aws_byte_buf_fields(#provider_id;) *
+        empty_aws_byte_buf_fields(#provider_info;) *
+        empty_aws_byte_buf_fields(#ciphertext;)
     }
 */
 
@@ -44,12 +44,12 @@ void aws_cryptosdk_edk_clean_up(struct aws_cryptosdk_edk *edk) {
     axiomatic spec aws_cryptosdk_edk_list_clear(edk_list) {
         requires:
             (edk_list == #edk_list) *
-            valid_edk_array_list_ptr(#edk_list, #alloc, #content) *
-            default_allocator(#alloc)
+            valid_edk_array_list_ptr(#edk_list; #alloc, #content) *
+            default_allocator(#alloc;)
 
         ensures:
-            empty_edk_array_list_ptr(#edk_list, #alloc) *
-            default_allocator(#alloc)
+            empty_edk_array_list_ptr(#edk_list; #alloc) *
+            default_allocator(#alloc;)
     }
 */
 void aws_cryptosdk_edk_list_clear(struct aws_array_list *edk_list) {

--- a/Gillian-C/examples/amazon/error.c
+++ b/Gillian-C/examples/amazon/error.c
@@ -20,11 +20,11 @@ static int tl_last_error = 0;
     }
 
     pred aws_last_error_is_SHORT_BUF(;) {
-        aws_last_error_is(3)
+        aws_last_error_is(3;)
     }
 
     pred aws_last_error_is_BAD_CIPHERTEXT(;) {
-        aws_last_error_is(8192)
+        aws_last_error_is(8192;)
     }
 */
 

--- a/Gillian-C/examples/amazon/error.c
+++ b/Gillian-C/examples/amazon/error.c
@@ -11,19 +11,19 @@ static int tl_last_error = 0;
 // Various predicates for describing errors
 /*@
 
-    pred any_aws_last_error() {
+    pred any_aws_last_error(;) {
         (error__tl_last_error -g> int(#trash))
     }
 
-    pred aws_last_error_is(err) {
+    pred aws_last_error_is(err;) {
         (error__tl_last_error -g> int(err))
     }
 
-    pred aws_last_error_is_SHORT_BUF() {
+    pred aws_last_error_is_SHORT_BUF(;) {
         aws_last_error_is(3)
     }
 
-    pred aws_last_error_is_BAD_CIPHERTEXT() {
+    pred aws_last_error_is_BAD_CIPHERTEXT(;) {
         aws_last_error_is(8192)
     }
 */

--- a/Gillian-C/examples/amazon/error.c
+++ b/Gillian-C/examples/amazon/error.c
@@ -11,20 +11,20 @@ static int tl_last_error = 0;
 // Various predicates for describing errors
 /*@
 
-    pred any_aws_last_error(;) {
+    pred any_aws_last_error() {
         (error__tl_last_error -g> int(#trash))
     }
 
-    pred aws_last_error_is(err;) {
+    pred aws_last_error_is(err) {
         (error__tl_last_error -g> int(err))
     }
 
-    pred aws_last_error_is_SHORT_BUF(;) {
-        aws_last_error_is(3;)
+    pred aws_last_error_is_SHORT_BUF() {
+        aws_last_error_is(3)
     }
 
-    pred aws_last_error_is_BAD_CIPHERTEXT(;) {
-        aws_last_error_is(8192;)
+    pred aws_last_error_is_BAD_CIPHERTEXT() {
+        aws_last_error_is(8192)
     }
 */
 

--- a/Gillian-C/examples/amazon/hash_table.c
+++ b/Gillian-C/examples/amazon/hash_table.c
@@ -6,23 +6,23 @@
 
     pred valid_hash_table_fields(fields; alloc, rawContents, contents) {
         (fields == [ #p_impl ]) * (not (#p_impl == NULL)) *
-        toUtf8PairMap(rawContents, contents) *
-        axiomatic_hash_table_in_memory(#p_impl, alloc, rawContents, contents)
+        toUtf8PairMap(rawContents; contents) *
+        axiomatic_hash_table_in_memory(#p_impl; alloc, rawContents, contents)
     }
 
     pred empty_hash_table_fields(fields; alloc) {
-        valid_hash_table_fields(fields, alloc, [], [])
+        valid_hash_table_fields(fields; alloc, [], [])
     }
 
     pred nounfold valid_hash_table_ptr(hash; alloc, rawContents, contents) {
         (hash -> struct aws_hash_table { #impl }) *
         (not (#impl == NULL)) *
-        toUtf8PairMap(rawContents, contents) *
-        axiomatic_hash_table_in_memory(#impl, alloc, rawContents, contents)
+        toUtf8PairMap(rawContents; contents) *
+        axiomatic_hash_table_in_memory(#impl; alloc, rawContents, contents)
     }
 
     pred empty_hash_table_ptr(hash; alloc) {
-        valid_hash_table_ptr(hash, alloc, nil, nil)
+        valid_hash_table_ptr(hash; alloc, nil, nil)
     }
 */
 
@@ -32,12 +32,12 @@
     axiomatic spec aws_hash_table_clear(hash) {
         requires:
             (hash == #hash) *
-            valid_hash_table_ptr(#hash, #alloc, #rawContents, #contents) *
-            default_allocator(#alloc)
+            valid_hash_table_ptr(#hash; #alloc, #rawContents, #contents) *
+            default_allocator(#alloc;)
 
         ensures:
-            empty_hash_table_ptr(#hash, #alloc) *
-            default_allocator(#alloc)
+            empty_hash_table_ptr(#hash; #alloc) *
+            default_allocator(#alloc;)
     }
 */
 
@@ -48,20 +48,20 @@
     axiomatic spec aws_hash_table_put(map, key, value, was_created) {
         requires:
             (map == #map) * (key == #key) * (value == #value) * (was_created == #wc) *
-            valid_aws_string_ptr(#key, #alloc, #rawKeyContent, #keyContent) *
-            valid_aws_string_ptr(#value, #alloc, #rawValueContent, #valueContent) *
-            valid_hash_table_ptr(map, #alloc, #mapRawContent, #mapContent) *
-            FirstProj(#mapContent, #keys) *
-            ListToSet(#keys, #keySet) *
+            valid_aws_string_ptr(#key; #alloc, #rawKeyContent, #keyContent) *
+            valid_aws_string_ptr(#value; #alloc, #rawValueContent, #valueContent) *
+            valid_hash_table_ptr(map; #alloc, #mapRawContent, #mapContent) *
+            FirstProj(#mapContent; #keys) *
+            ListToSet(#keys; #keySet) *
             ARRAY(#wc, int, 1, [ #trash ])
 
         ensures:
-            valid_hash_table_ptr(#map, #alloc, #mapRawContent @ [ [#rawKeyContent, #rawValueContent] ], #mapContent @ [ [#keyContent, #valueContent] ]) *
+            valid_hash_table_ptr(#map; #alloc, #mapRawContent @ [ [#rawKeyContent, #rawValueContent] ], #mapContent @ [ [#keyContent, #valueContent] ]) *
             (not (#keyContent --e-- #keySet)) *
             (#wc -> int(1)) *
             (ret == int(0));
 
-            valid_hash_table_ptr(#map, #alloc, #newRawContent, #newContent) *
+            valid_hash_table_ptr(#map; #alloc, #newRawContent, #newContent) *
             (#keyContent --e-- #keySet) *
             (#wc -> int(0)) *
             (ret == int(0))

--- a/Gillian-C/examples/amazon/hash_table.c
+++ b/Gillian-C/examples/amazon/hash_table.c
@@ -4,24 +4,24 @@
 /*@
     import `logic/hash_table_ax`;
 
-    pred valid_hash_table_fields(+fields, alloc, rawContents, contents) {
+    pred valid_hash_table_fields(fields; alloc, rawContents, contents) {
         (fields == [ #p_impl ]) * (not (#p_impl == NULL)) *
         toUtf8PairMap(rawContents, contents) *
         axiomatic_hash_table_in_memory(#p_impl, alloc, rawContents, contents)
     }
 
-    pred empty_hash_table_fields(+fields, alloc) {
+    pred empty_hash_table_fields(fields; alloc) {
         valid_hash_table_fields(fields, alloc, [], [])
     }
 
-    pred nounfold valid_hash_table_ptr(+hash, alloc, rawContents, contents) {
+    pred nounfold valid_hash_table_ptr(hash; alloc, rawContents, contents) {
         (hash -> struct aws_hash_table { #impl }) *
         (not (#impl == NULL)) *
         toUtf8PairMap(rawContents, contents) *
         axiomatic_hash_table_in_memory(#impl, alloc, rawContents, contents)
     }
 
-    pred empty_hash_table_ptr(+hash, alloc) {
+    pred empty_hash_table_ptr(hash; alloc) {
         valid_hash_table_ptr(hash, alloc, nil, nil)
     }
 */

--- a/Gillian-C/examples/amazon/hash_table.c
+++ b/Gillian-C/examples/amazon/hash_table.c
@@ -33,11 +33,11 @@
         requires:
             (hash == #hash) *
             valid_hash_table_ptr(#hash; #alloc, #rawContents, #contents) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
 
         ensures:
             empty_hash_table_ptr(#hash; #alloc) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
     }
 */
 

--- a/Gillian-C/examples/amazon/header.c
+++ b/Gillian-C/examples/amazon/header.c
@@ -44,10 +44,10 @@ pred nounfold any_valid_aws_cryptosdk_hdr(hdr; allocator) {
     #auth_len
   }) *
   (not (allocator == NULL)) *
-  valid_aws_byte_buf_fields(#iv, #len_iv, #cap_iv, #buf_iv, #iv_alloc, #content_iv) * or_NULL(allocator, #iv_alloc) *
-  valid_aws_byte_buf_fields(#auth_tag, #len_auth_tag, #cap_auth_tag, #buf_auth_tag, #auth_tag_alloc, #content_auth_tag) * or_NULL(allocator, #auth_tag_alloc) *
-  valid_hash_table_fields(#enc_ctx, allocator, #ctx_content, #ctx_content_utf8) *
-  valid_edk_array_list_fields(#edk_list, allocator, #edk_content)
+  valid_aws_byte_buf_fields(#iv; #len_iv, #cap_iv, #buf_iv, #iv_alloc, #content_iv) * or_NULL(allocator, #iv_alloc;) *
+  valid_aws_byte_buf_fields(#auth_tag; #len_auth_tag, #cap_auth_tag, #buf_auth_tag, #auth_tag_alloc, #content_auth_tag) * or_NULL(allocator, #auth_tag_alloc;) *
+  valid_hash_table_fields(#enc_ctx; allocator, #ctx_content, #ctx_content_utf8) *
+  valid_edk_array_list_fields(#edk_list; allocator, #edk_content)
 }
 */
 
@@ -66,10 +66,10 @@ pred nounfold empty_aws_cryptosdk_hdr(hdr; allocator) {
     long(0)
   }) *
   (not (allocator == NULL)) *
-  empty_aws_byte_buf_fields(#iv) *
-  empty_aws_byte_buf_fields(#auth_tag) *
-  empty_hash_table_fields(#enc_ctx, allocator) *
-  empty_edk_array_list_fields(#edk_list, allocator)
+  empty_aws_byte_buf_fields(#iv;) *
+  empty_aws_byte_buf_fields(#auth_tag;) *
+  empty_hash_table_fields(#enc_ctx; allocator) *
+  empty_edk_array_list_fields(#edk_list; allocator)
 }
 */
 
@@ -88,12 +88,12 @@ pred nounfold header_struct(hdr; allocator, alg_id, message_id, enc_ctx_content,
     long(auth_len)
   }) *
   (not (allocator == NULL)) *
-  valid_aws_byte_buf_fields(#iv, len iv, len iv, #iv_buf, allocator, iv) *
+  valid_aws_byte_buf_fields(#iv; len iv, len iv, #iv_buf, allocator, iv) *
   (0 <# len iv) * (not (#iv_buf == NULL)) *
-  valid_aws_byte_buf_fields(#auth_tag, len auth_tag, len auth_tag, #auth_buf, allocator, auth_tag) *
+  valid_aws_byte_buf_fields(#auth_tag; len auth_tag, len auth_tag, #auth_buf, allocator, auth_tag) *
   (0 <# len auth_tag) * (not (#auth_buf == NULL)) *
-  valid_hash_table_fields(#enc_ctx, allocator, enc_ctx_content, #enc_ctx_utf8) *
-  valid_edk_array_list_fields(#edk_list, allocator, edk_content)
+  valid_hash_table_fields(#enc_ctx; allocator, enc_ctx_content, #enc_ctx_utf8) *
+  valid_edk_array_list_fields(#edk_list; allocator, edk_content)
 }
 */
 
@@ -107,8 +107,8 @@ pred nounfold header_struct(hdr; allocator, alg_id, message_id, enc_ctx_content,
             (content_type == int(#ct))
 
         ensures:
-            CContentType(#ct) * (ret == TRUE);
-            BContentType(#ct) * (ret == FALSE)
+            CContentType(#ct;) * (ret == TRUE);
+            BContentType(#ct;) * (ret == FALSE)
     }
 */
 int is_known_type(uint8_t content_type) {
@@ -129,20 +129,20 @@ int is_known_type(uint8_t content_type) {
     spec aws_cryptosdk_algorithm_is_known(alg_id) {
         requires:
             (alg_id == int(#alg_id)) *
-            CAlgorithmSuite(#alg_id, #stringId, #ivLength, #tagLength)
+            CAlgorithmSuite(#alg_id; #stringId, #ivLength, #tagLength)
 
         ensures:
-            CAlgorithmSuite(#alg_id, #stringId, #ivLength, #tagLength) *
+            CAlgorithmSuite(#alg_id; #stringId, #ivLength, #tagLength) *
             (ret == TRUE)
 
     OR
 
         requires:
             (alg_id == int(#alg_id)) *
-            BAlgorithmSuite(#alg_id, #errorMessage)
+            BAlgorithmSuite(#alg_id; #errorMessage)
 
         ensures:
-            BAlgorithmSuite(#alg_id, #errorMessage) *
+            BAlgorithmSuite(#alg_id; #errorMessage) *
             (ret == FALSE)
     }
 */
@@ -173,20 +173,20 @@ int aws_cryptosdk_algorithm_is_known(uint16_t alg_id) {
     spec aws_cryptosdk_algorithm_ivlen(alg_id) {
         requires:
             (alg_id == int(#alg_id)) *
-            CAlgorithmSuite(#alg_id, #stringId, #ivLength, #tagLength)
+            CAlgorithmSuite(#alg_id; #stringId, #ivLength, #tagLength)
 
         ensures:
-            CAlgorithmSuite(#alg_id, #stringId, #ivLength, #tagLength) *
+            CAlgorithmSuite(#alg_id; #stringId, #ivLength, #tagLength) *
             (ret == int(#ivLength))
 
     OR
 
         requires:
             (alg_id == int(#alg_id)) *
-            BAlgorithmSuite(#alg_id, #errorMessage)
+            BAlgorithmSuite(#alg_id; #errorMessage)
 
         ensures:
-            BAlgorithmSuite(#alg_id, #errorMessage) *
+            BAlgorithmSuite(#alg_id; #errorMessage) *
             (ret == int(-1))
     }
 */
@@ -208,20 +208,20 @@ int aws_cryptosdk_algorithm_ivlen(uint16_t alg_id) {
     spec aws_cryptosdk_algorithm_taglen(alg_id) {
         requires:
             (alg_id == int(#alg_id)) *
-            CAlgorithmSuite(#alg_id, #stringId, #ivLength, #tagLength)
+            CAlgorithmSuite(#alg_id; #stringId, #ivLength, #tagLength)
 
         ensures:
-            CAlgorithmSuite(#alg_id, #stringId, #ivLength, #tagLength) *
+            CAlgorithmSuite(#alg_id; #stringId, #ivLength, #tagLength) *
             (ret == int(#tagLength))
 
     OR
 
         requires:
             (alg_id == int(#alg_id)) *
-            BAlgorithmSuite(#alg_id, #errorMessage)
+            BAlgorithmSuite(#alg_id; #errorMessage)
 
         ensures:
-            BAlgorithmSuite(#alg_id, #errorMessage) *
+            BAlgorithmSuite(#alg_id; #errorMessage) *
             (ret == int(-1))
     }
 */
@@ -241,12 +241,12 @@ int aws_cryptosdk_algorithm_taglen(uint16_t alg_id) {
     spec aws_cryptosdk_hdr_clear(hdr) {
         requires:
             (hdr == #hdr) *
-            any_valid_aws_cryptosdk_hdr(#hdr, #alloc) *
-            default_allocator(#alloc)
+            any_valid_aws_cryptosdk_hdr(#hdr; #alloc) *
+            default_allocator(#alloc;)
 
         ensures:
-            empty_aws_cryptosdk_hdr(#hdr, #alloc) *
-            default_allocator(#alloc)
+            empty_aws_cryptosdk_hdr(#hdr; #alloc) *
+            default_allocator(#alloc;)
     }
 */
 void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
@@ -277,11 +277,11 @@ void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
     spec parse_edk(allocator, edk, cur) {
         requires:
             (allocator == #alloc) * (edk == #edk) * (cur == #cur) *
-            default_allocator(#alloc) *
-            Element(#content, 0, 3, #definition, #edk_content, #element_length) *
-            valid_aws_byte_cursor_ptr(#cur, #total_length, #buffer, #content) *
+            default_allocator(#alloc;) *
+            Element(#content, 0, 3; #definition, #edk_content, #element_length) *
+            valid_aws_byte_cursor_ptr(#cur; #total_length, #buffer, #content) *
             (not (#buffer == NULL)) *
-            any_aws_last_error() *
+            any_aws_last_error(;) *
             ARRAY(#edk, long, 12, #trash) *
 
             (#content == #edk_raw_content @ #rest) *
@@ -289,24 +289,24 @@ void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
             (len #rest == #total_length - #element_length)
 
         ensures:
-            default_allocator(#alloc) *
+            default_allocator(#alloc;) *
             (#definition == `Complete`) *
-            valid_aws_byte_cursor_ptr(#cur, #total_length - #element_length, #buffer p+ #element_length, #rest) *
-            valid_aws_cryptosdk_edk_ptr(#edk, #alloc, #edk_content) *
+            valid_aws_byte_cursor_ptr(#cur; #total_length - #element_length, #buffer p+ #element_length, #rest) *
+            valid_aws_cryptosdk_edk_ptr(#edk; #alloc, #edk_content) *
             ARRAY(#buffer, char, #element_length, #edk_raw_content) *
-            any_aws_last_error() *
+            any_aws_last_error(;) *
             (ret == int(0));
 
-            default_allocator(#alloc) *
+            default_allocator(#alloc;) *
             (#definition == `Incomplete`) *
-            valid_aws_byte_cursor_ptr(#cur, #left_length, #new_buffer, #restAfterConsuming) *
+            valid_aws_byte_cursor_ptr(#cur; #left_length, #new_buffer, #restAfterConsuming) *
             (0 <=# #consumed_length) *
             (#consumed_length == #total_length - #left_length) *
             (#new_buffer == #buffer p+ #consumed_length) *
-            empty_aws_cryptosdk_edk_ptr(#edk) *
-            optBytes(#buffer, #consumed_length, #consumed_data) *
+            empty_aws_cryptosdk_edk_ptr(#edk;) *
+            optBytes(#buffer, #consumed_length; #consumed_data) *
             (#content == #consumed_data @ #restAfterConsuming) *
-            aws_last_error_is_SHORT_BUF() *
+            aws_last_error_is_SHORT_BUF(;) *
             (ret == int(-1))
 }
 */
@@ -398,37 +398,37 @@ MEM_ERR:
     spec aws_cryptosdk_hdr_parse(hdr, pcursor) {
         requires:
             (hdr == #hdr) * (pcursor == #pcursor) *
-            valid_aws_byte_cursor_ptr(#pcursor, #length, #buffer, #data) *
-            Header(#data, #definition, #part_one, #version, #type, #suiteId, #messageId,
+            valid_aws_byte_cursor_ptr(#pcursor; #length, #buffer, #data) *
+            Header(#data; #definition, #part_one, #version, #type, #suiteId, #messageId,
                    #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength,
                    #frameLength, #headerLength, #headerIv, #headerAuthTag, #edkDef, #errorMessage) *
             (#length == len #data) *
             (#length <# 2147483647) *
-            any_valid_aws_cryptosdk_hdr(#hdr, #alloc) *
-            default_allocator(#alloc) *
-            any_aws_last_error()
+            any_valid_aws_cryptosdk_hdr(#hdr; #alloc) *
+            default_allocator(#alloc;) *
+            any_aws_last_error(;)
 
         ensures:
             (#definition == `Complete`) *
             ARRAY(#buffer, char, #length, #data) *
-            valid_aws_byte_cursor_ptr(#pcursor, 0, #end_buffer, []) *
-            header_struct(#hdr, #alloc, #suiteId, #messageId, #ECKs, #EDKs, #frameLength, #headerLength, #headerIv, #headerAuthTag) *
-            default_allocator(#alloc) *
-            any_aws_last_error() *
+            valid_aws_byte_cursor_ptr(#pcursor; 0, #end_buffer, []) *
+            header_struct(#hdr; #alloc, #suiteId, #messageId, #ECKs, #EDKs, #frameLength, #headerLength, #headerIv, #headerAuthTag) *
+            default_allocator(#alloc;) *
+            any_aws_last_error(;) *
             (ret == int(0));
 
             (#definition == `Incomplete`) *
-            valid_aws_byte_cursor_ptr(#pcursor, #length, #buffer, #data) *
-            empty_aws_cryptosdk_hdr(#hdr, #alloc) *
-            default_allocator(#alloc) *
-            aws_last_error_is_SHORT_BUF() *
+            valid_aws_byte_cursor_ptr(#pcursor; #length, #buffer, #data) *
+            empty_aws_cryptosdk_hdr(#hdr; #alloc) *
+            default_allocator(#alloc;) *
+            aws_last_error_is_SHORT_BUF(;) *
             (ret == int(-1));
 
             (#definition == `Broken`) *
-            valid_aws_byte_cursor_ptr(#pcursor, #length, #buffer, #data) *
-            empty_aws_cryptosdk_hdr(#hdr, #alloc) *
-            default_allocator(#alloc) *
-            aws_last_error_is_BAD_CIPHERTEXT() *
+            valid_aws_byte_cursor_ptr(#pcursor; #length, #buffer, #data) *
+            empty_aws_cryptosdk_hdr(#hdr; #alloc) *
+            default_allocator(#alloc;) *
+            aws_last_error_is_BAD_CIPHERTEXT(;) *
             (ret == int(-1))
   }
 */
@@ -563,8 +563,8 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
                 (#eList == #EDKs) * \
                 (#EDKsAndRest == lsub(#part_three, 2, (len #part_three) - 2)) * \
                 (#EDKsAndRest == #justEDKs @ #restOfHeader) * \
-                CElements(#EDKsAndRest, 0, #edk_count, 3, #eList, #totalEDKLength) * \
-                valid_aws_byte_cursor_ptr(#cur, #atEDKs, #bptr, #EDKsAndRest) \
+                CElements(#EDKsAndRest, 0, #edk_count, 3; #eList, #totalEDKLength) * \
+                valid_aws_byte_cursor_ptr(#cur; #atEDKs, #bptr, #EDKsAndRest) \
         } else { \
             if (#edkDef = `Incomplete`) { \
                 assert [[bind #edk_al, #edkLenb0, #edkLenb1, #justEDKs, #EDKsAndRest, #restOfHeader, #totalEDKLength, #atEDKs, #bptr, #eList]] \
@@ -572,8 +572,8 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
                     (#edks == ([ #edkLenb0, #edkLenb1 ] @ #justEDKs)) * \
                     (#EDKsAndRest == lsub(#part_three, 2, (len #part_three) - 2)) * \
                     (#EDKsAndRest == #justEDKs @ #restOfHeader) * \
-                    IElements(#EDKsAndRest, 0, #edk_count, 3, #eList, #totalEDKLength) * \
-                    valid_aws_byte_cursor_ptr(#cur, #atEDKs, #bptr, #EDKsAndRest) \
+                    IElements(#EDKsAndRest, 0, #edk_count, 3; #eList, #totalEDKLength) * \
+                    valid_aws_byte_cursor_ptr(#cur; #atEDKs, #bptr, #EDKsAndRest) \
             } else { \
                 assert False \
             } \
@@ -585,17 +585,17 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
         "invariant: \
             [[bind i, #i, #cbptr, #readLength, #readEDKs, #leftEDKs, #restEDKsAndRest, \
                    #acc, #rest_count, #restEDKs, #restEDKLength, #restLength, #trash]] \
-            any_aws_last_error() * \
-            (i == int(#i)) * default_allocator(#alloc) * \
+            any_aws_last_error(;) * \
+            (i == int(#i)) * default_allocator(#alloc;) * \
             (#hdr -> ptr(#all, #alo)) * (#alloc == ptr(#all, #alo)) * \
-            optBytes(#bptr, #readLength, #readEDKs) * \
+            optBytes(#bptr, #readLength; #readEDKs) * \
             (#readLength == len #readEDKs) * \
             (len #data == 22 + #ECLength + 2 + #readLength + #restLength) * \
-            valid_aws_byte_cursor_ptr(#cur, #restLength, #cbptr, #restEDKsAndRest) * \
-            valid_edk_array_list_ptr(#edk_al, #alloc, #acc) * \
+            valid_aws_byte_cursor_ptr(#cur; #restLength, #cbptr, #restEDKsAndRest) * \
+            valid_edk_array_list_ptr(#edk_al; #alloc, #acc) * \
             (len #acc == #i) * (#eList == #acc @ #restEDKs) * \
             (#i <=# #edk_count) * \
-            Elements(#restEDKsAndRest, 0, #rest_count, 3, #edkDef, #restEDKs, #restEDKLength) * \
+            Elements(#restEDKsAndRest, 0, #rest_count, 3; #edkDef, #restEDKs, #restEDKLength) * \
             (#restLength == len #restEDKsAndRest) * \
             (#rest_count == (#edk_count - #i)) * \
             (#restLength == (#atEDKs - #readLength)) * \

--- a/Gillian-C/examples/amazon/header.c
+++ b/Gillian-C/examples/amazon/header.c
@@ -278,7 +278,7 @@ void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
         requires:
             (allocator == #alloc) * (edk == #edk) * (cur == #cur) *
             default_allocator(#alloc) *
-            Element(#definition, #content, 0, 3, #edk_content, #element_length) *
+            Element(#content, 0, 3, #definition, #edk_content, #element_length) *
             valid_aws_byte_cursor_ptr(#cur, #total_length, #buffer, #content) *
             (not (#buffer == NULL)) *
             any_aws_last_error() *
@@ -318,7 +318,7 @@ int parse_edk(struct aws_allocator *allocator, struct aws_cryptosdk_edk *edk,
     memset(edk, 0, sizeof(*edk));
 
     GILLIAN("apply valid_aws_byte_cursor_ptr_facts(#cur, #total_length, #buffer, #content)");
-    GILLIAN("unfold Element(#definition, #content, 0, 3, #edk_content, #element_length)");
+    GILLIAN("unfold Element(#content, 0, 3, #definition, #edk_content, #element_length)");
     GILLIAN(
         "if (#definition = `Complete`) { \
             unfold CElement(#content, 0, 3, #edk_content, #element_length) \
@@ -399,7 +399,7 @@ MEM_ERR:
         requires:
             (hdr == #hdr) * (pcursor == #pcursor) *
             valid_aws_byte_cursor_ptr(#pcursor, #length, #buffer, #data) *
-            Header(#definition, #data, #part_one, #version, #type, #suiteId, #messageId,
+            Header(#data, #definition, #part_one, #version, #type, #suiteId, #messageId,
                    #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength,
                    #frameLength, #headerLength, #headerIv, #headerAuthTag, #edkDef, #errorMessage) *
             (#length == len #data) *
@@ -436,7 +436,7 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
                             struct aws_byte_cursor *pcursor) {
 
     GILLIAN(
-        "unfold Header(#definition, #data, #part_one, #version, #type, \
+        "unfold Header(#data, #definition, #part_one, #version, #type, \
             #suiteId, #messageId, #ECLength, #part_two, #ECKs, \
             #part_three, #EDKs, #contentType, #headerIvLength, \
             #frameLength, #headerLength, #headerIv, #headerAuthTag, #edkDef, #errorMessage) \
@@ -510,7 +510,7 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
 
     GILLIAN("unfold_all Elements");
     if (aad_len) {
-        GILLIAN("if (#definition = `Broken`) { if (#ECDef = `Broken`) { unfold BRawEncryptionContext(#errorMessage, #BEC, #ECKs) } }");
+        GILLIAN("if (#definition = `Broken`) { if (#ECDef = `Broken`) { unfold BRawEncryptionContext(#BEC, #errorMessage, #ECKs) } }");
         struct aws_byte_cursor aad = aws_byte_cursor_advance(&cur, aad_len);
         if (!aad.ptr)
             goto SHORT_BUF;
@@ -595,7 +595,7 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
             valid_edk_array_list_ptr(#edk_al, #alloc, #acc) * \
             (len #acc == #i) * (#eList == #acc @ #restEDKs) * \
             (#i <=# #edk_count) * \
-            Elements(#edkDef, #restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength) * \
+            Elements(#restEDKsAndRest, 0, #rest_count, 3, #edkDef, #restEDKs, #restEDKLength) * \
             (#restLength == len #restEDKsAndRest) * \
             (#rest_count == (#edk_count - #i)) * \
             (#restLength == (#atEDKs - #readLength)) * \
@@ -612,7 +612,7 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
 
         GILLIAN("unfold_all i__ptr");
         GILLIAN("unfold_all i__ptr_add");
-        GILLIAN("unfold Elements(#edkDef, #restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength)");
+        GILLIAN("unfold Elements(#restEDKsAndRest, 0, #rest_count, 3, #edkDef, #restEDKs, #restEDKLength)");
         GILLIAN(
             "if (#edkDef = `Complete`) { \
                 unfold CElements(#restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength) \
@@ -647,12 +647,12 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
     GILLIAN("assert (len #acc == #edk_count)");
     GILLIAN(
         "if (#edkDef = `Incomplete`) { \
-            unfold Elements(#edkDef, #restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength); \
+            unfold Elements(#restEDKsAndRest, 0, #rest_count, 3, #edkDef, #restEDKs, #restEDKLength); \
             unfold IElements(#restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength) \
         }");
     GILLIAN("assert (len #restEDKs == 0) ");
     GILLIAN("assert (#rest_count == 0) * (#EDKs == #acc) ");
-    GILLIAN("unfold Elements(#edkDef, #restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength)");
+    GILLIAN("unfold Elements(#restEDKsAndRest, 0, #rest_count, 3, #edkDef, #restEDKs, #restEDKLength)");
     GILLIAN("unfold CElements(#restEDKsAndRest, 0, #rest_count, 3, #restEDKs, #restEDKLength)");
     GILLIAN("assert (len #leftEDKs == 0)");
 

--- a/Gillian-C/examples/amazon/header.c
+++ b/Gillian-C/examples/amazon/header.c
@@ -23,7 +23,7 @@
 
 // Optional value or null
 /*@
-pred or_NULL(+x, +x_opt) {
+pred or_NULL(x, x_opt;) {
     x_opt == x;
     x_opt == NULL
 }
@@ -31,7 +31,7 @@ pred or_NULL(+x, +x_opt) {
 
 // Any valid header
 /*@
-pred nounfold any_valid_aws_cryptosdk_hdr(+hdr, allocator) {
+pred nounfold any_valid_aws_cryptosdk_hdr(hdr; allocator) {
   (hdr -> struct aws_cryptosdk_hdr {
     allocator;
     #alg_id;
@@ -53,7 +53,7 @@ pred nounfold any_valid_aws_cryptosdk_hdr(+hdr, allocator) {
 
 // Empty header
 /*@
-pred nounfold empty_aws_cryptosdk_hdr(+hdr, allocator) {
+pred nounfold empty_aws_cryptosdk_hdr(hdr; allocator) {
   (hdr -> struct aws_cryptosdk_hdr {
     allocator;
     int(0);
@@ -75,7 +75,7 @@ pred nounfold empty_aws_cryptosdk_hdr(+hdr, allocator) {
 
 // Deserialised header
 /*@
-pred nounfold header_struct(+hdr, allocator, alg_id, message_id, enc_ctx_content, edk_content, frame_len, auth_len, iv, auth_tag) {
+pred nounfold header_struct(hdr; allocator, alg_id, message_id, enc_ctx_content, edk_content, frame_len, auth_len, iv, auth_tag) {
   (hdr -> struct aws_cryptosdk_hdr {
     allocator;
     int(alg_id);

--- a/Gillian-C/examples/amazon/header.c
+++ b/Gillian-C/examples/amazon/header.c
@@ -23,7 +23,7 @@
 
 // Optional value or null
 /*@
-pred or_NULL(x, x_opt;) {
+pred or_NULL(x, x_opt) {
     x_opt == x;
     x_opt == NULL
 }
@@ -44,8 +44,8 @@ pred nounfold any_valid_aws_cryptosdk_hdr(hdr; allocator) {
     #auth_len
   }) *
   (not (allocator == NULL)) *
-  valid_aws_byte_buf_fields(#iv; #len_iv, #cap_iv, #buf_iv, #iv_alloc, #content_iv) * or_NULL(allocator, #iv_alloc;) *
-  valid_aws_byte_buf_fields(#auth_tag; #len_auth_tag, #cap_auth_tag, #buf_auth_tag, #auth_tag_alloc, #content_auth_tag) * or_NULL(allocator, #auth_tag_alloc;) *
+  valid_aws_byte_buf_fields(#iv; #len_iv, #cap_iv, #buf_iv, #iv_alloc, #content_iv) * or_NULL(allocator, #iv_alloc) *
+  valid_aws_byte_buf_fields(#auth_tag; #len_auth_tag, #cap_auth_tag, #buf_auth_tag, #auth_tag_alloc, #content_auth_tag) * or_NULL(allocator, #auth_tag_alloc) *
   valid_hash_table_fields(#enc_ctx; allocator, #ctx_content, #ctx_content_utf8) *
   valid_edk_array_list_fields(#edk_list; allocator, #edk_content)
 }
@@ -66,8 +66,8 @@ pred nounfold empty_aws_cryptosdk_hdr(hdr; allocator) {
     long(0)
   }) *
   (not (allocator == NULL)) *
-  empty_aws_byte_buf_fields(#iv;) *
-  empty_aws_byte_buf_fields(#auth_tag;) *
+  empty_aws_byte_buf_fields(#iv) *
+  empty_aws_byte_buf_fields(#auth_tag) *
   empty_hash_table_fields(#enc_ctx; allocator) *
   empty_edk_array_list_fields(#edk_list; allocator)
 }
@@ -107,8 +107,8 @@ pred nounfold header_struct(hdr; allocator, alg_id, message_id, enc_ctx_content,
             (content_type == int(#ct))
 
         ensures:
-            CContentType(#ct;) * (ret == TRUE);
-            BContentType(#ct;) * (ret == FALSE)
+            CContentType(#ct) * (ret == TRUE);
+            BContentType(#ct) * (ret == FALSE)
     }
 */
 int is_known_type(uint8_t content_type) {
@@ -242,11 +242,11 @@ int aws_cryptosdk_algorithm_taglen(uint16_t alg_id) {
         requires:
             (hdr == #hdr) *
             any_valid_aws_cryptosdk_hdr(#hdr; #alloc) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
 
         ensures:
             empty_aws_cryptosdk_hdr(#hdr; #alloc) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
     }
 */
 void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
@@ -277,11 +277,11 @@ void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
     spec parse_edk(allocator, edk, cur) {
         requires:
             (allocator == #alloc) * (edk == #edk) * (cur == #cur) *
-            default_allocator(#alloc;) *
+            default_allocator(#alloc) *
             Element(#content, 0, 3; #definition, #edk_content, #element_length) *
             valid_aws_byte_cursor_ptr(#cur; #total_length, #buffer, #content) *
             (not (#buffer == NULL)) *
-            any_aws_last_error(;) *
+            any_aws_last_error() *
             ARRAY(#edk, long, 12, #trash) *
 
             (#content == #edk_raw_content @ #rest) *
@@ -289,24 +289,24 @@ void aws_cryptosdk_hdr_clear(struct aws_cryptosdk_hdr *hdr) {
             (len #rest == #total_length - #element_length)
 
         ensures:
-            default_allocator(#alloc;) *
+            default_allocator(#alloc) *
             (#definition == `Complete`) *
             valid_aws_byte_cursor_ptr(#cur; #total_length - #element_length, #buffer p+ #element_length, #rest) *
             valid_aws_cryptosdk_edk_ptr(#edk; #alloc, #edk_content) *
             ARRAY(#buffer, char, #element_length, #edk_raw_content) *
-            any_aws_last_error(;) *
+            any_aws_last_error() *
             (ret == int(0));
 
-            default_allocator(#alloc;) *
+            default_allocator(#alloc) *
             (#definition == `Incomplete`) *
             valid_aws_byte_cursor_ptr(#cur; #left_length, #new_buffer, #restAfterConsuming) *
             (0 <=# #consumed_length) *
             (#consumed_length == #total_length - #left_length) *
             (#new_buffer == #buffer p+ #consumed_length) *
-            empty_aws_cryptosdk_edk_ptr(#edk;) *
+            empty_aws_cryptosdk_edk_ptr(#edk) *
             optBytes(#buffer, #consumed_length; #consumed_data) *
             (#content == #consumed_data @ #restAfterConsuming) *
-            aws_last_error_is_SHORT_BUF(;) *
+            aws_last_error_is_SHORT_BUF() *
             (ret == int(-1))
 }
 */
@@ -405,30 +405,30 @@ MEM_ERR:
             (#length == len #data) *
             (#length <# 2147483647) *
             any_valid_aws_cryptosdk_hdr(#hdr; #alloc) *
-            default_allocator(#alloc;) *
-            any_aws_last_error(;)
+            default_allocator(#alloc) *
+            any_aws_last_error()
 
         ensures:
             (#definition == `Complete`) *
             ARRAY(#buffer, char, #length, #data) *
             valid_aws_byte_cursor_ptr(#pcursor; 0, #end_buffer, []) *
             header_struct(#hdr; #alloc, #suiteId, #messageId, #ECKs, #EDKs, #frameLength, #headerLength, #headerIv, #headerAuthTag) *
-            default_allocator(#alloc;) *
-            any_aws_last_error(;) *
+            default_allocator(#alloc) *
+            any_aws_last_error() *
             (ret == int(0));
 
             (#definition == `Incomplete`) *
             valid_aws_byte_cursor_ptr(#pcursor; #length, #buffer, #data) *
             empty_aws_cryptosdk_hdr(#hdr; #alloc) *
-            default_allocator(#alloc;) *
-            aws_last_error_is_SHORT_BUF(;) *
+            default_allocator(#alloc) *
+            aws_last_error_is_SHORT_BUF() *
             (ret == int(-1));
 
             (#definition == `Broken`) *
             valid_aws_byte_cursor_ptr(#pcursor; #length, #buffer, #data) *
             empty_aws_cryptosdk_hdr(#hdr; #alloc) *
-            default_allocator(#alloc;) *
-            aws_last_error_is_BAD_CIPHERTEXT(;) *
+            default_allocator(#alloc) *
+            aws_last_error_is_BAD_CIPHERTEXT() *
             (ret == int(-1))
   }
 */
@@ -585,8 +585,8 @@ int aws_cryptosdk_hdr_parse(struct aws_cryptosdk_hdr *hdr,
         "invariant: \
             [[bind i, #i, #cbptr, #readLength, #readEDKs, #leftEDKs, #restEDKsAndRest, \
                    #acc, #rest_count, #restEDKs, #restEDKLength, #restLength, #trash]] \
-            any_aws_last_error(;) * \
-            (i == int(#i)) * default_allocator(#alloc;) * \
+            any_aws_last_error() * \
+            (i == int(#i)) * default_allocator(#alloc) * \
             (#hdr -> ptr(#all, #alo)) * (#alloc == ptr(#all, #alo)) * \
             optBytes(#bptr, #readLength; #readEDKs) * \
             (#readLength == len #readEDKs) * \

--- a/Gillian-C/examples/amazon/logic/ByteLogic.gil
+++ b/Gillian-C/examples/amazon/logic/ByteLogic.gil
@@ -7,7 +7,7 @@
  ****************************************)
 
 (* A byte is positive and less than 256i *)
-pred isByte(byte: Int;):
+pred isByte(byte: Int):
   (byte i<# 256i) * (0i i<=# byte);
 
 (* Interpretation: one byte as an unsigned 8i-bit integer *)

--- a/Gillian-C/examples/amazon/logic/ByteLogic.gil
+++ b/Gillian-C/examples/amazon/logic/ByteLogic.gil
@@ -7,17 +7,17 @@
  ****************************************)
 
 (* A byte is positive and less than 256i *)
-pred isByte(+byte: Int):
+pred isByte(byte: Int;):
   (byte i<# 256i) * (0i i<=# byte);
 
 (* Interpretation: one byte as an unsigned 8i-bit integer *)
-pure pred rawToUInt8(+bytes:List, num:Int) :
+pure pred rawToUInt8(bytes:List; num:Int) :
     (bytes == {{ #b0 }}) * (num == #b0) *
     (0i i<=# #b0) * (#b0 i<# 256i);
 
 (* Interpretation: two bytes as an unsigned 16i-bit integer *)
 @nopath
-pure pred rawToUInt16(+bytes:List, +littleEndian:Bool, num:Int) :
+pure pred rawToUInt16(bytes:List, littleEndian:Bool; num:Int) :
     (littleEndian == false) *
       (bytes == {{ #b0, #b1 }}) *
       (0i i<=# #b0) * (#b0 i<# 256i) *
@@ -32,7 +32,7 @@ pure pred rawToUInt16(+bytes:List, +littleEndian:Bool, num:Int) :
 
 (* Interpretation: four bytes as an unsigned 32i-bit integer *)
 @nopath
-pure pred rawToUInt32(+bytes:List, +littleEndian:Bool, num:Int) :
+pure pred rawToUInt32(bytes:List, littleEndian:Bool; num:Int) :
     (littleEndian == false) *
       (bytes == {{ #b0, #b1, #b2, #b3 }}) *
       (0i i<=# #b0) * (#b0 i<# 256i) *

--- a/Gillian-C/examples/amazon/logic/EncryptionHeaderLogic.gil
+++ b/Gillian-C/examples/amazon/logic/EncryptionHeaderLogic.gil
@@ -236,8 +236,8 @@ lemma IElementsShift(buffer, readPos, eCount, fCount, shift)
       IElements(#rBuffer, #readPos i- #shift, #eCount, #fCount, #eList, #esLength) ]]
 
 
-nounfold pred Element(definition : Str, +buffer : List, +readPos : Int,
-                      +fCount : Int, fList : List, eLength : Int) :
+nounfold pred Element(+buffer : List, +readPos : Int, +fCount : Int,
+                      definition : Str, fList : List, eLength : Int) :
   (definition == "Complete") *
     CElement(buffer, readPos, fCount, fList, eLength),
   (definition == "Incomplete") *
@@ -255,18 +255,18 @@ nounfold pred Element(definition : Str, +buffer : List, +readPos : Int,
 
 (* A general element sequene is either a complete or an incomplete element sequence *)
 @nopath
-nounfold pred Elements(definition : Str, +buffer : List, +readPos : Int,
-                       +eCount : Int, +fCount : Int, eList : List,
+nounfold pred Elements(+buffer : List, +readPos : Int, +eCount : Int,
+                       +fCount : Int, definition : Str, eList : List,
                        esLength : Int) :
   (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
   (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
   facts: (0i i<=# readPos) and (readPos i<=# (l-len buffer)) and (0i i<=# eCount) and (0i i<# fCount) and (0i i<=# esLength);
 
 lemma ElementsShift(buffer, readPos, eCount, fCount, shift)
-  [[  Elements(#definition, #buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
+  [[  Elements(#buffer, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
       (0i i<=# (#readPos i- #shift)) ]]
   [[  (#rBuffer == l-sub(#buffer, #shift, ((l-len #buffer) i- #shift))) *
-      Elements(#definition, #rBuffer, #readPos i- #shift, #eCount, #fCount, #eList, #esLength) ]]
+      Elements(#rBuffer, #readPos i- #shift, #eCount, #fCount, #definition, #eList, #esLength) ]]
 
 (*****************************
  *****************************
@@ -294,7 +294,7 @@ nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Int,
     (0i i<=# readPos) * (readPos i<=# (l-len buffer)) *
     (#rawEC == l-sub(buffer, readPos, 2i)) *
     rawToUInt16(#rawEC, false, #keyCount) * (0i i<# #keyCount) *
-    Elements("Complete", buffer, (readPos i+ 2i), #keyCount, 3i, EDKs, #EDKsLength) *
+    Elements(buffer, (readPos i+ 2i), #keyCount, 3i, "Complete", EDKs, #EDKsLength) *
     (0i i<# #EDKsLength) * (* This can be derived... *)
     (EDKsLength == (#EDKsLength i+ 2i));
 
@@ -307,11 +307,11 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Int) :
     (* Enough data to read the number of EDKs, but not enough data to read the EDKs *)
   (0i i<=# readPos) * ((readPos i+ 2i) i<=# (l-len buffer)) * (#rawEC == l-sub(buffer, readPos, 2i)) *
     rawToUInt16(#rawEC, false, #keyCount) * (0i i<# #keyCount) *
-    Elements("Incomplete", buffer, (readPos i+ 2i), #keyCount, 3i, #eList, #esLength);
+    Elements(buffer, (readPos i+ 2i), #keyCount, 3i, "Incomplete", #eList, #esLength);
 
 (* Broken serialised EDKs *)
 @nopath
-nounfold pred BRawEncryptedDataKeys(errorMessage : Str, +buffer : List, +readPos : Int, EDKs : List, EDKsLength : Int) :
+nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Int, errorMessage : Str, EDKs : List, EDKsLength : Int) :
     (* Incorrect starting position *)
     ((readPos i<# 0i) \/ ((l-len buffer) i<# readPos)) *
     (errorMessage == "deserializeMessageHeader: startPos out of bounds.") *
@@ -325,10 +325,10 @@ nounfold pred BRawEncryptedDataKeys(errorMessage : Str, +buffer : List, +readPos
 
 (* General serialised EDKs *)
 @nopath
-nounfold pred RawEncryptedDataKeys(definition : Str, +buffer : List, +readPos : Int, EDKs : List, EDKsLength : Int, errorMessage : Str) :
+nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Int, definition : Str, EDKs : List, EDKsLength : Int, errorMessage : Str) :
   (definition == "Complete")   * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
   (definition == "Incomplete") * (errorMessage == "") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0i),
-  (definition == "Broken") * BRawEncryptedDataKeys(errorMessage, buffer, readPos, EDKs, EDKsLength);
+  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage, EDKs, EDKsLength);
 
 
 (******************************
@@ -355,17 +355,17 @@ nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
   (* ((l-len buffer) == 0i) * (ECKs == {{  }}), *)
   (0i i<# l-len buffer) * (#rawKC == l-sub(buffer, 0i, 2i)) *
     rawToUInt16(#rawKC, false, #keyCount) * (0i i<# #keyCount) *
-    Elements("Complete", buffer, 2i, #keyCount, 2i, ECKs, #ECKsLength) *
+    Elements(buffer, 2i, #keyCount, 2i, "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) *
     Unique(#ECKeys) * ((2i i+ #ECKsLength) == (l-len buffer));
 
 (* Broken serialised encryption context *)
-pure nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:List) :
+pure nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
     rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
     (0i i<# #keyCount) * (ECKs == {{ }}) *
-    Elements("Incomplete", buffer, 2i, #keyCount, 2i, #eList, #esLength) *
+    Elements(buffer, 2i, #keyCount, 2i, "Incomplete", #eList, #esLength) *
     toUtf8PairMap(#eList, #utf8EList) * FirstProj(#eList, #keys) *
     Unique(#keys) *
     (errorMessage == "decodeEncryptionContext: Underflow, not enough data."),
@@ -382,7 +382,7 @@ pure nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:Li
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
     rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
     (0i i<# #keyCount) *
-    Elements("Complete", buffer, 2i, #keyCount, 2i, ECKs, #ECKsLength) *
+    Elements(buffer, 2i, #keyCount, 2i, "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Unique(#ECKeys) *
     (! (#ECKsLength i+ 2i == l-len buffer)) *
     (errorMessage == "decodeEncryptionContext: Overflow, too much data."),
@@ -391,15 +391,15 @@ pure nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:Li
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
     rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
     (0i i<# #keyCount) *
-    Elements("Complete", buffer, 2i, #keyCount, 2i, ECKs, #ECKsLength) *
+    Elements(buffer, 2i, #keyCount, 2i, "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Duplicated({{ }}, #ECKeys) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
 (* General serialised encryption context *)
 @nopath
-pure nounfold pred RawEncryptionContext(definition:Str, +buffer:List, ECKs:List, errorMessage:Str) :
+pure nounfold pred RawEncryptionContext(+buffer:List, definition:Str, ECKs:List, errorMessage:Str) :
   (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
-  (definition == "Broken")   * BRawEncryptionContext(errorMessage, buffer, ECKs);
+  (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
 
 (****************************
 *****************************
@@ -526,7 +526,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (0i i<# ECLength) *
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) * (ECDef == "Broken") * (edkDef == "") *
-    BRawEncryptionContext(errorMessage, #EC, ECKs) *
+    BRawEncryptionContext(#EC, errorMessage, ECKs) *
 
     (EDKs == {{ }}) * (contentType == 0i) * (frameLength == 0i) *
     (headerLength == 0i) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -548,7 +548,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) * (ECDef == "") * (edkDef == "Broken") *
-    RawEncryptedDataKeys("Broken", rawHeaderData, 22i i+ ECLength, EDKs, EDKsLength, errorMessage) *
+    RawEncryptedDataKeys(rawHeaderData, 22i i+ ECLength, "Broken", EDKs, EDKsLength, errorMessage) *
 
     (contentType == 0i) * (frameLength == 0i) *
     (headerLength == 0i) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -571,7 +571,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, #rest)) *
-    RawEncryptedDataKeys("Complete", part_three, 0i, EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     BContentType(contentType) *
 
@@ -597,7 +597,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     CRawEncryptionContext(#EC, ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, #rawReservedBytes, #rest)) *
     CContentType(contentType) *
-    RawEncryptedDataKeys("Complete", part_three, 0i, EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (l-len #rawReservedBytes == 4i) *
     rawToUInt32(#rawReservedBytes, false, #reservedBytes) *
@@ -625,7 +625,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     CRawEncryptionContext(#EC, ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }}, {{ headerIvLength }}, #rest)) *
     CContentType(contentType) *
-    RawEncryptedDataKeys("Complete", part_three, 0i, EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (! (headerIvLength == #ivLength)) *
 
@@ -752,7 +752,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
 
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }}, {{ headerIvLength }}, #rawFrameLength, #rest)) *
     CContentType(contentType) *
-    RawEncryptedDataKeys("Complete", part_three, 0i, EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (l-len #rawFrameLength == 4i) *
     rawToUInt32(#rawFrameLength, false, frameLength) *
@@ -782,7 +782,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
 
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }}, {{ headerIvLength }}, #rawFrameLength, headerIv, #rest)) *
     CContentType(contentType) *
-    RawEncryptedDataKeys("Complete", part_three, 0i, EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (l-len #rawFrameLength == 4i) *
     rawToUInt32(#rawFrameLength, false, frameLength) *
@@ -810,7 +810,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
     (part_three == #edks) *
-    RawEncryptedDataKeys("Incomplete", part_three, 0i, {{ }}, #EDKsLength, "") * (edkDef == "Incomplete") *
+    RawEncryptedDataKeys(part_three, 0i, "Incomplete", {{ }}, #EDKsLength, "") * (edkDef == "Incomplete") *
     (contentType == 0i) * (frameLength == 0i) * (headerLength == 0i) * (headerIv == {{ }}) * (headerAuthTag == {{ }}) *
     (EDKs == {{ }});
 
@@ -849,7 +849,7 @@ nounfold pred CHeader(+rawHeaderData, part_one, version, type, suiteId,
 
 
 (* General serialised header *)
-nounfold pred Header(definition, +rawHeaderData, part_one, version, type,
+nounfold pred Header(+rawHeaderData, definition, part_one, version, type,
                      suiteId, messageId, ECLength, part_two, ECKs,
                      part_three, EDKs, contentType, headerIvLength,
                      frameLength, headerLength, headerIv, headerAuthTag, edkDef,

--- a/Gillian-C/examples/amazon/logic/EncryptionHeaderLogic.gil
+++ b/Gillian-C/examples/amazon/logic/EncryptionHeaderLogic.gil
@@ -300,7 +300,7 @@ nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Int;
 
 (* Incomplete serialised EDKs *)
 @nopath
-nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Int;) :
+nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Int) :
   (* Not enough data to read the number of EDKs *)
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) * ((l-len buffer) i<# (readPos i+ 2i)),
 
@@ -327,7 +327,7 @@ nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Int; errorMessage :
 @nopath
 nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Int; definition : Str, EDKs : List, EDKsLength : Int, errorMessage : Str) :
   (definition == "Complete")   * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos; EDKs, EDKsLength),
-  (definition == "Incomplete") * (errorMessage == "") * IRawEncryptedDataKeys(buffer, readPos;) * (EDKs == {{  }}) * (EDKsLength == 0i),
+  (definition == "Incomplete") * (errorMessage == "") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0i),
   (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos; errorMessage, EDKs, EDKsLength);
 
 
@@ -357,7 +357,7 @@ nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
     rawToUInt16(#rawKC, false; #keyCount) * (0i i<# #keyCount) *
     Elements(buffer, 2i, #keyCount, 2i; "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) *
-    Unique(#ECKeys;) * ((2i i+ #ECKsLength) == (l-len buffer));
+    Unique(#ECKeys) * ((2i i+ #ECKsLength) == (l-len buffer));
 
 (* Broken serialised encryption context *)
 pure nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
@@ -367,7 +367,7 @@ pure nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:Lis
     (0i i<# #keyCount) * (ECKs == {{ }}) *
     Elements(buffer, 2i, #keyCount, 2i; "Incomplete", #eList, #esLength) *
     toUtf8PairMap(#eList; #utf8EList) * FirstProj(#eList; #keys) *
-    Unique(#keys;) *
+    Unique(#keys) *
     (errorMessage == "decodeEncryptionContext: Underflow, not enough data."),
 
     (* Not enough data to read the key_count *)
@@ -383,7 +383,7 @@ pure nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:Lis
     rawToUInt16({{ #kc0, #kc1 }}, false; #keyCount) *
     (0i i<# #keyCount) *
     Elements(buffer, 2i, #keyCount, 2i; "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Unique(#ECKeys;) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Unique(#ECKeys) *
     (! (#ECKsLength i+ 2i == l-len buffer)) *
     (errorMessage == "decodeEncryptionContext: Overflow, too much data."),
 
@@ -392,7 +392,7 @@ pure nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:Lis
     rawToUInt16({{ #kc0, #kc1 }}, false; #keyCount) *
     (0i i<# #keyCount) *
     Elements(buffer, 2i, #keyCount, 2i; "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Duplicated({{ }}, #ECKeys;) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Duplicated({{ }}, #ECKeys) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
 (* General serialised encryption context *)
@@ -445,19 +445,19 @@ pred BAlgorithmSuite(numId; errorMessage) :
 
 (* Correctly formed algorithm suite *)
 @nopath
-pred CContentType(contentType: Int;) :
+pred CContentType(contentType: Int) :
   (contentType == 1i) \/ (contentType == 2i);
 
 (* Broken algorithm suite *)
 @nopath
-pred BContentType(contentType;) :
+pred BContentType(contentType) :
   (! (contentType == 1i)) * (! (contentType == 2i));
 
 (* If type is NONFRAMED (i.e. = 1i), frame_len has to be 0i, otherwise, if type is FRAMED (i.e = 2i), frame_len has to be > 0i *)
-pred CompatibleContentTypeAndFrameLength(contentType: Int, frameLength: Int;):
+pred CompatibleContentTypeAndFrameLength(contentType: Int, frameLength: Int):
   ((contentType == 1i) /\ (frameLength == 0i)) \/ ((contentType == 2i) /\ (0i i<# frameLength));
 
-pred IncompatibleContentTypeAndFrameLength(contentType, frameLength;):
+pred IncompatibleContentTypeAndFrameLength(contentType, frameLength):
   ((contentType == 1i) /\ (0i i<# frameLength)) \/ ((contentType == 2i) /\ (frameLength == 0i));
 
 
@@ -472,7 +472,7 @@ pred IncompatibleContentTypeAndFrameLength(contentType, frameLength;):
 
 (* The correct version and type *)
 @nopath
-pred CVersionAndType(version, type;) :
+pred CVersionAndType(version, type) :
   (version == 1i) * (type == 128i);
 
 (* Broken version and type *)
@@ -501,7 +501,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (22i i<=# l-len rawHeaderData) *
     (rawHeaderData == l+ ({{ version, type }}, #rawSuiteId, #rest)) *
     (l-len #rawSuiteId == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     BAlgorithmSuite(suiteId; errorMessage) *
 
@@ -518,7 +518,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -539,7 +539,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -561,7 +561,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -573,7 +573,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (part_three == l+ (#edks, {{ contentType }}, #rest)) *
     RawEncryptedDataKeys(part_three, 0i; "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
-    BContentType(contentType;) *
+    BContentType(contentType) *
 
     (errorMessage == "Malformed Header: Incorrect content type.") *
     (frameLength == 0i) * (headerLength == 0i) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -586,7 +586,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -596,7 +596,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC; ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, #rawReservedBytes, #rest)) *
-    CContentType(contentType;) *
+    CContentType(contentType) *
     RawEncryptedDataKeys(part_three, 0i; "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (l-len #rawReservedBytes == 4i) *
@@ -614,7 +614,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, #ivLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -624,7 +624,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC; ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }}, {{ headerIvLength }}, #rest)) *
-    CContentType(contentType;) *
+    CContentType(contentType) *
     RawEncryptedDataKeys(part_three, 0i; "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (! (headerIvLength == #ivLength)) *
@@ -638,21 +638,21 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     ((l-len #rawSuiteId) == 2i) *
     ((l-len messageId) == 16i) *
-    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type;) *
+    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
     (part_two == l+ (#EC, part_three)) *
     ((l-len #EC) == ECLength) *
     CRawEncryptionContext(#EC; ECKs) *
-    CContentType(contentType;) * (ECDef == "") *
+    CContentType(contentType) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }},
                        {{ headerIvLength }}, #rawFrameLength, #rest)) *
     CRawEncryptedDataKeys(part_three, 0i; EDKs, #EDKsLength) *
     (edkDef == "Complete") *
     (#EDKsLength == (l-len #edks)) * ((l-len #rawFrameLength) == 4i) *
     rawToUInt32(#rawFrameLength, false; frameLength) *
-    IncompatibleContentTypeAndFrameLength(contentType, frameLength;);
+    IncompatibleContentTypeAndFrameLength(contentType, frameLength);
     facts: (22i i<=# l-len rawHeaderData);
 
 
@@ -680,7 +680,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (rawHeaderData == part_one) *
     (part_one == l+ ({{ version, type }}, #rawSuiteId)) *
     (l-len #rawSuiteId i<# 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     (suiteId == 0i) * (messageId == {{ }}) * (ECLength == 0i) *
     (part_two == {{ }}) * (ECKs == {{ }}) * (edkDef == "") *
     (part_three == {{ }}) * (EDKs == {{ }}) * (contentType == 0i) * (headerIvLength == 0i) *
@@ -691,7 +691,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (rawHeaderData == part_one) *
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId)) *
     (l-len #rawSuiteId == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     (l-len messageId i<# 16i) *
@@ -705,7 +705,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     (l-len #rawContextLength i<# 2i) *
@@ -722,7 +722,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) * (edkDef == "") *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -740,7 +740,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -751,12 +751,12 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     CRawEncryptionContext(#EC; ECKs) *
 
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }}, {{ headerIvLength }}, #rawFrameLength, #rest)) *
-    CContentType(contentType;) *
+    CContentType(contentType) *
     RawEncryptedDataKeys(part_three, 0i; "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (l-len #rawFrameLength == 4i) *
     rawToUInt32(#rawFrameLength, false; frameLength) *
-    CompatibleContentTypeAndFrameLength(contentType, frameLength;) *
+    CompatibleContentTypeAndFrameLength(contentType, frameLength) *
     (headerLength == 22i i+ ECLength i+ #EDKsLength i+ 1i i+ 4i i+ 1i i+ 4i) *
     (l-len rawHeaderData i<# headerLength i+ headerIvLength) *
 
@@ -770,7 +770,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -781,12 +781,12 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     CRawEncryptionContext(#EC; ECKs) *
 
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }}, {{ headerIvLength }}, #rawFrameLength, headerIv, #rest)) *
-    CContentType(contentType;) *
+    CContentType(contentType) *
     RawEncryptedDataKeys(part_three, 0i; "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (l-len #rawFrameLength == 4i) *
     rawToUInt32(#rawFrameLength, false; frameLength) *
-    CompatibleContentTypeAndFrameLength(contentType, frameLength;) *
+    CompatibleContentTypeAndFrameLength(contentType, frameLength) *
     (headerLength == 22i i+ ECLength i+ #EDKsLength i+ 1i i+ 4i i+ 1i i+ 4i) *
     (l-len rawHeaderData i<# headerLength i+ headerIvLength) *
     ((l-len headerIv) == headerIvLength) *
@@ -800,7 +800,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -825,21 +825,21 @@ nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     ((l-len #rawSuiteId) == 2i) *
     ((l-len messageId) == 16i) *
-    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type;) *
+    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
     (part_two == l+ (#EC, part_three)) *
     ((l-len #EC) == ECLength) *
     CRawEncryptionContext(#EC; ECKs) *
-    CContentType(contentType;) *
+    CContentType(contentType) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }},
                        {{ headerIvLength }}, #rawFrameLength, headerIv, headerAuthTag)) *
     CRawEncryptedDataKeys(part_three, 0i; EDKs, #EDKsLength) *
     (edkDef == "Complete") *
     (#EDKsLength == (l-len #edks)) * ((l-len #rawFrameLength) == 4i) *
     rawToUInt32(#rawFrameLength, false; frameLength) *
-    CompatibleContentTypeAndFrameLength(contentType, frameLength;) *
+    CompatibleContentTypeAndFrameLength(contentType, frameLength) *
     (headerLength == ((((((22i i+ ECLength) i+ #EDKsLength) i+ 1i) i+ 4i) i+ 1i) i+ 4i)) *
     ((l-len headerIv) == headerIvLength) *
     ((l-len headerAuthTag) == #tagLength) *

--- a/Gillian-C/examples/amazon/logic/EncryptionHeaderLogic.gil
+++ b/Gillian-C/examples/amazon/logic/EncryptionHeaderLogic.gil
@@ -16,7 +16,7 @@
 *)
 pred Field(buffer : List, readPos : Int; field : List, length : Int) :
     (0i i<=# readPos) * (#rawFL == l-sub(buffer, readPos, 2i)) *
-    rawToUInt16(#rawFL, false, #fieldLength) *
+    rawToUInt16(#rawFL, false; #fieldLength) *
     (field == l-sub(buffer, (readPos i+ 2i), #fieldLength)) *
     (length == (2i i+ #fieldLength)) * ((readPos i+ length) i<=# (l-len buffer));
 
@@ -72,14 +72,14 @@ pred IElement(buffer : List, readPos : Int, fCount : Int; fList : List, eLength 
 
   (* Base case: enough data to read length of next field, but not enough data to read next field *)
   (0i i<=# readPos) * (0i i<# fCount) * ((readPos i+ 2i) i<=# (l-len buffer)) *
-    (#rawFL == l-sub(buffer, readPos, 2i)) * rawToUInt16(#rawFL, false, #fLength) *
+    (#rawFL == l-sub(buffer, readPos, 2i)) * rawToUInt16(#rawFL, false; #fLength) *
     ((l-len buffer) i<# ((readPos i+ 2i) i+ #fLength)) * (fList == {{  }}) *
     (eLength == ((l-len buffer) i- (readPos i+ 2i))),
 
   (* Recursive case: enough data to read one field, but not enough data to read the remaining ones *)
-  (0i i<=# readPos) * (1i i<# fCount) * Field(buffer, readPos, #field, #fLength) *
+  (0i i<=# readPos) * (1i i<# fCount) * Field(buffer, readPos; #field, #fLength) *
     (#restFCount == (fCount i- 1i)) * ((readPos i+ #fLength) i<=# (l-len buffer)) *
-    IElement(buffer, (readPos i+ #fLength), #restFCount, #restFList, #restELength) *
+    IElement(buffer, (readPos i+ #fLength), #restFCount; #restFList, #restELength) *
     (fList == l+ ({{ #field }}, #restFList)) *
     (eLength == (#fLength i+ #restELength));
 
@@ -127,13 +127,13 @@ pred IElements(buffer : List, readPos : Int, eCount : Int, fCount : Int;
                eList : List, esLength : Int) :
   (* Base case: single incomplete element *)
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) * (0i i<# eCount) * (0i i<# fCount) *
-    IElement(buffer, readPos, fCount, #fList, esLength) * (eList == {{  }}),
+    IElement(buffer, readPos, fCount; #fList, esLength) * (eList == {{  }}),
 
   (* Recursive case: enough data to read first element, but not enough data to read the remaining ones *)
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) * (1i i<# eCount) * (0i i<# fCount) *
-    CElement(buffer, readPos, fCount, #fList, #eLength) *
+    CElement(buffer, readPos, fCount; #fList, #eLength) *
     (#restECount == (eCount i- 1i)) *
-    IElements(buffer, (readPos i+ #eLength), #restECount, fCount, #restEList, #restESLength) *
+    IElements(buffer, (readPos i+ #eLength), #restECount, fCount; #restEList, #restESLength) *
     (eList == l+ ({{ #fList }}, #restEList)) * (esLength == (#eLength i+ #restESLength));
   facts: (0i i<=# readPos) and (readPos i<=# (l-len buffer)) and (0i i<# eCount) and (0i i<# fCount) and (0i i<=# esLength);
 
@@ -162,9 +162,9 @@ pred IElements(buffer : List, readPos : Int, eCount : Int, fCount : Int;
 pred CElement(buffer : List, readPos : Int, fCount : Int; element : List, length : Int) :
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) *
     (fCount == 0i) * (element == {{  }}) * (length == 0i),
-  (0i i<# fCount) * Field(buffer, readPos, #field, #fLength) * ((typeOf #field) == List) *
+  (0i i<# fCount) * Field(buffer, readPos; #field, #fLength) * ((typeOf #field) == List) *
     (#restFCount == (fCount i- 1i)) *
-    CElement(buffer, (readPos i+ #fLength), #restFCount, #restFields, #restLength) *
+    CElement(buffer, (readPos i+ #fLength), #restFCount; #restFields, #restLength) *
     (element == l+ ({{ #field }}, #restFields)) * (length == (#fLength i+ #restLength));
   (*
       A complete element has a non-negative number of fields
@@ -198,8 +198,8 @@ pred CElements(buffer : List, readPos : Int, eCount : Int, fCount : Int;
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) * (eCount == 0i) *
     (0i i<# fCount) * (elements == {{  }}) * (length == 0i),
   (0i i<=# readPos) * (0i i<# eCount) * (0i i<# fCount) * (0i i<# length) *
-    CElement(buffer, readPos, fCount, #element, #eLength) * (#restECount == (eCount i- 1i)) *
-    CElements(buffer, (readPos i+ #eLength), #restECount, fCount, #restElements, #restLength) *
+    CElement(buffer, readPos, fCount; #element, #eLength) * (#restECount == (eCount i- 1i)) *
+    CElements(buffer, (readPos i+ #eLength), #restECount, fCount; #restElements, #restLength) *
     (elements == l+ ({{ #element }}, #restElements)) *
     (length == (#eLength i+ #restLength));
   (*
@@ -213,35 +213,35 @@ pred CElements(buffer : List, readPos : Int, eCount : Int, fCount : Int;
 
 
 lemma CElementNonEmptyPositiveLength(buffer, readPos, fCount, fList, eLength)
-  [[  CElement(#buffer, #readPos, #fCount, #fList, #eLength) *
+  [[  CElement(#buffer, #readPos, #fCount; #fList, #eLength) *
       (0i i<# #fCount) ]]
-  [[  CElement(#buffer, #readPos, #fCount, #fList, #eLength) *
+  [[  CElement(#buffer, #readPos, #fCount; #fList, #eLength) *
       (0i i<# #eLength) ]]
   (*
   [*  unfold CElement(#buffer, #readPos, #fCount, #fList, #eLength) ;
-      sep_assert (Field(#buffer, #readPos, #field, #fLength)) [bind: #fLength];
-      sep_assert (CElement(#buffer, (#readPos i+ #fLength), (#fCount i- 1i), #restFields, #restELength)) [bind: #restELength]  *]
+      sep_assert (Field(#buffer, #readPos; #field, #fLength)) [bind: #fLength];
+      sep_assert (CElement(#buffer, (#readPos i+ #fLength), (#fCount i- 1i); #restFields, #restELength)) [bind: #restELength]  *]
   *)
 
 lemma CElementsShift(buffer, readPos, eCount, fCount, shift)
-  [[  CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
+  [[  CElements(#buffer, #readPos, #eCount, #fCount; #eList, #esLength) *
       (0i i<=# (#readPos i- #shift)) ]]
   [[  (#rBuffer == l-sub(#buffer, #shift, ((l-len #buffer) i- #shift))) *
-      CElements(#rBuffer, #readPos i- #shift, #eCount, #fCount, #eList, #esLength) ]]
+      CElements(#rBuffer, #readPos i- #shift, #eCount, #fCount; #eList, #esLength) ]]
 
 lemma IElementsShift(buffer, readPos, eCount, fCount, shift)
-  [[  IElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
+  [[  IElements(#buffer, #readPos, #eCount, #fCount; #eList, #esLength) *
       (0i i<=# (#readPos i- #shift)) ]]
   [[  (#rBuffer == l-sub(#buffer, #shift, ((l-len #buffer) i- #shift))) *
-      IElements(#rBuffer, #readPos i- #shift, #eCount, #fCount, #eList, #esLength) ]]
+      IElements(#rBuffer, #readPos i- #shift, #eCount, #fCount; #eList, #esLength) ]]
 
 
 nounfold pred Element(buffer : List, readPos : Int, fCount : Int;
                       definition : Str, fList : List, eLength : Int) :
   (definition == "Complete") *
-    CElement(buffer, readPos, fCount, fList, eLength),
+    CElement(buffer, readPos, fCount; fList, eLength),
   (definition == "Incomplete") *
-    IElement(buffer, readPos, fCount, fList, eLength);
+    IElement(buffer, readPos, fCount; fList, eLength);
 
 (****************************
  ****************************
@@ -258,15 +258,15 @@ nounfold pred Element(buffer : List, readPos : Int, fCount : Int;
 nounfold pred Elements(buffer : List, readPos : Int, eCount : Int,
                        fCount : Int; definition : Str, eList : List,
                        esLength : Int) :
-  (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
-  (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
+  (definition == "Complete") * CElements(buffer, readPos, eCount, fCount; eList, esLength),
+  (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount; eList, esLength);
   facts: (0i i<=# readPos) and (readPos i<=# (l-len buffer)) and (0i i<=# eCount) and (0i i<# fCount) and (0i i<=# esLength);
 
 lemma ElementsShift(buffer, readPos, eCount, fCount, shift)
-  [[  Elements(#buffer, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
+  [[  Elements(#buffer, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
       (0i i<=# (#readPos i- #shift)) ]]
   [[  (#rBuffer == l-sub(#buffer, #shift, ((l-len #buffer) i- #shift))) *
-      Elements(#rBuffer, #readPos i- #shift, #eCount, #fCount, #definition, #eList, #esLength) ]]
+      Elements(#rBuffer, #readPos i- #shift, #eCount, #fCount; #definition, #eList, #esLength) ]]
 
 (*****************************
  *****************************
@@ -293,8 +293,8 @@ nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Int;
                                     EDKs : List, EDKsLength : Int) :
     (0i i<=# readPos) * (readPos i<=# (l-len buffer)) *
     (#rawEC == l-sub(buffer, readPos, 2i)) *
-    rawToUInt16(#rawEC, false, #keyCount) * (0i i<# #keyCount) *
-    Elements(buffer, (readPos i+ 2i), #keyCount, 3i, "Complete", EDKs, #EDKsLength) *
+    rawToUInt16(#rawEC, false; #keyCount) * (0i i<# #keyCount) *
+    Elements(buffer, (readPos i+ 2i), #keyCount, 3i; "Complete", EDKs, #EDKsLength) *
     (0i i<# #EDKsLength) * (* This can be derived... *)
     (EDKsLength == (#EDKsLength i+ 2i));
 
@@ -306,8 +306,8 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Int;) :
 
     (* Enough data to read the number of EDKs, but not enough data to read the EDKs *)
   (0i i<=# readPos) * ((readPos i+ 2i) i<=# (l-len buffer)) * (#rawEC == l-sub(buffer, readPos, 2i)) *
-    rawToUInt16(#rawEC, false, #keyCount) * (0i i<# #keyCount) *
-    Elements(buffer, (readPos i+ 2i), #keyCount, 3i, "Incomplete", #eList, #esLength);
+    rawToUInt16(#rawEC, false; #keyCount) * (0i i<# #keyCount) *
+    Elements(buffer, (readPos i+ 2i), #keyCount, 3i; "Incomplete", #eList, #esLength);
 
 (* Broken serialised EDKs *)
 @nopath
@@ -319,16 +319,16 @@ nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Int; errorMessage :
 
     (* Zero EDKs provided *)
     (0i i<=# readPos) * ((readPos i+ 2i) i<=# (l-len buffer)) *
-    (#rawEC == l-sub(buffer, readPos, 2i)) * rawToUInt16(#rawEC, false, 0i) *
+    (#rawEC == l-sub(buffer, readPos, 2i)) * rawToUInt16(#rawEC, false; 0i) *
     (EDKs == {{ }}) * (EDKsLength == 2i) *
     (errorMessage == "Malformed Header: No EncryptedDataKey found.");
 
 (* General serialised EDKs *)
 @nopath
 nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Int; definition : Str, EDKs : List, EDKsLength : Int, errorMessage : Str) :
-  (definition == "Complete")   * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
-  (definition == "Incomplete") * (errorMessage == "") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0i),
-  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage, EDKs, EDKsLength);
+  (definition == "Complete")   * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos; EDKs, EDKsLength),
+  (definition == "Incomplete") * (errorMessage == "") * IRawEncryptedDataKeys(buffer, readPos;) * (EDKs == {{  }}) * (EDKsLength == 0i),
+  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos; errorMessage, EDKs, EDKsLength);
 
 
 (******************************
@@ -354,20 +354,20 @@ nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Int; definition : St
 nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
   (* ((l-len buffer) == 0i) * (ECKs == {{  }}), *)
   (0i i<# l-len buffer) * (#rawKC == l-sub(buffer, 0i, 2i)) *
-    rawToUInt16(#rawKC, false, #keyCount) * (0i i<# #keyCount) *
-    Elements(buffer, 2i, #keyCount, 2i, "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) *
-    Unique(#ECKeys) * ((2i i+ #ECKsLength) == (l-len buffer));
+    rawToUInt16(#rawKC, false; #keyCount) * (0i i<# #keyCount) *
+    Elements(buffer, 2i, #keyCount, 2i; "Complete", ECKs, #ECKsLength) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) *
+    Unique(#ECKeys;) * ((2i i+ #ECKsLength) == (l-len buffer));
 
 (* Broken serialised encryption context *)
 pure nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
-    rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
+    rawToUInt16({{ #kc0, #kc1 }}, false; #keyCount) *
     (0i i<# #keyCount) * (ECKs == {{ }}) *
-    Elements(buffer, 2i, #keyCount, 2i, "Incomplete", #eList, #esLength) *
-    toUtf8PairMap(#eList, #utf8EList) * FirstProj(#eList, #keys) *
-    Unique(#keys) *
+    Elements(buffer, 2i, #keyCount, 2i; "Incomplete", #eList, #esLength) *
+    toUtf8PairMap(#eList; #utf8EList) * FirstProj(#eList; #keys) *
+    Unique(#keys;) *
     (errorMessage == "decodeEncryptionContext: Underflow, not enough data."),
 
     (* Not enough data to read the key_count *)
@@ -380,26 +380,26 @@ pure nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:Lis
 
     (* Too much data provided *)
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
-    rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
+    rawToUInt16({{ #kc0, #kc1 }}, false; #keyCount) *
     (0i i<# #keyCount) *
-    Elements(buffer, 2i, #keyCount, 2i, "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Unique(#ECKeys) *
+    Elements(buffer, 2i, #keyCount, 2i; "Complete", ECKs, #ECKsLength) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Unique(#ECKeys;) *
     (! (#ECKsLength i+ 2i == l-len buffer)) *
     (errorMessage == "decodeEncryptionContext: Overflow, too much data."),
 
     (* Duplicated key in context *)
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
-    rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
+    rawToUInt16({{ #kc0, #kc1 }}, false; #keyCount) *
     (0i i<# #keyCount) *
-    Elements(buffer, 2i, #keyCount, 2i, "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Duplicated({{ }}, #ECKeys) *
+    Elements(buffer, 2i, #keyCount, 2i; "Complete", ECKs, #ECKsLength) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Duplicated({{ }}, #ECKeys;) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
 (* General serialised encryption context *)
 @nopath
 pure nounfold pred RawEncryptionContext(buffer:List; definition:Str, ECKs:List, errorMessage:Str) :
-  (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
-  (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
+  (definition == "Complete") * CRawEncryptionContext(buffer; ECKs) * (errorMessage == ""),
+  (definition == "Broken")   * BRawEncryptionContext(buffer; errorMessage, ECKs);
 
 (****************************
 *****************************
@@ -489,7 +489,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (* Incorrect version and/or type *)
     (22i i<=# l-len rawHeaderData) *
     (rawHeaderData == l+ ({{ version, type }}, #rest)) *
-    BVersionAndType(version, type, errorMessage) *
+    BVersionAndType(version, type; errorMessage) *
 
     (part_one == {{ }}) *
     (suiteId == 0i) * (messageId == {{ }}) * (ECLength == 0i) *
@@ -501,9 +501,9 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (22i i<=# l-len rawHeaderData) *
     (rawHeaderData == l+ ({{ version, type }}, #rawSuiteId, #rest)) *
     (l-len #rawSuiteId == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    BAlgorithmSuite(suiteId, errorMessage) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    BAlgorithmSuite(suiteId; errorMessage) *
 
     (part_one == {{ }}) * (messageId == {{ }}) * (ECLength == 0i) *
     (part_two == {{ }}) * (ECKs == {{ }}) * (ECDef == "") * (edkDef == "") *
@@ -518,15 +518,15 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22i i+ ECLength i<=# l-len rawHeaderData) *
     (0i i<# ECLength) *
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) * (ECDef == "Broken") * (edkDef == "") *
-    BRawEncryptionContext(#EC, errorMessage, ECKs) *
+    BRawEncryptionContext(#EC; errorMessage, ECKs) *
 
     (EDKs == {{ }}) * (contentType == 0i) * (frameLength == 0i) *
     (headerLength == 0i) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -539,16 +539,16 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22i i+ ECLength i<=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) * (ECDef == "") * (edkDef == "Broken") *
-    RawEncryptedDataKeys(rawHeaderData, 22i i+ ECLength, "Broken", EDKs, EDKsLength, errorMessage) *
+    CRawEncryptionContext(#EC; ECKs) * (ECDef == "") * (edkDef == "Broken") *
+    RawEncryptedDataKeys(rawHeaderData, 22i i+ ECLength; "Broken", EDKs, EDKsLength, errorMessage) *
 
     (contentType == 0i) * (frameLength == 0i) *
     (headerLength == 0i) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -561,19 +561,19 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22i i+ ECLength i<=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) * (ECDef == "") *
+    CRawEncryptionContext(#EC; ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, #rest)) *
-    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    RawEncryptedDataKeys(part_three, 0i; "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
-    BContentType(contentType) *
+    BContentType(contentType;) *
 
     (errorMessage == "Malformed Header: Incorrect content type.") *
     (frameLength == 0i) * (headerLength == 0i) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -586,21 +586,21 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22i i+ ECLength i<=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) * (ECDef == "") *
+    CRawEncryptionContext(#EC; ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, #rawReservedBytes, #rest)) *
-    CContentType(contentType) *
-    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    CContentType(contentType;) *
+    RawEncryptedDataKeys(part_three, 0i; "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (l-len #rawReservedBytes == 4i) *
-    rawToUInt32(#rawReservedBytes, false, #reservedBytes) *
+    rawToUInt32(#rawReservedBytes, false; #reservedBytes) *
     (! (#reservedBytes == 0i)) *
 
     (errorMessage == "Malformed Header: Reserved bytes not equal to zero.") *
@@ -614,18 +614,18 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, #ivLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, #ivLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22i i+ ECLength i<=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) * (ECDef == "") *
+    CRawEncryptionContext(#EC; ECKs) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }}, {{ headerIvLength }}, #rest)) *
-    CContentType(contentType) *
-    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    CContentType(contentType;) *
+    RawEncryptedDataKeys(part_three, 0i; "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (! (headerIvLength == #ivLength)) *
 
@@ -638,21 +638,21 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     ((l-len #rawSuiteId) == 2i) *
     ((l-len messageId) == 16i) *
-    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (part_two == l+ (#EC, part_three)) *
     ((l-len #EC) == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
-    CContentType(contentType) * (ECDef == "") *
+    CRawEncryptionContext(#EC; ECKs) *
+    CContentType(contentType;) * (ECDef == "") *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }},
                        {{ headerIvLength }}, #rawFrameLength, #rest)) *
-    CRawEncryptedDataKeys(part_three, 0i, EDKs, #EDKsLength) *
+    CRawEncryptedDataKeys(part_three, 0i; EDKs, #EDKsLength) *
     (edkDef == "Complete") *
     (#EDKsLength == (l-len #edks)) * ((l-len #rawFrameLength) == 4i) *
-    rawToUInt32(#rawFrameLength, false, frameLength) *
-    IncompatibleContentTypeAndFrameLength(contentType, frameLength);
+    rawToUInt32(#rawFrameLength, false; frameLength) *
+    IncompatibleContentTypeAndFrameLength(contentType, frameLength;);
     facts: (22i i<=# l-len rawHeaderData);
 
 
@@ -680,7 +680,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (rawHeaderData == part_one) *
     (part_one == l+ ({{ version, type }}, #rawSuiteId)) *
     (l-len #rawSuiteId i<# 2i) *
-    CVersionAndType(version, type) *
+    CVersionAndType(version, type;) *
     (suiteId == 0i) * (messageId == {{ }}) * (ECLength == 0i) *
     (part_two == {{ }}) * (ECKs == {{ }}) * (edkDef == "") *
     (part_three == {{ }}) * (EDKs == {{ }}) * (contentType == 0i) * (headerIvLength == 0i) *
@@ -691,9 +691,9 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (rawHeaderData == part_one) *
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId)) *
     (l-len #rawSuiteId == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     (l-len messageId i<# 16i) *
     (messageId == {{ }}) * (ECLength == 0i) *
     (part_two == {{ }}) * (ECKs == {{ }}) * (edkDef == "") *
@@ -705,9 +705,9 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     (l-len #rawContextLength i<# 2i) *
     (ECLength == 0i) *
     (part_two == {{ }}) * (ECKs == {{ }}) * (edkDef == "") *
@@ -722,10 +722,10 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) * (edkDef == "") *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) * (edkDef == "") *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (l-len rawHeaderData i<# 22i i+ ECLength) *
 
     (ECKs == {{ }}) *
@@ -740,23 +740,23 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22i i+ ECLength i<=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
 
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }}, {{ headerIvLength }}, #rawFrameLength, #rest)) *
-    CContentType(contentType) *
-    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    CContentType(contentType;) *
+    RawEncryptedDataKeys(part_three, 0i; "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (l-len #rawFrameLength == 4i) *
-    rawToUInt32(#rawFrameLength, false, frameLength) *
-    CompatibleContentTypeAndFrameLength(contentType, frameLength) *
+    rawToUInt32(#rawFrameLength, false; frameLength) *
+    CompatibleContentTypeAndFrameLength(contentType, frameLength;) *
     (headerLength == 22i i+ ECLength i+ #EDKsLength i+ 1i i+ 4i i+ 1i i+ 4i) *
     (l-len rawHeaderData i<# headerLength i+ headerIvLength) *
 
@@ -770,23 +770,23 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22i i+ ECLength i<=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
 
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }}, {{ headerIvLength }}, #rawFrameLength, headerIv, #rest)) *
-    CContentType(contentType) *
-    RawEncryptedDataKeys(part_three, 0i, "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
+    CContentType(contentType;) *
+    RawEncryptedDataKeys(part_three, 0i; "Complete", EDKs, #EDKsLength, _) * (edkDef == "Complete") *
     (#EDKsLength == l-len #edks) *
     (l-len #rawFrameLength == 4i) *
-    rawToUInt32(#rawFrameLength, false, frameLength) *
-    CompatibleContentTypeAndFrameLength(contentType, frameLength) *
+    rawToUInt32(#rawFrameLength, false; frameLength) *
+    CompatibleContentTypeAndFrameLength(contentType, frameLength;) *
     (headerLength == 22i i+ ECLength i+ #EDKsLength i+ 1i i+ 4i i+ 1i i+ 4i) *
     (l-len rawHeaderData i<# headerLength i+ headerIvLength) *
     ((l-len headerIv) == headerIvLength) *
@@ -800,17 +800,17 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22i i+ ECLength i<=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
     (part_three == #edks) *
-    RawEncryptedDataKeys(part_three, 0i, "Incomplete", {{ }}, #EDKsLength, "") * (edkDef == "Incomplete") *
+    RawEncryptedDataKeys(part_three, 0i; "Incomplete", {{ }}, #EDKsLength, "") * (edkDef == "Incomplete") *
     (contentType == 0i) * (frameLength == 0i) * (headerLength == 0i) * (headerIv == {{ }}) * (headerAuthTag == {{ }}) *
     (EDKs == {{ }});
 
@@ -825,21 +825,21 @@ nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     ((l-len #rawSuiteId) == 2i) *
     ((l-len messageId) == 16i) *
-    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (part_two == l+ (#EC, part_three)) *
     ((l-len #EC) == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
-    CContentType(contentType) *
+    CRawEncryptionContext(#EC; ECKs) *
+    CContentType(contentType;) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0i, 0i, 0i, 0i }},
                        {{ headerIvLength }}, #rawFrameLength, headerIv, headerAuthTag)) *
-    CRawEncryptedDataKeys(part_three, 0i, EDKs, #EDKsLength) *
+    CRawEncryptedDataKeys(part_three, 0i; EDKs, #EDKsLength) *
     (edkDef == "Complete") *
     (#EDKsLength == (l-len #edks)) * ((l-len #rawFrameLength) == 4i) *
-    rawToUInt32(#rawFrameLength, false, frameLength) *
-    CompatibleContentTypeAndFrameLength(contentType, frameLength) *
+    rawToUInt32(#rawFrameLength, false; frameLength) *
+    CompatibleContentTypeAndFrameLength(contentType, frameLength;) *
     (headerLength == ((((((22i i+ ECLength) i+ #EDKsLength) i+ 1i) i+ 4i) i+ 1i) i+ 4i)) *
     ((l-len headerIv) == headerIvLength) *
     ((l-len headerAuthTag) == #tagLength) *
@@ -856,17 +856,17 @@ nounfold pred Header(rawHeaderData; definition, part_one, version, type,
                      errorMessage) :
   (* Complete header *)
   (definition == "Complete") *
-  CHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, edkDef) *
+  CHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, edkDef) *
   (errorMessage == ""),
 
   (* Incomplete header *)
   (definition == "Incomplete") *
-  IHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, edkDef) *
+  IHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, edkDef) *
   (errorMessage == ""),
 
   (* Broken header *)
   (definition == "Broken") *
-  BHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, #ECDef, edkDef, errorMessage);
+  BHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, #ECDef, edkDef, errorMessage);
 
 (*************************
  *************************

--- a/Gillian-C/examples/amazon/logic/EncryptionHeaderLogic.gil
+++ b/Gillian-C/examples/amazon/logic/EncryptionHeaderLogic.gil
@@ -14,7 +14,7 @@
     ----------------||----|----|---- ... ----||----------------
                 readPos
 *)
-pred Field(+buffer : List, +readPos : Int, field : List, length : Int) :
+pred Field(buffer : List, readPos : Int; field : List, length : Int) :
     (0i i<=# readPos) * (#rawFL == l-sub(buffer, readPos, 2i)) *
     rawToUInt16(#rawFL, false, #fieldLength) *
     (field == l-sub(buffer, (readPos i+ 2i), #fieldLength)) *
@@ -64,7 +64,7 @@ pred Field(+buffer : List, +readPos : Int, field : List, length : Int) :
                 readPos
 *)
 @nopath
-pred IElement(+buffer : List, +readPos : Int, +fCount : Int, fList : List, eLength : Int) :
+pred IElement(buffer : List, readPos : Int, fCount : Int; fList : List, eLength : Int) :
   (* Base case: not enough data to read length of next field *)
   (0i i<=# readPos) * (0i i<# fCount) * (readPos i<=# (l-len buffer)) *
     ((l-len buffer) i<# (readPos i+ 2i)) * (fList == {{  }}) *
@@ -123,7 +123,7 @@ pred IElement(+buffer : List, +readPos : Int, +fCount : Int, fList : List, eLeng
                 readPos
 *)
 @nopath
-pred IElements(+buffer : List, +readPos : Int, +eCount : Int, +fCount : Int,
+pred IElements(buffer : List, readPos : Int, eCount : Int, fCount : Int;
                eList : List, esLength : Int) :
   (* Base case: single incomplete element *)
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) * (0i i<# eCount) * (0i i<# fCount) *
@@ -159,7 +159,7 @@ pred IElements(+buffer : List, +readPos : Int, +eCount : Int, +fCount : Int,
                 readPos
 *)
 @nopath
-pred CElement(+buffer : List, +readPos : Int, +fCount : Int, element : List, length : Int) :
+pred CElement(buffer : List, readPos : Int, fCount : Int; element : List, length : Int) :
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) *
     (fCount == 0i) * (element == {{  }}) * (length == 0i),
   (0i i<# fCount) * Field(buffer, readPos, #field, #fLength) * ((typeOf #field) == List) *
@@ -193,7 +193,7 @@ pred CElement(+buffer : List, +readPos : Int, +fCount : Int, element : List, len
     ----------------||-------| ... |-------||----------------
                  readPos
 *)
-pred CElements(+buffer : List, +readPos : Int, +eCount : Int, +fCount : Int,
+pred CElements(buffer : List, readPos : Int, eCount : Int, fCount : Int;
                elements : List, length : Int) :
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) * (eCount == 0i) *
     (0i i<# fCount) * (elements == {{  }}) * (length == 0i),
@@ -236,7 +236,7 @@ lemma IElementsShift(buffer, readPos, eCount, fCount, shift)
       IElements(#rBuffer, #readPos i- #shift, #eCount, #fCount, #eList, #esLength) ]]
 
 
-nounfold pred Element(+buffer : List, +readPos : Int, +fCount : Int,
+nounfold pred Element(buffer : List, readPos : Int, fCount : Int;
                       definition : Str, fList : List, eLength : Int) :
   (definition == "Complete") *
     CElement(buffer, readPos, fCount, fList, eLength),
@@ -255,8 +255,8 @@ nounfold pred Element(+buffer : List, +readPos : Int, +fCount : Int,
 
 (* A general element sequene is either a complete or an incomplete element sequence *)
 @nopath
-nounfold pred Elements(+buffer : List, +readPos : Int, +eCount : Int,
-                       +fCount : Int, definition : Str, eList : List,
+nounfold pred Elements(buffer : List, readPos : Int, eCount : Int,
+                       fCount : Int; definition : Str, eList : List,
                        esLength : Int) :
   (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
   (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
@@ -289,7 +289,7 @@ lemma ElementsShift(buffer, readPos, eCount, fCount, shift)
 
 (* Complete serialised EDKs *)
 @nopath
-nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Int,
+nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Int;
                                     EDKs : List, EDKsLength : Int) :
     (0i i<=# readPos) * (readPos i<=# (l-len buffer)) *
     (#rawEC == l-sub(buffer, readPos, 2i)) *
@@ -300,7 +300,7 @@ nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Int,
 
 (* Incomplete serialised EDKs *)
 @nopath
-nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Int) :
+nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Int;) :
   (* Not enough data to read the number of EDKs *)
   (0i i<=# readPos) * (readPos i<=# (l-len buffer)) * ((l-len buffer) i<# (readPos i+ 2i)),
 
@@ -311,7 +311,7 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Int) :
 
 (* Broken serialised EDKs *)
 @nopath
-nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Int, errorMessage : Str, EDKs : List, EDKsLength : Int) :
+nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Int; errorMessage : Str, EDKs : List, EDKsLength : Int) :
     (* Incorrect starting position *)
     ((readPos i<# 0i) \/ ((l-len buffer) i<# readPos)) *
     (errorMessage == "deserializeMessageHeader: startPos out of bounds.") *
@@ -325,7 +325,7 @@ nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Int, errorMessage
 
 (* General serialised EDKs *)
 @nopath
-nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Int, definition : Str, EDKs : List, EDKsLength : Int, errorMessage : Str) :
+nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Int; definition : Str, EDKs : List, EDKsLength : Int, errorMessage : Str) :
   (definition == "Complete")   * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
   (definition == "Incomplete") * (errorMessage == "") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0i),
   (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage, EDKs, EDKsLength);
@@ -351,7 +351,7 @@ nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Int, definition : 
 
 (* Complete serialised encryption context *)
 @nopath
-nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
+nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
   (* ((l-len buffer) == 0i) * (ECKs == {{  }}), *)
   (0i i<# l-len buffer) * (#rawKC == l-sub(buffer, 0i, 2i)) *
     rawToUInt16(#rawKC, false, #keyCount) * (0i i<# #keyCount) *
@@ -360,7 +360,7 @@ nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
     Unique(#ECKeys) * ((2i i+ #ECKsLength) == (l-len buffer));
 
 (* Broken serialised encryption context *)
-pure nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:List) :
+pure nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (buffer == l+ ({{ #kc0, #kc1 }}, #rest)) *
     rawToUInt16({{ #kc0, #kc1 }}, false, #keyCount) *
@@ -397,7 +397,7 @@ pure nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:Li
 
 (* General serialised encryption context *)
 @nopath
-pure nounfold pred RawEncryptionContext(+buffer:List, definition:Str, ECKs:List, errorMessage:Str) :
+pure nounfold pred RawEncryptionContext(buffer:List; definition:Str, ECKs:List, errorMessage:Str) :
   (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
   (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
 
@@ -412,7 +412,7 @@ pure nounfold pred RawEncryptionContext(+buffer:List, definition:Str, ECKs:List,
 
 (* Correctly formed algorithm suite *)
 @nopath
-nounfold pred CAlgorithmSuite(+numId, stringId, ivLength, tagLength) :
+nounfold pred CAlgorithmSuite(numId; stringId, ivLength, tagLength) :
   (numId == 20i)   * (stringId == "ALG_AES128_GCM_IV12_TAG16_NO_KDF")                 * (ivLength == 12i) * (tagLength == 16i),
   (numId == 70i)   * (stringId == "ALG_AES192_GCM_IV12_TAG16_NO_KDF")                 * (ivLength == 12i) * (tagLength == 16i),
   (numId == 120i)  * (stringId == "ALG_AES256_GCM_IV12_TAG16_NO_KDF")                 * (ivLength == 12i) * (tagLength == 16i),
@@ -429,7 +429,7 @@ facts: (ivLength == 12i) and (tagLength == 16i);
 
 (* Broken algorithm suite *)
 @nopath
-pred BAlgorithmSuite(+numId, errorMessage) :
+pred BAlgorithmSuite(numId; errorMessage) :
   (! (numId == 20i)) * (! (numId == 70i)) * (! (numId == 120i)) * (! (numId == 276i)) * (! (numId == 326i)) * (! (numId == 376i)) *
   (! (numId == 532i)) * (! (numId == 838i)) * (! (numId == 888i)) * (! (numId == 1144i)) * (! (numId == 1400i)) *
   (errorMessage == "Malformed Header: Unsupported algorithm suite.");
@@ -445,19 +445,19 @@ pred BAlgorithmSuite(+numId, errorMessage) :
 
 (* Correctly formed algorithm suite *)
 @nopath
-pred CContentType(+contentType: Int) :
+pred CContentType(contentType: Int;) :
   (contentType == 1i) \/ (contentType == 2i);
 
 (* Broken algorithm suite *)
 @nopath
-pred BContentType(+contentType) :
+pred BContentType(contentType;) :
   (! (contentType == 1i)) * (! (contentType == 2i));
 
 (* If type is NONFRAMED (i.e. = 1i), frame_len has to be 0i, otherwise, if type is FRAMED (i.e = 2i), frame_len has to be > 0i *)
-pred CompatibleContentTypeAndFrameLength(+contentType: Int, +frameLength: Int):
+pred CompatibleContentTypeAndFrameLength(contentType: Int, frameLength: Int;):
   ((contentType == 1i) /\ (frameLength == 0i)) \/ ((contentType == 2i) /\ (0i i<# frameLength));
 
-pred IncompatibleContentTypeAndFrameLength(+contentType, +frameLength):
+pred IncompatibleContentTypeAndFrameLength(contentType, frameLength;):
   ((contentType == 1i) /\ (0i i<# frameLength)) \/ ((contentType == 2i) /\ (frameLength == 0i));
 
 
@@ -472,18 +472,18 @@ pred IncompatibleContentTypeAndFrameLength(+contentType, +frameLength):
 
 (* The correct version and type *)
 @nopath
-pred CVersionAndType(version, type) :
+pred CVersionAndType(version, type;) :
   (version == 1i) * (type == 128i);
 
 (* Broken version and type *)
-nounfold pred BVersionAndType(+version:Int, +type:Int, errorMessage:Str) :
+nounfold pred BVersionAndType(version:Int, type:Int; errorMessage:Str) :
     (version == 65i) * (type == 89i) * (errorMessage == "Malformed Header: This blob may be base64 encoded."),
     (! (version == 1i) \/ ! (type == 128i)) * (! (version == 65i) \/ ! (type == 89i)) * (errorMessage == "Malformed Header: Unsupported version and/or type.");
 
 
 
 (* Broken serialised header *)
-nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageId, ECLength,
+nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength,
                                       part_two, ECKs,
                                       part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, ECDef, edkDef, errorMessage) :
     (* Incorrect version and/or type *)
@@ -657,7 +657,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
 
 
 (* Serialised incomplete header *)
-nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageId, ECLength,
+nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength,
                                       part_two, ECKs,
                                       part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, edkDef) :
 
@@ -816,7 +816,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
 
 (* Serialised complete header *)
 @nopath
-nounfold pred CHeader(+rawHeaderData, part_one, version, type, suiteId,
+nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
                       messageId, ECLength, part_two, ECKs, part_three, EDKs,
                       contentType, headerIvLength, frameLength, headerLength,
                       headerIv, headerAuthTag, edkDef) :
@@ -849,7 +849,7 @@ nounfold pred CHeader(+rawHeaderData, part_one, version, type, suiteId,
 
 
 (* General serialised header *)
-nounfold pred Header(+rawHeaderData, definition, part_one, version, type,
+nounfold pred Header(rawHeaderData; definition, part_one, version, type,
                      suiteId, messageId, ECLength, part_two, ECKs,
                      part_three, EDKs, contentType, headerIvLength,
                      frameLength, headerLength, headerIv, headerAuthTag, edkDef,

--- a/Gillian-C/examples/amazon/logic/ListLogic.gil
+++ b/Gillian-C/examples/amazon/logic/ListLogic.gil
@@ -74,13 +74,13 @@ lemma FirstProjToUtf8MapPairCompat(PVPairs)
  ********************************)
   
 @nopath
-pure pred Unique(l : List;) :
+pure pred Unique(l : List) :
   (l == {{  }}),
   (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest; #setRest) *
-    (! (#fst --e-- #setRest)) * Unique(#rest;);
+    (! (#fst --e-- #setRest)) * Unique(#rest);
     
 lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
-  [[  (#props == l+ (#prefix, #suffix)) * Unique(#props;) *
+  [[  (#props == l+ (#prefix, #suffix)) * Unique(#props) *
       ListToSet(#prefix; #setPrefix) * ListToSet(#suffix; #setSuffix) *
       (#prop --e-- #setSuffix) ]]
   [[  (! (#prop --e-- #setPrefix)) ]]
@@ -110,7 +110,7 @@ lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
  ************************************)
 
 (* Lists with duplicates *)
-pure pred Duplicated(prefix:List, suffix:List;) :
+pure pred Duplicated(prefix:List, suffix:List) :
     (* Either the head is duplicated *)
     (suffix == l+ ({{ #fst }}, #rest)) *
     ListToSet(prefix; #preSet) *
@@ -120,7 +120,7 @@ pure pred Duplicated(prefix:List, suffix:List;) :
     (suffix == l+ ({{ #fst }}, #rest)) *
     ListToSet(prefix; #preSet) *
     (! (#fst --e-- #preSet)) *
-    Duplicated(l+ (prefix, {{ #fst }}), #rest;);
+    Duplicated(l+ (prefix, {{ #fst }}), #rest);
         
 
 (*****************************************

--- a/Gillian-C/examples/amazon/logic/ListLogic.gil
+++ b/Gillian-C/examples/amazon/logic/ListLogic.gil
@@ -13,11 +13,11 @@ lemma DestructList(lst)
 (* First projection of a list of pairs *)
 pure pred FirstProj(lst : List; fProj : List) : (lst == {{  }}) *
   (fProj == {{  }}), (lst == l+ ({{ {{ #fst, #lvar_js_7 }} }}, #rest)) *
-  FirstProj(#rest, #fProjRest) * (fProj == l+ ({{ #fst }}, #fProjRest));
+  FirstProj(#rest; #fProjRest) * (fProj == l+ ({{ #fst }}, #fProjRest));
   
 
 lemma FirstProjFunction(lst1, proj1, lst2, proj2)
-  [[  FirstProj(#lst1, #proj1) * FirstProj(#lst2, #proj2) * (#lst1 == #lst2) ]]
+  [[  FirstProj(#lst1; #proj1) * FirstProj(#lst2; #proj2) * (#lst1 == #lst2) ]]
   [[  (#proj1 == #proj2) ]]
   [*  unfold FirstProj(#lst1, #proj1)  [bind: (#fst1 := #fst) and (#rest1 := #rest) and (#fProjRest1 := #fProjRest)];
       if ((not (#lst1 = {{  }}))) then {
@@ -27,20 +27,20 @@ lemma FirstProjFunction(lst1, proj1, lst2, proj2)
   *]
 
 lemma FirstProjAppendPair(lst, fProj, prop, value)
-  [[  FirstProj(#lst, #fProj) ]]
-  [[  FirstProj(l+ (#lst, {{ {{ #prop, #value }} }}), l+ (#fProj, {{ #prop }})) ]]
+  [[  FirstProj(#lst; #fProj) ]]
+  [[  FirstProj(l+ (#lst, {{ {{ #prop, #value }} }}); l+ (#fProj, {{ #prop }})) ]]
   [*  unfold FirstProj(#lst, #fProj) ;
       if ((not (#lst = {{  }}))) then {
         sep_assert ((#lst == l+ ({{ {{ #fProp, #fValue }} }}, #restPVPairs)))
           [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (FirstProj(#restPVPairs, #restProj)) [bind: #restProj];
+        sep_assert (FirstProj(#restPVPairs; #restProj)) [bind: #restProj];
         apply FirstProjAppendPair(#restPVPairs, #restProj, #prop, #value) 
       }
   *]
       
 lemma FirstProjConcatSplit(PVPairs, prefix, suffix)
-  [[  (#PVPairs == l+ (#prefix, #suffix)) * FirstProj(#PVPairs, #props) *
-      FirstProj(#prefix, #preProps) * FirstProj(#suffix, #sufProps) ]]
+  [[  (#PVPairs == l+ (#prefix, #suffix)) * FirstProj(#PVPairs; #props) *
+      FirstProj(#prefix; #preProps) * FirstProj(#suffix; #sufProps) ]]
   [[  (#props == l+ (#preProps, #sufProps)) ]]
   [*  apply DestructList(#prefix) ; unfold FirstProj(#prefix, #preProps) ;
       if ((#prefix = {{  }})) then {
@@ -53,9 +53,9 @@ lemma FirstProjConcatSplit(PVPairs, prefix, suffix)
   *]
 
 lemma FirstProjToUtf8MapPairCompat(PVPairs)
-  [[  FirstProj(#PVPairs, #props) * toUtf8PairMap(#PVPairs, #utf8PVPairs) *
-      FirstProj(#utf8PVPairs, #utf8Props) ]]
-  [[  toUtf8Map(#props, #utf8Props) ]]
+  [[  FirstProj(#PVPairs; #props) * toUtf8PairMap(#PVPairs; #utf8PVPairs) *
+      FirstProj(#utf8PVPairs; #utf8Props) ]]
+  [[  toUtf8Map(#props; #utf8Props) ]]
   [*  unfold FirstProj(#PVPairs, #props) ;
       unfold toUtf8PairMap(#PVPairs, #utf8PVPairs) ;
       unfold FirstProj(#utf8PVPairs, #utf8Props) ;
@@ -76,12 +76,12 @@ lemma FirstProjToUtf8MapPairCompat(PVPairs)
 @nopath
 pure pred Unique(l : List;) :
   (l == {{  }}),
-  (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest, #setRest) *
-    (! (#fst --e-- #setRest)) * Unique(#rest);
+  (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest; #setRest) *
+    (! (#fst --e-- #setRest)) * Unique(#rest;);
     
 lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
-  [[  (#props == l+ (#prefix, #suffix)) * Unique(#props) *
-      ListToSet(#prefix, #setPrefix) * ListToSet(#suffix, #setSuffix) *
+  [[  (#props == l+ (#prefix, #suffix)) * Unique(#props;) *
+      ListToSet(#prefix; #setPrefix) * ListToSet(#suffix; #setSuffix) *
       (#prop --e-- #setSuffix) ]]
   [[  (! (#prop --e-- #setPrefix)) ]]
   [*  apply DestructList(#prefix) ;
@@ -113,14 +113,14 @@ lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
 pure pred Duplicated(prefix:List, suffix:List;) :
     (* Either the head is duplicated *)
     (suffix == l+ ({{ #fst }}, #rest)) *
-    ListToSet(prefix, #preSet) *
+    ListToSet(prefix; #preSet) *
     (#fst --e-- #preSet),
 
     (* Or the duplication is in the tail *)
     (suffix == l+ ({{ #fst }}, #rest)) *
-    ListToSet(prefix, #preSet) *
+    ListToSet(prefix; #preSet) *
     (! (#fst --e-- #preSet)) *
-    Duplicated(l+ (prefix, {{ #fst }}), #rest);
+    Duplicated(l+ (prefix, {{ #fst }}), #rest;);
         
 
 (*****************************************
@@ -134,11 +134,11 @@ pure pred Duplicated(prefix:List, suffix:List;) :
 pure pred ListToSet(lst : List; set : Set) :
   (lst == {{  }}) * (set == -{  }-),
   (lst == l+ ({{ #e }}, #restLst)) *
-    ListToSet(#restLst, #restSet) * (set == -u- (#restSet, -{ #e }-));
+    ListToSet(#restLst; #restSet) * (set == -u- (#restSet, -{ #e }-));
 
 lemma ListToSetUnion(lst1, lst2)
-  [[  ListToSet(#lst1, #set1) * ListToSet(#lst2, #set2) *
-      ListToSet(l+ (#lst1, #lst2), #uset) ]]
+  [[  ListToSet(#lst1; #set1) * ListToSet(#lst2; #set2) *
+      ListToSet(l+ (#lst1, #lst2); #uset) ]]
   [[  (#uset == -u- (#set1, #set2)) ]]
   [*  sep_assert ((#x == l+ (#lst1, #lst2))) [bind: #x];
       unfold ListToSet(#lst1, #set1)  [bind: (#h1 := #e) and (#rest1 := #restLst) and (#restSet1 := #restSet)];
@@ -149,7 +149,7 @@ lemma ListToSetUnion(lst1, lst2)
   *]
   
 lemma ListToSetFunction(lst1, set1, lst2, set2)
-  [[  ListToSet(#lst1, #set1) * ListToSet(#lst2, #set2) * (#lst1 == #lst2) ]]
+  [[  ListToSet(#lst1; #set1) * ListToSet(#lst2; #set2) * (#lst1 == #lst2) ]]
   [[  (#set1 == #set2) ]]
   [*  unfold ListToSet(#lst1, #set1)  [bind: (#h1 := #e) and (#t1 := #restLst) and (#restSet1 := #restSet)];
       if ((not (#lst1 = {{  }}))) then {
@@ -159,7 +159,7 @@ lemma ListToSetFunction(lst1, set1, lst2, set2)
     
 lemma ProduceListToSet(lst)
   [[  types(lst : List) ]]
-  [[  ListToSet(#lst, #set) ]]
+  [[  ListToSet(#lst; #set) ]]
   [*  apply DestructList(#lst) ;
       if ((not (#lst = {{  }}))) then {
         sep_assert ((#lst == l+ ({{ #head }}, #rest))) [bind: #head, #rest];

--- a/Gillian-C/examples/amazon/logic/ListLogic.gil
+++ b/Gillian-C/examples/amazon/logic/ListLogic.gil
@@ -11,7 +11,7 @@ lemma DestructList(lst)
  *****************************************)
 
 (* First projection of a list of pairs *)
-pure pred FirstProj(+lst : List, fProj : List) : (lst == {{  }}) *
+pure pred FirstProj(lst : List; fProj : List) : (lst == {{  }}) *
   (fProj == {{  }}), (lst == l+ ({{ {{ #fst, #lvar_js_7 }} }}, #rest)) *
   FirstProj(#rest, #fProjRest) * (fProj == l+ ({{ #fst }}, #fProjRest));
   
@@ -74,7 +74,7 @@ lemma FirstProjToUtf8MapPairCompat(PVPairs)
  ********************************)
   
 @nopath
-pure pred Unique(l : List) :
+pure pred Unique(l : List;) :
   (l == {{  }}),
   (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest, #setRest) *
     (! (#fst --e-- #setRest)) * Unique(#rest);
@@ -110,7 +110,7 @@ lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
  ************************************)
 
 (* Lists with duplicates *)
-pure pred Duplicated(+prefix:List, +suffix:List) :
+pure pred Duplicated(prefix:List, suffix:List;) :
     (* Either the head is duplicated *)
     (suffix == l+ ({{ #fst }}, #rest)) *
     ListToSet(prefix, #preSet) *
@@ -131,7 +131,7 @@ pure pred Duplicated(+prefix:List, +suffix:List) :
 ******************************************
 ******************************************)
 
-pure pred ListToSet(+lst : List, set : Set) :
+pure pred ListToSet(lst : List; set : Set) :
   (lst == {{  }}) * (set == -{  }-),
   (lst == l+ ({{ #e }}, #restLst)) *
     ListToSet(#restLst, #restSet) * (set == -u- (#restSet, -{ #e }-));

--- a/Gillian-C/examples/amazon/logic/StringStruct.gil
+++ b/Gillian-C/examples/amazon/logic/StringStruct.gil
@@ -13,7 +13,7 @@
 *)
 
 @internal
-pred m_struct_aws_string_exposing_pointer(+ptr: List, allocator : List,
+pred m_struct_aws_string_exposing_pointer(ptr: List; allocator : List,
                           len : List, bytes : List) :
   i__ptr_to_0(ptr, #loc) *
   i__is_ptr_opt(allocator) *

--- a/Gillian-C/examples/amazon/logic/StringStruct.gil
+++ b/Gillian-C/examples/amazon/logic/StringStruct.gil
@@ -16,7 +16,7 @@
 pred m_struct_aws_string_exposing_pointer(ptr: List; allocator : List,
                           len : List, bytes : List) :
   i__ptr_to_0(ptr; #loc) *
-  i__is_ptr_opt(allocator;) *
+  i__is_ptr_opt(allocator) *
   <mem_single>(#loc, 0i, "int64"; allocator, "Freeable") *
   i__long(len; #i__len_v) *
   <mem_single>(#loc, 8i, "int64"; {{ "long", #i__len_v }}, "Freeable") *

--- a/Gillian-C/examples/amazon/logic/StringStruct.gil
+++ b/Gillian-C/examples/amazon/logic/StringStruct.gil
@@ -15,10 +15,10 @@
 @internal
 pred m_struct_aws_string_exposing_pointer(ptr: List; allocator : List,
                           len : List, bytes : List) :
-  i__ptr_to_0(ptr, #loc) *
-  i__is_ptr_opt(allocator) *
+  i__ptr_to_0(ptr; #loc) *
+  i__is_ptr_opt(allocator;) *
   <mem_single>(#loc, 0i, "int64"; allocator, "Freeable") *
-  i__long(len, #i__len_v) *
+  i__long(len; #i__len_v) *
   <mem_single>(#loc, 8i, "int64"; {{ "long", #i__len_v }}, "Freeable") *
   (bytes == {{ #loc, 16i }}) *
   <mem_single>(#loc, -8i, "int64"; {{ "long", #i__len_v i+ 17i }}, "Freeable") *

--- a/Gillian-C/examples/amazon/logic/Utf8Logic.gil
+++ b/Gillian-C/examples/amazon/logic/Utf8Logic.gil
@@ -16,13 +16,13 @@
 abstract pure nounfold pred toUtf8(rawData : List; utf8Data : Str);
 
 lemma toUtf8Injective(rawData1, utf8Data1, rawData2, utf8Data2)
-  [[  toUtf8(#rawData1, #utf8Data1) * toUtf8(#rawData2, #utf8Data2) ]]
+  [[  toUtf8(#rawData1; #utf8Data1) * toUtf8(#rawData2; #utf8Data2) ]]
   [[  (#rawData1 == #rawData2) * (#utf8Data1 == #utf8Data2);
       (! (#rawData1 == #rawData2)) * (! (#utf8Data1 == #utf8Data2)) ]]
 
 pure pred toUtf8Map(data : List; utf8Data : List) : (data == {{  }}) *
   (utf8Data == {{  }}), (data == l+ ({{ #fst }}, #rest)) *
-  toUtf8(#fst, #utf8Fst) * toUtf8Map(#rest, #utf8Rest) *
+  toUtf8(#fst; #utf8Fst) * toUtf8Map(#rest; #utf8Rest) *
   (utf8Data == l+ ({{ #utf8Fst }}, #utf8Rest));
 
 (* UTF-8 Mapping of lists of pairs *)
@@ -30,16 +30,16 @@ pure pred toUtf8Map(data : List; utf8Data : List) : (data == {{  }}) *
 pure pred toUtf8PairMap(data : List; utf8Data : List) :
   (data == {{  }}) * (utf8Data == {{  }}),
   (data == l+ ({{ {{ #prop, #value }} }}, #rest)) *
-    toUtf8(#prop, #utf8Prop) * toUtf8(#value, #utf8Value) *
-    toUtf8PairMap(#rest, #utf8Rest) *
+    toUtf8(#prop; #utf8Prop) * toUtf8(#value; #utf8Value) *
+    toUtf8PairMap(#rest; #utf8Rest) *
     (utf8Data == l+ ({{ {{ #utf8Prop, #utf8Value }} }}, #utf8Rest));
 
 lemma toUtf8PairMapAppendPair(data, utf8Data, prop, value)
-  [[  toUtf8PairMap(#data, #utf8Data) *
-      toUtf8(#prop, #utf8Prop) *
-      toUtf8(#value, #utf8Value) ]]
+  [[  toUtf8PairMap(#data; #utf8Data) *
+      toUtf8(#prop; #utf8Prop) *
+      toUtf8(#value; #utf8Value) ]]
   [[  toUtf8PairMap(
-        l+ (#data, {{ {{ #prop, #value }} }}),
+        l+ (#data, {{ {{ #prop, #value }} }});
         l+ (#utf8Data, {{ {{ #utf8Prop, #utf8Value }} }})
       )
   ]]
@@ -47,13 +47,13 @@ lemma toUtf8PairMapAppendPair(data, utf8Data, prop, value)
       if ((not (#data = {{  }}))) then {
         sep_assert ((#data == l+ ({{ {{ #fProp, #fValue }} }}, #restPVPairs)))
           [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (toUtf8PairMap(#restPVPairs, #restUtf8Data)) [bind: #restUtf8Data];
+        sep_assert (toUtf8PairMap(#restPVPairs; #restUtf8Data)) [bind: #restUtf8Data];
         apply toUtf8PairMapAppendPair(#restPVPairs, #restUtf8Data, #prop, #value)
       }  *]
 
 lemma toUtf8PairMapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
-  [[  toUtf8PairMap(#rawData1, #utf8Data1) *
-      toUtf8PairMap(#rawData2, #utf8Data2) ]]
+  [[  toUtf8PairMap(#rawData1; #utf8Data1) *
+      toUtf8PairMap(#rawData2; #utf8Data2) ]]
   [[  (#rawData1 == #rawData2) * (#utf8Data1 == #utf8Data2);
       (! (#rawData1 == #rawData2)) * (! (#utf8Data1 == #utf8Data2)) ]]
   [*  unfold toUtf8PairMap(#rawData1, #utf8Data1) ;
@@ -72,30 +72,30 @@ lemma toUtf8PairMapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
   *]
 
 lemma NotInListToUtf8(prop, props)
-  [[  ListToSet(#props, #propsSet) * (! (#prop --e-- #propsSet)) *
-      toUtf8(#prop, #utf8Prop) * toUtf8Map(#props, #utf8Props) *
-      ListToSet(#utf8Props, #utf8PropsSet) ]]
+  [[  ListToSet(#props; #propsSet) * (! (#prop --e-- #propsSet)) *
+      toUtf8(#prop; #utf8Prop) * toUtf8Map(#props; #utf8Props) *
+      ListToSet(#utf8Props; #utf8PropsSet) ]]
   [[  (! (#utf8Prop --e-- #utf8PropsSet)) ]]
   [*  unfold ListToSet(#props, #propsSet) ;
       unfold toUtf8Map(#props, #utf8Props) ;
       unfold ListToSet(#utf8Props, #utf8PropsSet) ;
       if ((not (#props = {{  }}))) then {
         sep_assert ((#props == l+ ({{ #fstProp }}, #rest))) [bind: #rest];
-        sep_assert (toUtf8(#fstProp, #utf8FstProp)) [bind: #utf8FstProp];
+        sep_assert (toUtf8(#fstProp; #utf8FstProp)) [bind: #utf8FstProp];
         apply toUtf8Injective(#prop, #utf8Prop, #fstProp, #utf8FstProp);
         apply NotInListToUtf8(#prop, #rest)
       }  *]
 
 lemma InListToUtf8(prop, props)
-  [[  ListToSet(#props, #propsSet) * (#prop --e-- #propsSet) *
-      toUtf8(#prop, #utf8Prop) * toUtf8Map(#props, #utf8Props) *
-      ListToSet(#utf8Props, #utf8PropsSet) ]]
+  [[  ListToSet(#props; #propsSet) * (#prop --e-- #propsSet) *
+      toUtf8(#prop; #utf8Prop) * toUtf8Map(#props; #utf8Props) *
+      ListToSet(#utf8Props; #utf8PropsSet) ]]
   [[  (#utf8Prop --e-- #utf8PropsSet) ]]
   [*  unfold ListToSet(#props, #propsSet) ;
       if ((not (#props = {{  }}))) then {
         sep_assert ((#props == l+ ({{ #fstProp }}, #rest))) [bind: #rest];
         unfold toUtf8Map(#props, #utf8Props) ;
-        sep_assert (toUtf8(#fstProp, #utf8FstProp)) [bind: #utf8FstProp];
+        sep_assert (toUtf8(#fstProp; #utf8FstProp)) [bind: #utf8FstProp];
         sep_assert ((#utf8Props == l+ ({{ #utf8FstProp }}, #restUtf8))) [bind: #restUtf8];
         unfold ListToSet(#utf8Props, #utf8PropsSet);
         if ((#prop = #fstProp)) then {

--- a/Gillian-C/examples/amazon/logic/Utf8Logic.gil
+++ b/Gillian-C/examples/amazon/logic/Utf8Logic.gil
@@ -13,21 +13,21 @@
     the raw bytes rawData to UTF-8 format
 *)
 @nopath
-abstract pure nounfold pred toUtf8(+rawData : List, utf8Data : Str);
+abstract pure nounfold pred toUtf8(rawData : List; utf8Data : Str);
 
 lemma toUtf8Injective(rawData1, utf8Data1, rawData2, utf8Data2)
   [[  toUtf8(#rawData1, #utf8Data1) * toUtf8(#rawData2, #utf8Data2) ]]
   [[  (#rawData1 == #rawData2) * (#utf8Data1 == #utf8Data2);
       (! (#rawData1 == #rawData2)) * (! (#utf8Data1 == #utf8Data2)) ]]
 
-pure pred toUtf8Map(+data : List, utf8Data : List) : (data == {{  }}) *
+pure pred toUtf8Map(data : List; utf8Data : List) : (data == {{  }}) *
   (utf8Data == {{  }}), (data == l+ ({{ #fst }}, #rest)) *
   toUtf8(#fst, #utf8Fst) * toUtf8Map(#rest, #utf8Rest) *
   (utf8Data == l+ ({{ #utf8Fst }}, #utf8Rest));
 
 (* UTF-8 Mapping of lists of pairs *)
 @nopath
-pure pred toUtf8PairMap(+data : List, utf8Data : List) :
+pure pred toUtf8PairMap(data : List; utf8Data : List) :
   (data == {{  }}) * (utf8Data == {{  }}),
   (data == l+ ({{ {{ #prop, #value }} }}, #rest)) *
     toUtf8(#prop, #utf8Prop) * toUtf8(#value, #utf8Value) *

--- a/Gillian-C/examples/amazon/logic/hash_table_ax.gil
+++ b/Gillian-C/examples/amazon/logic/hash_table_ax.gil
@@ -6,4 +6,4 @@
  ****************************************
  ****************************************)
 
-abstract pred axiomatic_hash_table_in_memory(+p_impl, alloc, rawContents: List, contents: List);
+abstract pred axiomatic_hash_table_in_memory(p_impl; alloc, rawContents: List, contents: List);

--- a/Gillian-C/examples/amazon/string.c
+++ b/Gillian-C/examples/amazon/string.c
@@ -10,12 +10,12 @@
 // valid pointer to an AWS string
 /*@
     pred valid_aws_string_ptr(str; alloc, rawContent, content) {
-        m_struct_aws_string_exposing_pointer(str, alloc, long(#len), #bytes) *
+        m_struct_aws_string_exposing_pointer(str; alloc, long(#len), #bytes) *
         (0 <=# #len) *
         ARRAY(#bytes, char, #len + 1, #bytes_content) *
         (rawContent == lsub(#bytes_content, 0, #len)) *
         (#bytes_content == rawContent @ [ 0 ]) *
-        toUtf8(rawContent, content)
+        toUtf8(rawContent; content)
     }
 */
 
@@ -30,14 +30,14 @@
             (allocator == #alloc) *
             (bytes == #bytes) * (length == long(#len)) *
             (#len <=# 65535) *
-            optBytes(#bytes, #len, #rawContent) *
-            toUtf8(#rawContent, #strContent) *
-            default_allocator(#alloc)
+            optBytes(#bytes, #len; #rawContent) *
+            toUtf8(#rawContent; #strContent) *
+            default_allocator(#alloc;)
 
         ensures:
-            valid_aws_string_ptr(ret, #alloc, #rawContent, #strContent) *
-            optBytes(#bytes, #len, #rawContent) *
-            default_allocator(#alloc)
+            valid_aws_string_ptr(ret; #alloc, #rawContent, #strContent) *
+            optBytes(#bytes, #len; #rawContent) *
+            default_allocator(#alloc;)
     }
 */
 struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator,
@@ -70,11 +70,11 @@ struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator,
 /*@
     spec aws_string_destroy(str) {
         requires:
-            valid_aws_string_ptr(str, #alloc, #rawContent, #strContent) *
-            default_allocator(#alloc)
+            valid_aws_string_ptr(str; #alloc, #rawContent, #strContent) *
+            default_allocator(#alloc;)
 
         ensures:
-            default_allocator(#alloc)
+            default_allocator(#alloc;)
 
     OR
 

--- a/Gillian-C/examples/amazon/string.c
+++ b/Gillian-C/examples/amazon/string.c
@@ -9,7 +9,7 @@
 
 // valid pointer to an AWS string
 /*@
-    pred valid_aws_string_ptr(+str, alloc, rawContent, content) {
+    pred valid_aws_string_ptr(str; alloc, rawContent, content) {
         m_struct_aws_string_exposing_pointer(str, alloc, long(#len), #bytes) *
         (0 <=# #len) *
         ARRAY(#bytes, char, #len + 1, #bytes_content) *

--- a/Gillian-C/examples/amazon/string.c
+++ b/Gillian-C/examples/amazon/string.c
@@ -32,12 +32,12 @@
             (#len <=# 65535) *
             optBytes(#bytes, #len; #rawContent) *
             toUtf8(#rawContent; #strContent) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
 
         ensures:
             valid_aws_string_ptr(ret; #alloc, #rawContent, #strContent) *
             optBytes(#bytes, #len; #rawContent) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
     }
 */
 struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator,
@@ -71,10 +71,10 @@ struct aws_string *aws_string_new_from_array(struct aws_allocator *allocator,
     spec aws_string_destroy(str) {
         requires:
             valid_aws_string_ptr(str; #alloc, #rawContent, #strContent) *
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
 
         ensures:
-            default_allocator(#alloc;)
+            default_allocator(#alloc)
 
     OR
 

--- a/Gillian-C/examples/incremental/verification/test_add_proc/src_after/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_add_proc/src_after/sll_a.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_add_proc/src_after/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_add_proc/src_after/sll_a.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,12 +10,12 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 
 lemma lsegToList(p, alpha) {
-    hypothesis: listSeg(#p, NULL, #alpha)
-    conclusions: list(#p, #alpha)
+    hypothesis: listSeg(#p, NULL; #alpha)
+    conclusions: list(#p; #alpha)
     proof:
       unfold listSeg(#p, NULL, #alpha) [[bind #head: #head,
                                            #tail: #tail,
@@ -27,8 +27,8 @@ lemma lsegToList(p, alpha) {
 }
 
 lemma listSegAppend(p, q, alpha, a, end) {
-    hypothesis: listSeg(#p, #q, #alpha) * (#q -m> struct ln { #a; #end })
-    conclusions: listSeg(#p, #end, #alpha @ [#a])
+    hypothesis: listSeg(#p, #q; #alpha) * (#q -m> struct ln { #a; #end })
+    conclusions: listSeg(#p, #end; #alpha @ [#a])
     proof:
       unfold listSeg(#p, #q, #alpha)[[bind #head: #head,
                                            #tail: #tail,
@@ -41,8 +41,8 @@ lemma listSegAppend(p, q, alpha, a, end) {
 */
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures:  list(ret, #alpha @ [ #v ])
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures:  list(ret; #alpha @ [ #v ])
 } */
 SLL *listAppend(SLL *x, int v) {
     if (x == NULL) {
@@ -52,7 +52,7 @@ SLL *listAppend(SLL *x, int v) {
         return el;
     } else {
         SLL *tailp = listAppend(x->next, v);
-        __builtin_annot("assert [[bind #t]] list(tailp, #t)");
+        __builtin_annot("assert [[bind #t]] list(tailp; #t)");
         __builtin_annot("unfold list(tailp, #t)");
         __builtin_annot("fold list(tailp, #t)");
         x->next = tailp;
@@ -64,8 +64,8 @@ SLL *listAppend(SLL *x, int v) {
   requires: (x -m> struct ln { #head; NULL }) *
             (x == #v) *
             (z == #z) *
-            list(#z, #alpha)
-  ensures: list(ret, #head::#alpha)
+            list(#z; #alpha)
+  ensures: list(ret; #head::#alpha)
 } */
 SLL *listPrepend(SLL *x, SLL *z) {
     __builtin_annot("unfold list(#z, #alpha)");
@@ -74,8 +74,8 @@ SLL *listPrepend(SLL *x, SLL *z) {
 }
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {
@@ -87,8 +87,8 @@ SLL* listPrependV(SLL *x, int v) {
 }
 
 /*@ spec listLength(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(#x, #alpha) * (ret == int(#r)) * (#r == len #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(#x; #alpha) * (ret == int(#r)) * (#r == len #alpha)
 } */
 int listLength(SLL *x) {
     if (x == NULL) {

--- a/Gillian-C/examples/incremental/verification/test_add_proc/src_after/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_add_proc/src_after/sll_b.c
@@ -1,7 +1,7 @@
 #include "sll.h"
 
 /*@ spec listDispose(x) {
-  requires: list(#x, #alpha) * (x == #x)
+  requires: list(#x; #alpha) * (x == #x)
   ensures:  emp
 } */
 void listDispose(SLL *x) {
@@ -15,8 +15,8 @@ void listDispose(SLL *x) {
 }
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;

--- a/Gillian-C/examples/incremental/verification/test_add_proc/src_before/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_add_proc/src_before/sll_a.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_add_proc/src_before/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_add_proc/src_before/sll_a.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,12 +10,12 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 
 lemma lsegToList(p, alpha) {
-    hypothesis: listSeg(#p, NULL, #alpha)
-    conclusions: list(#p, #alpha)
+    hypothesis: listSeg(#p, NULL; #alpha)
+    conclusions: list(#p; #alpha)
     proof:
       unfold listSeg(#p, NULL, #alpha) [[bind #head: #head,
                                            #tail: #tail,
@@ -27,8 +27,8 @@ lemma lsegToList(p, alpha) {
 }
 
 lemma listSegAppend(p, q, alpha, a, end) {
-    hypothesis: listSeg(#p, #q, #alpha) * (#q -m> struct ln { #a; #end })
-    conclusions: listSeg(#p, #end, #alpha @ [#a])
+    hypothesis: listSeg(#p, #q; #alpha) * (#q -m> struct ln { #a; #end })
+    conclusions: listSeg(#p, #end; #alpha @ [#a])
     proof:
       unfold listSeg(#p, #q, #alpha)[[bind #head: #head,
                                            #tail: #tail,
@@ -41,8 +41,8 @@ lemma listSegAppend(p, q, alpha, a, end) {
 */
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures:  list(ret, #alpha @ [ #v ])
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures:  list(ret; #alpha @ [ #v ])
 } */
 SLL *listAppend(SLL *x, int v) {
     if (x == NULL) {
@@ -52,7 +52,7 @@ SLL *listAppend(SLL *x, int v) {
         return el;
     } else {
         SLL *tailp = listAppend(x->next, v);
-        __builtin_annot("assert [[bind #t]] list(tailp, #t)");
+        __builtin_annot("assert [[bind #t]] list(tailp; #t)");
         __builtin_annot("unfold list(tailp, #t)");
         __builtin_annot("fold list(tailp, #t)");
         x->next = tailp;
@@ -64,8 +64,8 @@ SLL *listAppend(SLL *x, int v) {
   requires: (x -m> struct ln { #head; NULL }) *
             (x == #v) *
             (z == #z) *
-            list(#z, #alpha)
-  ensures: list(ret, #head::#alpha)
+            list(#z; #alpha)
+  ensures: list(ret; #head::#alpha)
 } */
 SLL *listPrepend(SLL *x, SLL *z) {
     __builtin_annot("unfold list(#z, #alpha)");
@@ -74,8 +74,8 @@ SLL *listPrepend(SLL *x, SLL *z) {
 }
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {
@@ -87,8 +87,8 @@ SLL* listPrependV(SLL *x, int v) {
 }
 
 /*@ spec listLength(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(#x, #alpha) * (ret == int(#r)) * (#r == len #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(#x; #alpha) * (ret == int(#r)) * (#r == len #alpha)
 } */
 int listLength(SLL *x) {
     if (x == NULL) {

--- a/Gillian-C/examples/incremental/verification/test_add_proc/src_before/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_add_proc/src_before/sll_b.c
@@ -1,7 +1,7 @@
 #include "sll.h"
 
 /*@ spec listDispose(x) {
-  requires: list(#x, #alpha) * (x == #x)
+  requires: list(#x; #alpha) * (x == #x)
   ensures:  emp
 } */
 void listDispose(SLL *x) {

--- a/Gillian-C/examples/incremental/verification/test_change_header/src_after/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_change_header/src_after/sll_a.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_change_header/src_after/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_change_header/src_after/sll_a.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,12 +10,12 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 
 lemma lsegToList(p, alpha) {
-    hypothesis: listSeg(#p, NULL, #alpha)
-    conclusions: list(#p, #alpha)
+    hypothesis: listSeg(#p, NULL; #alpha)
+    conclusions: list(#p; #alpha)
     proof:
       unfold listSeg(#p, NULL, #alpha) [[bind #head: #head,
                                            #tail: #tail,
@@ -27,8 +27,8 @@ lemma lsegToList(p, alpha) {
 }
 
 lemma listSegAppend(p, q, alpha, a, end) {
-    hypothesis: listSeg(#p, #q, #alpha) * (#q -m> struct ln { #a; #end })
-    conclusions: listSeg(#p, #end, #alpha @ [#a])
+    hypothesis: listSeg(#p, #q; #alpha) * (#q -m> struct ln { #a; #end })
+    conclusions: listSeg(#p, #end; #alpha @ [#a])
     proof:
       unfold listSeg(#p, #q, #alpha)[[bind #head: #head,
                                            #tail: #tail,
@@ -41,8 +41,8 @@ lemma listSegAppend(p, q, alpha, a, end) {
 */
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures:  list(ret, #alpha @ [ #v ])
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures:  list(ret; #alpha @ [ #v ])
 } */
 SLL *listAppend(SLL *x, int v) {
     if (x == NULL) {
@@ -52,7 +52,7 @@ SLL *listAppend(SLL *x, int v) {
         return el;
     } else {
         SLL *tailp = listAppend(x->next, v);
-        __builtin_annot("assert [[bind #t]] list(tailp, #t)");
+        __builtin_annot("assert [[bind #t]] list(tailp; #t)");
         __builtin_annot("unfold list(tailp, #t)");
         __builtin_annot("fold list(tailp, #t)");
         x->next = tailp;
@@ -64,8 +64,8 @@ SLL *listAppend(SLL *x, int v) {
   requires: (x -m> struct ln { #head; NULL }) *
             (x == #v) *
             (z == #z) *
-            list(#z, #alpha)
-  ensures: list(ret, #head::#alpha)
+            list(#z; #alpha)
+  ensures: list(ret; #head::#alpha)
 } */
 SLL *listPrepend(SLL *x, SLL *z) {
     __builtin_annot("unfold list(#z, #alpha)");
@@ -74,8 +74,8 @@ SLL *listPrepend(SLL *x, SLL *z) {
 }
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {
@@ -87,8 +87,8 @@ SLL* listPrependV(SLL *x, int v) {
 }
 
 /*@ spec listLength(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(#x, #alpha) * (ret == int(#r)) * (#r == len #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(#x; #alpha) * (ret == int(#r)) * (#r == len #alpha)
 } */
 int listLength(SLL *x) {
     if (x == NULL) {

--- a/Gillian-C/examples/incremental/verification/test_change_header/src_after/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_change_header/src_after/sll_b.c
@@ -1,7 +1,7 @@
 #include "sll.h"
 
 /*@ spec listDispose(x) {
-  requires: list(#x, #alpha) * (x == #x)
+  requires: list(#x; #alpha) * (x == #x)
   ensures:  emp
 } */
 void listDispose(SLL *x) {
@@ -15,8 +15,8 @@ void listDispose(SLL *x) {
 }
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;
@@ -30,8 +30,8 @@ SLL *listCopy(SLL *x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: list(#x, #alpha) * (x == #x) * list(#y, #beta) * (y == #y)
-  ensures:  list(ret, #alpha @ #beta)
+  requires: list(#x; #alpha) * (x == #x) * list(#y; #beta) * (y == #y)
+  ensures:  list(ret; #alpha @ #beta)
 } */
 SLL *listConcat(SLL *x, SLL *y) {
     SLL *r;
@@ -39,7 +39,7 @@ SLL *listConcat(SLL *x, SLL *y) {
         r = y;
     } else {
         SLL *c = listConcat(x->next, y);
-        __builtin_annot("assert [[bind #gamma]] list(c, #gamma)");
+        __builtin_annot("assert [[bind #gamma]] list(c; #gamma)");
         __builtin_annot("unfold list(c, #gamma)");
         __builtin_annot("fold list(c, #gamma)");
         x->next = c;

--- a/Gillian-C/examples/incremental/verification/test_change_header/src_before/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_change_header/src_before/sll_a.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_change_header/src_before/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_change_header/src_before/sll_a.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,12 +10,12 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 
 lemma lsegToList(p, alpha) {
-    hypothesis: listSeg(#p, NULL, #alpha)
-    conclusions: list(#p, #alpha)
+    hypothesis: listSeg(#p, NULL; #alpha)
+    conclusions: list(#p; #alpha)
     proof:
       unfold listSeg(#p, NULL, #alpha) [[bind #head: #head,
                                            #tail: #tail,
@@ -27,8 +27,8 @@ lemma lsegToList(p, alpha) {
 }
 
 lemma listSegAppend(p, q, alpha, a, end) {
-    hypothesis: listSeg(#p, #q, #alpha) * (#q -m> struct ln { #a; #end })
-    conclusions: listSeg(#p, #end, #alpha @ [#a])
+    hypothesis: listSeg(#p, #q; #alpha) * (#q -m> struct ln { #a; #end })
+    conclusions: listSeg(#p, #end; #alpha @ [#a])
     proof:
       unfold listSeg(#p, #q, #alpha)[[bind #head: #head,
                                            #tail: #tail,
@@ -41,8 +41,8 @@ lemma listSegAppend(p, q, alpha, a, end) {
 */
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures:  list(ret, #alpha @ [ #v ])
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures:  list(ret; #alpha @ [ #v ])
 } */
 SLL *listAppend(SLL *x, int v) {
     if (x == NULL) {
@@ -52,7 +52,7 @@ SLL *listAppend(SLL *x, int v) {
         return el;
     } else {
         SLL *tailp = listAppend(x->next, v);
-        __builtin_annot("assert [[bind #t]] list(tailp, #t)");
+        __builtin_annot("assert [[bind #t]] list(tailp; #t)");
         __builtin_annot("unfold list(tailp, #t)");
         __builtin_annot("fold list(tailp, #t)");
         x->next = tailp;
@@ -64,8 +64,8 @@ SLL *listAppend(SLL *x, int v) {
   requires: (x -m> struct ln { #head; NULL }) *
             (x == #v) *
             (z == #z) *
-            list(#z, #alpha)
-  ensures: list(ret, #head::#alpha)
+            list(#z; #alpha)
+  ensures: list(ret; #head::#alpha)
 } */
 SLL *listPrepend(SLL *x, SLL *z) {
     __builtin_annot("unfold list(#z, #alpha)");
@@ -74,8 +74,8 @@ SLL *listPrepend(SLL *x, SLL *z) {
 }
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {
@@ -87,8 +87,8 @@ SLL* listPrependV(SLL *x, int v) {
 }
 
 /*@ spec listLength(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(#x, #alpha) * (ret == int(#r)) * (#r == len #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(#x; #alpha) * (ret == int(#r)) * (#r == len #alpha)
 } */
 int listLength(SLL *x) {
     if (x == NULL) {

--- a/Gillian-C/examples/incremental/verification/test_change_header/src_before/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_change_header/src_before/sll_b.c
@@ -1,7 +1,7 @@
 #include "sll.h"
 
 /*@ spec listDispose(x) {
-  requires: list(#x, #alpha) * (x == #x)
+  requires: list(#x; #alpha) * (x == #x)
   ensures:  emp
 } */
 void listDispose(SLL *x) {
@@ -15,8 +15,8 @@ void listDispose(SLL *x) {
 }
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;
@@ -30,8 +30,8 @@ SLL *listCopy(SLL *x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: list(#x, #alpha) * (x == #x) * list(#y, #beta) * (y == #y)
-  ensures:  list(ret, #alpha @ #beta)
+  requires: list(#x; #alpha) * (x == #x) * list(#y; #beta) * (y == #y)
+  ensures:  list(ret; #alpha @ #beta)
 } */
 SLL *listConcat(SLL *x, SLL *y) {
     SLL *r;
@@ -39,7 +39,7 @@ SLL *listConcat(SLL *x, SLL *y) {
         r = y;
     } else {
         SLL *c = listConcat(x->next, y);
-        __builtin_annot("assert [[bind #gamma]] list(c, #gamma)");
+        __builtin_annot("assert [[bind #gamma]] list(c; #gamma)");
         __builtin_annot("unfold list(c, #gamma)");
         __builtin_annot("fold list(c, #gamma)");
         x->next = c;

--- a/Gillian-C/examples/incremental/verification/test_change_pred/src_after/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_change_pred/src_after/sll_a.c
@@ -1,8 +1,8 @@
 #include "sll.h"
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {
@@ -14,8 +14,8 @@ SLL* listPrependV(SLL *x, int v) {
 }
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;

--- a/Gillian-C/examples/incremental/verification/test_change_pred/src_after/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_change_pred/src_after/sll_b.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil) * (1 == 1)
 }
 
@@ -10,7 +10,7 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 */
 

--- a/Gillian-C/examples/incremental/verification/test_change_pred/src_after/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_change_pred/src_after/sll_b.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil) * (1 == 1)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_change_pred/src_before/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_change_pred/src_before/sll_a.c
@@ -1,8 +1,8 @@
 #include "sll.h"
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {
@@ -14,8 +14,8 @@ SLL* listPrependV(SLL *x, int v) {
 }
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;

--- a/Gillian-C/examples/incremental/verification/test_change_pred/src_before/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_change_pred/src_before/sll_b.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_change_pred/src_before/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_change_pred/src_before/sll_b.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,7 +10,7 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 */
 

--- a/Gillian-C/examples/incremental/verification/test_change_proc/src_after/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_change_proc/src_after/sll_a.c
@@ -2,8 +2,8 @@
 
 // Some change either in the spec or body
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {

--- a/Gillian-C/examples/incremental/verification/test_change_proc/src_after/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_change_proc/src_after/sll_b.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_change_proc/src_after/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_change_proc/src_after/sll_b.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,13 +10,13 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 */
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;

--- a/Gillian-C/examples/incremental/verification/test_change_proc/src_before/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_change_proc/src_before/sll_a.c
@@ -1,8 +1,8 @@
 #include "sll.h"
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {

--- a/Gillian-C/examples/incremental/verification/test_change_proc/src_before/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_change_proc/src_before/sll_b.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_change_proc/src_before/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_change_proc/src_before/sll_b.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,13 +10,13 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 */
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;

--- a/Gillian-C/examples/incremental/verification/test_no_change/src_after/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_no_change/src_after/sll_a.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_no_change/src_after/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_no_change/src_after/sll_a.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,12 +10,12 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 
 lemma lsegToList(p, alpha) {
-    hypothesis: listSeg(#p, NULL, #alpha)
-    conclusions: list(#p, #alpha)
+    hypothesis: listSeg(#p, NULL; #alpha)
+    conclusions: list(#p; #alpha)
     proof:
       unfold listSeg(#p, NULL, #alpha) [[bind #head: #head,
                                            #tail: #tail,
@@ -27,8 +27,8 @@ lemma lsegToList(p, alpha) {
 }
 
 lemma listSegAppend(p, q, alpha, a, end) {
-    hypothesis: listSeg(#p, #q, #alpha) * (#q -m> struct ln { #a; #end })
-    conclusions: listSeg(#p, #end, #alpha @ [#a])
+    hypothesis: listSeg(#p, #q; #alpha) * (#q -m> struct ln { #a; #end })
+    conclusions: listSeg(#p, #end; #alpha @ [#a])
     proof:
       unfold listSeg(#p, #q, #alpha)[[bind #head: #head,
                                            #tail: #tail,
@@ -41,8 +41,8 @@ lemma listSegAppend(p, q, alpha, a, end) {
 */
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures:  list(ret, #alpha @ [ #v ])
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures:  list(ret; #alpha @ [ #v ])
 } */
 SLL *listAppend(SLL *x, int v) {
     if (x == NULL) {
@@ -52,7 +52,7 @@ SLL *listAppend(SLL *x, int v) {
         return el;
     } else {
         SLL *tailp = listAppend(x->next, v);
-        __builtin_annot("assert [[bind #t]] list(tailp, #t)");
+        __builtin_annot("assert [[bind #t]] list(tailp; #t)");
         __builtin_annot("unfold list(tailp, #t)");
         __builtin_annot("fold list(tailp, #t)");
         x->next = tailp;
@@ -64,8 +64,8 @@ SLL *listAppend(SLL *x, int v) {
   requires: (x -m> struct ln { #head; NULL }) *
             (x == #v) *
             (z == #z) *
-            list(#z, #alpha)
-  ensures: list(ret, #head::#alpha)
+            list(#z; #alpha)
+  ensures: list(ret; #head::#alpha)
 } */
 SLL *listPrepend(SLL *x, SLL *z) {
     __builtin_annot("unfold list(#z, #alpha)");
@@ -74,8 +74,8 @@ SLL *listPrepend(SLL *x, SLL *z) {
 }
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {
@@ -87,8 +87,8 @@ SLL* listPrependV(SLL *x, int v) {
 }
 
 /*@ spec listLength(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(#x, #alpha) * (ret == int(#r)) * (#r == len #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(#x; #alpha) * (ret == int(#r)) * (#r == len #alpha)
 } */
 int listLength(SLL *x) {
     if (x == NULL) {

--- a/Gillian-C/examples/incremental/verification/test_no_change/src_after/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_no_change/src_after/sll_b.c
@@ -1,7 +1,7 @@
 #include "sll.h"
 
 /*@ spec listDispose(x) {
-  requires: list(#x, #alpha) * (x == #x)
+  requires: list(#x; #alpha) * (x == #x)
   ensures:  emp
 } */
 void listDispose(SLL *x) {
@@ -15,8 +15,8 @@ void listDispose(SLL *x) {
 }
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;
@@ -30,8 +30,8 @@ SLL *listCopy(SLL *x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: list(#x, #alpha) * (x == #x) * list(#y, #beta) * (y == #y)
-  ensures:  list(ret, #alpha @ #beta)
+  requires: list(#x; #alpha) * (x == #x) * list(#y; #beta) * (y == #y)
+  ensures:  list(ret; #alpha @ #beta)
 } */
 SLL *listConcat(SLL *x, SLL *y) {
     SLL *r;
@@ -39,7 +39,7 @@ SLL *listConcat(SLL *x, SLL *y) {
         r = y;
     } else {
         SLL *c = listConcat(x->next, y);
-        __builtin_annot("assert [[bind #gamma]] list(c, #gamma)");
+        __builtin_annot("assert [[bind #gamma]] list(c; #gamma)");
         __builtin_annot("unfold list(c, #gamma)");
         __builtin_annot("fold list(c, #gamma)");
         x->next = c;

--- a/Gillian-C/examples/incremental/verification/test_no_change/src_before/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_no_change/src_before/sll_a.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_no_change/src_before/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_no_change/src_before/sll_a.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,12 +10,12 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 
 lemma lsegToList(p, alpha) {
-    hypothesis: listSeg(#p, NULL, #alpha)
-    conclusions: list(#p, #alpha)
+    hypothesis: listSeg(#p, NULL; #alpha)
+    conclusions: list(#p; #alpha)
     proof:
       unfold listSeg(#p, NULL, #alpha) [[bind #head: #head,
                                            #tail: #tail,
@@ -27,8 +27,8 @@ lemma lsegToList(p, alpha) {
 }
 
 lemma listSegAppend(p, q, alpha, a, end) {
-    hypothesis: listSeg(#p, #q, #alpha) * (#q -m> struct ln { #a; #end })
-    conclusions: listSeg(#p, #end, #alpha @ [#a])
+    hypothesis: listSeg(#p, #q; #alpha) * (#q -m> struct ln { #a; #end })
+    conclusions: listSeg(#p, #end; #alpha @ [#a])
     proof:
       unfold listSeg(#p, #q, #alpha)[[bind #head: #head,
                                            #tail: #tail,
@@ -41,8 +41,8 @@ lemma listSegAppend(p, q, alpha, a, end) {
 */
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures:  list(ret, #alpha @ [ #v ])
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures:  list(ret; #alpha @ [ #v ])
 } */
 SLL *listAppend(SLL *x, int v) {
     if (x == NULL) {
@@ -52,7 +52,7 @@ SLL *listAppend(SLL *x, int v) {
         return el;
     } else {
         SLL *tailp = listAppend(x->next, v);
-        __builtin_annot("assert [[bind #t]] list(tailp, #t)");
+        __builtin_annot("assert [[bind #t]] list(tailp; #t)");
         __builtin_annot("unfold list(tailp, #t)");
         __builtin_annot("fold list(tailp, #t)");
         x->next = tailp;
@@ -64,8 +64,8 @@ SLL *listAppend(SLL *x, int v) {
   requires: (x -m> struct ln { #head; NULL }) *
             (x == #v) *
             (z == #z) *
-            list(#z, #alpha)
-  ensures: list(ret, #head::#alpha)
+            list(#z; #alpha)
+  ensures: list(ret; #head::#alpha)
 } */
 SLL *listPrepend(SLL *x, SLL *z) {
     __builtin_annot("unfold list(#z, #alpha)");
@@ -74,8 +74,8 @@ SLL *listPrepend(SLL *x, SLL *z) {
 }
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {
@@ -87,8 +87,8 @@ SLL* listPrependV(SLL *x, int v) {
 }
 
 /*@ spec listLength(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(#x, #alpha) * (ret == int(#r)) * (#r == len #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(#x; #alpha) * (ret == int(#r)) * (#r == len #alpha)
 } */
 int listLength(SLL *x) {
     if (x == NULL) {

--- a/Gillian-C/examples/incremental/verification/test_no_change/src_before/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_no_change/src_before/sll_b.c
@@ -1,7 +1,7 @@
 #include "sll.h"
 
 /*@ spec listDispose(x) {
-  requires: list(#x, #alpha) * (x == #x)
+  requires: list(#x; #alpha) * (x == #x)
   ensures:  emp
 } */
 void listDispose(SLL *x) {
@@ -15,8 +15,8 @@ void listDispose(SLL *x) {
 }
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;
@@ -30,8 +30,8 @@ SLL *listCopy(SLL *x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: list(#x, #alpha) * (x == #x) * list(#y, #beta) * (y == #y)
-  ensures:  list(ret, #alpha @ #beta)
+  requires: list(#x; #alpha) * (x == #x) * list(#y; #beta) * (y == #y)
+  ensures:  list(ret; #alpha @ #beta)
 } */
 SLL *listConcat(SLL *x, SLL *y) {
     SLL *r;
@@ -39,7 +39,7 @@ SLL *listConcat(SLL *x, SLL *y) {
         r = y;
     } else {
         SLL *c = listConcat(x->next, y);
-        __builtin_annot("assert [[bind #gamma]] list(c, #gamma)");
+        __builtin_annot("assert [[bind #gamma]] list(c; #gamma)");
         __builtin_annot("unfold list(c, #gamma)");
         __builtin_annot("fold list(c, #gamma)");
         x->next = c;

--- a/Gillian-C/examples/incremental/verification/test_remove_proc/src_after/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_remove_proc/src_after/sll_a.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_remove_proc/src_after/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_remove_proc/src_after/sll_a.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,12 +10,12 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 
 lemma lsegToList(p, alpha) {
-    hypothesis: listSeg(#p, NULL, #alpha)
-    conclusions: list(#p, #alpha)
+    hypothesis: listSeg(#p, NULL; #alpha)
+    conclusions: list(#p; #alpha)
     proof:
       unfold listSeg(#p, NULL, #alpha) [[bind #head: #head,
                                            #tail: #tail,
@@ -27,8 +27,8 @@ lemma lsegToList(p, alpha) {
 }
 
 lemma listSegAppend(p, q, alpha, a, end) {
-    hypothesis: listSeg(#p, #q, #alpha) * (#q -m> struct ln { #a; #end })
-    conclusions: listSeg(#p, #end, #alpha @ [#a])
+    hypothesis: listSeg(#p, #q; #alpha) * (#q -m> struct ln { #a; #end })
+    conclusions: listSeg(#p, #end; #alpha @ [#a])
     proof:
       unfold listSeg(#p, #q, #alpha)[[bind #head: #head,
                                            #tail: #tail,
@@ -41,8 +41,8 @@ lemma listSegAppend(p, q, alpha, a, end) {
 */
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {

--- a/Gillian-C/examples/incremental/verification/test_remove_proc/src_after/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_remove_proc/src_after/sll_b.c
@@ -1,7 +1,7 @@
 #include "sll.h"
 
 /*@ spec listDispose(x) {
-  requires: list(#x, #alpha) * (x == #x)
+  requires: list(#x; #alpha) * (x == #x)
   ensures:  emp
 } */
 void listDispose(SLL *x) {
@@ -15,8 +15,8 @@ void listDispose(SLL *x) {
 }
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;
@@ -30,8 +30,8 @@ SLL *listCopy(SLL *x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: list(#x, #alpha) * (x == #x) * list(#y, #beta) * (y == #y)
-  ensures:  list(ret, #alpha @ #beta)
+  requires: list(#x; #alpha) * (x == #x) * list(#y; #beta) * (y == #y)
+  ensures:  list(ret; #alpha @ #beta)
 } */
 SLL *listConcat(SLL *x, SLL *y) {
     SLL *r;
@@ -39,7 +39,7 @@ SLL *listConcat(SLL *x, SLL *y) {
         r = y;
     } else {
         SLL *c = listConcat(x->next, y);
-        __builtin_annot("assert [[bind #gamma]] list(c, #gamma)");
+        __builtin_annot("assert [[bind #gamma]] list(c; #gamma)");
         __builtin_annot("unfold list(c, #gamma)");
         __builtin_annot("fold list(c, #gamma)");
         x->next = c;

--- a/Gillian-C/examples/incremental/verification/test_remove_proc/src_before/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_remove_proc/src_before/sll_a.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_remove_proc/src_before/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_remove_proc/src_before/sll_a.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,12 +10,12 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 
 lemma lsegToList(p, alpha) {
-    hypothesis: listSeg(#p, NULL, #alpha)
-    conclusions: list(#p, #alpha)
+    hypothesis: listSeg(#p, NULL; #alpha)
+    conclusions: list(#p; #alpha)
     proof:
       unfold listSeg(#p, NULL, #alpha) [[bind #head: #head,
                                            #tail: #tail,
@@ -27,8 +27,8 @@ lemma lsegToList(p, alpha) {
 }
 
 lemma listSegAppend(p, q, alpha, a, end) {
-    hypothesis: listSeg(#p, #q, #alpha) * (#q -m> struct ln { #a; #end })
-    conclusions: listSeg(#p, #end, #alpha @ [#a])
+    hypothesis: listSeg(#p, #q; #alpha) * (#q -m> struct ln { #a; #end })
+    conclusions: listSeg(#p, #end; #alpha @ [#a])
     proof:
       unfold listSeg(#p, #q, #alpha)[[bind #head: #head,
                                            #tail: #tail,
@@ -41,8 +41,8 @@ lemma listSegAppend(p, q, alpha, a, end) {
 */
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures:  list(ret, #alpha @ [ #v ])
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures:  list(ret; #alpha @ [ #v ])
 } */
 SLL *listAppend(SLL *x, int v) {
     if (x == NULL) {
@@ -52,7 +52,7 @@ SLL *listAppend(SLL *x, int v) {
         return el;
     } else {
         SLL *tailp = listAppend(x->next, v);
-        __builtin_annot("assert [[bind #t]] list(tailp, #t)");
+        __builtin_annot("assert [[bind #t]] list(tailp; #t)");
         __builtin_annot("unfold list(tailp, #t)");
         __builtin_annot("fold list(tailp, #t)");
         x->next = tailp;
@@ -64,8 +64,8 @@ SLL *listAppend(SLL *x, int v) {
   requires: (x -m> struct ln { #head; NULL }) *
             (x == #v) *
             (z == #z) *
-            list(#z, #alpha)
-  ensures: list(ret, #head::#alpha)
+            list(#z; #alpha)
+  ensures: list(ret; #head::#alpha)
 } */
 SLL *listPrepend(SLL *x, SLL *z) {
     __builtin_annot("unfold list(#z, #alpha)");
@@ -74,8 +74,8 @@ SLL *listPrepend(SLL *x, SLL *z) {
 }
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {
@@ -87,8 +87,8 @@ SLL* listPrependV(SLL *x, int v) {
 }
 
 /*@ spec listLength(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(#x, #alpha) * (ret == int(#r)) * (#r == len #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(#x; #alpha) * (ret == int(#r)) * (#r == len #alpha)
 } */
 int listLength(SLL *x) {
     if (x == NULL) {

--- a/Gillian-C/examples/incremental/verification/test_remove_proc/src_before/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_remove_proc/src_before/sll_b.c
@@ -1,7 +1,7 @@
 #include "sll.h"
 
 /*@ spec listDispose(x) {
-  requires: list(#x, #alpha) * (x == #x)
+  requires: list(#x; #alpha) * (x == #x)
   ensures:  emp
 } */
 void listDispose(SLL *x) {
@@ -15,8 +15,8 @@ void listDispose(SLL *x) {
 }
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;
@@ -30,8 +30,8 @@ SLL *listCopy(SLL *x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: list(#x, #alpha) * (x == #x) * list(#y, #beta) * (y == #y)
-  ensures:  list(ret, #alpha @ #beta)
+  requires: list(#x; #alpha) * (x == #x) * list(#y; #beta) * (y == #y)
+  ensures:  list(ret; #alpha @ #beta)
 } */
 SLL *listConcat(SLL *x, SLL *y) {
     SLL *r;
@@ -39,7 +39,7 @@ SLL *listConcat(SLL *x, SLL *y) {
         r = y;
     } else {
         SLL *c = listConcat(x->next, y);
-        __builtin_annot("assert [[bind #gamma]] list(c, #gamma)");
+        __builtin_annot("assert [[bind #gamma]] list(c; #gamma)");
         __builtin_annot("unfold list(c, #gamma)");
         __builtin_annot("fold list(c, #gamma)");
         x->next = c;

--- a/Gillian-C/examples/incremental/verification/test_transitive_call/src_after/bst_a.c
+++ b/Gillian-C/examples/incremental/verification/test_transitive_call/src_after/bst_a.c
@@ -5,20 +5,20 @@
 
   x -m> struct bstn { int(#val); #left; #right } *
   (not (#left == NULL)) * (not (#right == NULL)) *
-  BST(#right, #KR) * BST(#left, #KL) *
+  BST(#right; #KR) * BST(#left; #KL) *
   (forall #z : Int. #z --e-- #KL => #z <# #val) *
   (forall #z : Int. #z --e-- #KR => #val <# #z) *
   (K == -u- (#KL, -{ #val }-, #KR));
 
   x -m> struct bstn { int(#val); NULL; #right } *
   (not (#right == NULL)) *
-  BST(#right, #KR) *
+  BST(#right; #KR) *
   (forall #z : Int. #z --e-- #KR => #val <# #z) *
   (K == -u- (-{ #val }-, #KR));
 
   x -m> struct bstn { int(#val); #left; NULL } *
   (not (#left == NULL)) *
-  BST(#left, #KL) *
+  BST(#left; #KL) *
   (forall #z : Int. #z --e-- #KL => #z <# #val) *
   (K == -u- (-{ #val }-, #KL));
 
@@ -32,8 +32,8 @@ BST *make_node_wrapper_b(int v) { return make_node(v); }
 BST *make_node_wrapper_a(int v) { return make_node_wrapper_b(v); }
 
 /*@ spec insert(v, t) {
-  requires: (v == int(#vv)) * (t == #t) * BST(#t, #K)
-  ensures:  BST(ret, -u- (#K, -{ #vv }-))
+  requires: (v == int(#vv)) * (t == #t) * BST(#t; #K)
+  ensures:  BST(ret; -u- (#K, -{ #vv }-))
 }*/
 BST *insert(int v, BST *t) {
     BST *tmp;

--- a/Gillian-C/examples/incremental/verification/test_transitive_call/src_after/bst_a.c
+++ b/Gillian-C/examples/incremental/verification/test_transitive_call/src_after/bst_a.c
@@ -1,6 +1,6 @@
 #include "bst.h"
 
-/*@ pred BST(+x, K) {
+/*@ pred BST(x; K) {
   (x == NULL) * (K == -{ }-);
 
   x -m> struct bstn { int(#val); #left; #right } *

--- a/Gillian-C/examples/incremental/verification/test_transitive_call/src_after/bst_b.c
+++ b/Gillian-C/examples/incremental/verification/test_transitive_call/src_after/bst_b.c
@@ -3,7 +3,7 @@
 // Some change either in the spec or body
 /*@ spec make_node(v) {
   requires: (v == #v) * (#v == int(#vv))
-  ensures:  BST(ret, -{ #vv }-)
+  ensures:  BST(ret; -{ #vv }-)
 }*/
 BST *make_node(int v) {
     BST *new_node = malloc(sizeof(BST));

--- a/Gillian-C/examples/incremental/verification/test_transitive_call/src_after/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_transitive_call/src_after/sll_a.c
@@ -2,8 +2,8 @@
 
 // Some change either in the spec or body
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {

--- a/Gillian-C/examples/incremental/verification/test_transitive_call/src_after/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_transitive_call/src_after/sll_b.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_transitive_call/src_after/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_transitive_call/src_after/sll_b.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,7 +10,7 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 */
 
@@ -20,8 +20,8 @@ SLL *listPrependV_wrapper_b(SLL* x, int v) { return listPrependV(x, v); }
 SLL *listPrependV_wrapper_a(SLL* x, int v) { return listPrependV_wrapper_b(x, v); }
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;

--- a/Gillian-C/examples/incremental/verification/test_transitive_call/src_before/bst_a.c
+++ b/Gillian-C/examples/incremental/verification/test_transitive_call/src_before/bst_a.c
@@ -5,20 +5,20 @@
 
   x -m> struct bstn { int(#val); #left; #right } *
   (not (#left == NULL)) * (not (#right == NULL)) *
-  BST(#right, #KR) * BST(#left, #KL) *
+  BST(#right; #KR) * BST(#left; #KL) *
   (forall #z : Int. #z --e-- #KL => #z <# #val) *
   (forall #z : Int. #z --e-- #KR => #val <# #z) *
   (K == -u- (#KL, -{ #val }-, #KR));
 
   x -m> struct bstn { int(#val); NULL; #right } *
   (not (#right == NULL)) *
-  BST(#right, #KR) *
+  BST(#right; #KR) *
   (forall #z : Int. #z --e-- #KR => #val <# #z) *
   (K == -u- (-{ #val }-, #KR));
 
   x -m> struct bstn { int(#val); #left; NULL } *
   (not (#left == NULL)) *
-  BST(#left, #KL) *
+  BST(#left; #KL) *
   (forall #z : Int. #z --e-- #KL => #z <# #val) *
   (K == -u- (-{ #val }-, #KL));
 
@@ -32,8 +32,8 @@ BST *make_node_wrapper_b(int v) { return make_node(v); }
 BST *make_node_wrapper_a(int v) { return make_node_wrapper_b(v); }
 
 /*@ spec insert(v, t) {
-  requires: (v == int(#vv)) * (t == #t) * BST(#t, #K)
-  ensures:  BST(ret, -u- (#K, -{ #vv }-))
+  requires: (v == int(#vv)) * (t == #t) * BST(#t; #K)
+  ensures:  BST(ret; -u- (#K, -{ #vv }-))
 }*/
 BST *insert(int v, BST *t) {
     BST *tmp;

--- a/Gillian-C/examples/incremental/verification/test_transitive_call/src_before/bst_a.c
+++ b/Gillian-C/examples/incremental/verification/test_transitive_call/src_before/bst_a.c
@@ -1,6 +1,6 @@
 #include "bst.h"
 
-/*@ pred BST(+x, K) {
+/*@ pred BST(x; K) {
   (x == NULL) * (K == -{ }-);
 
   x -m> struct bstn { int(#val); #left; #right } *

--- a/Gillian-C/examples/incremental/verification/test_transitive_call/src_before/bst_b.c
+++ b/Gillian-C/examples/incremental/verification/test_transitive_call/src_before/bst_b.c
@@ -2,7 +2,7 @@
 
 /*@ spec make_node(v) {
   requires: (v == #v) * (#v == int(#vv))
-  ensures:  BST(ret, -{ #vv }-)
+  ensures:  BST(ret; -{ #vv }-)
 }*/
 BST *make_node(int v) {
     BST *new_node = malloc(sizeof(BST));

--- a/Gillian-C/examples/incremental/verification/test_transitive_call/src_before/sll_a.c
+++ b/Gillian-C/examples/incremental/verification/test_transitive_call/src_before/sll_a.c
@@ -1,8 +1,8 @@
 #include "sll.h"
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {

--- a/Gillian-C/examples/incremental/verification/test_transitive_call/src_before/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_transitive_call/src_before/sll_b.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/incremental/verification/test_transitive_call/src_before/sll_b.c
+++ b/Gillian-C/examples/incremental/verification/test_transitive_call/src_before/sll_b.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,7 +10,7 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 */
 
@@ -20,8 +20,8 @@ SLL *listPrependV_wrapper_b(SLL* x, int v) { return listPrependV(x, v); }
 SLL *listPrependV_wrapper_a(SLL* x, int v) { return listPrependV_wrapper_b(x, v); }
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;

--- a/Gillian-C/examples/multifile/verification/sll_a.c
+++ b/Gillian-C/examples/multifile/verification/sll_a.c
@@ -1,12 +1,12 @@
 #include "sll.h"
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/multifile/verification/sll_a.c
+++ b/Gillian-C/examples/multifile/verification/sll_a.c
@@ -2,7 +2,7 @@
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -10,12 +10,12 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 
 lemma lsegToList(p, alpha) {
-    hypothesis: listSeg(#p, NULL, #alpha)
-    conclusions: list(#p, #alpha)
+    hypothesis: listSeg(#p, NULL; #alpha)
+    conclusions: list(#p; #alpha)
     proof:
       unfold listSeg(#p, NULL, #alpha) [[bind #head: #head,
                                            #tail: #tail,
@@ -27,8 +27,8 @@ lemma lsegToList(p, alpha) {
 }
 
 lemma listSegAppend(p, q, alpha, a, end) {
-    hypothesis: listSeg(#p, #q, #alpha) * (#q -m> struct ln { #a; #end })
-    conclusions: listSeg(#p, #end, #alpha @ [#a])
+    hypothesis: listSeg(#p, #q; #alpha) * (#q -m> struct ln { #a; #end })
+    conclusions: listSeg(#p, #end; #alpha @ [#a])
     proof:
       unfold listSeg(#p, #q, #alpha)[[bind #head: #head,
                                            #tail: #tail,
@@ -41,8 +41,8 @@ lemma listSegAppend(p, q, alpha, a, end) {
 */
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures:  list(ret, #alpha @ [ #v ])
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures:  list(ret; #alpha @ [ #v ])
 } */
 SLL *listAppend(SLL *x, int v) {
     if (x == NULL) {
@@ -52,7 +52,7 @@ SLL *listAppend(SLL *x, int v) {
         return el;
     } else {
         SLL *tailp = listAppend(x->next, v);
-        __builtin_annot("assert [[bind #t]] list(tailp, #t)");
+        __builtin_annot("assert [[bind #t]] list(tailp; #t)");
         __builtin_annot("unfold list(tailp, #t)");
         __builtin_annot("fold list(tailp, #t)");
         x->next = tailp;

--- a/Gillian-C/examples/multifile/verification/sll_b.c
+++ b/Gillian-C/examples/multifile/verification/sll_b.c
@@ -4,8 +4,8 @@
   requires: (x -m> struct ln { #head; NULL }) *
             (x == #v) *
             (z == #z) *
-            list(#z, #alpha)
-  ensures: list(ret, #head::#alpha)
+            list(#z; #alpha)
+  ensures: list(ret; #head::#alpha)
 } */
 SLL *listPrepend(SLL *x, SLL *z) {
     __builtin_annot("unfold list(#z, #alpha)");
@@ -14,8 +14,8 @@ SLL *listPrepend(SLL *x, SLL *z) {
 }
 
 /*@ spec listLength(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(#x, #alpha) * (ret == int(#r)) * (#r == len #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(#x; #alpha) * (ret == int(#r)) * (#r == len #alpha)
 } */
 int listLength(SLL *x) {
     if (x == NULL) {
@@ -26,7 +26,7 @@ int listLength(SLL *x) {
 }
 
 /*@ spec listDispose(x) {
-  requires: list(#x, #alpha) * (x == #x)
+  requires: list(#x; #alpha) * (x == #x)
   ensures:  emp
 } */
 void listDispose(SLL *x) {
@@ -40,8 +40,8 @@ void listDispose(SLL *x) {
 }
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;
@@ -59,8 +59,8 @@ SLL *listCopy(SLL *x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: list(#x, #alpha) * (x == #x) * list(#y, #beta) * (y == #y)
-  ensures:  list(ret, #alpha @ #beta)
+  requires: list(#x; #alpha) * (x == #x) * list(#y; #beta) * (y == #y)
+  ensures:  list(ret; #alpha @ #beta)
 } */
 SLL *listConcat(SLL *x, SLL *y) {
     SLL *r;
@@ -68,7 +68,7 @@ SLL *listConcat(SLL *x, SLL *y) {
         r = y;
     } else {
         SLL *c = listConcat(x->next, y);
-        __builtin_annot("assert [[bind #gamma]] list(c, #gamma)");
+        __builtin_annot("assert [[bind #gamma]] list(c; #gamma)");
         __builtin_annot("unfold list(c, #gamma)");
         __builtin_annot("fold list(c, #gamma)");
         x->next = c;

--- a/Gillian-C/examples/verification/array.c
+++ b/Gillian-C/examples/verification/array.c
@@ -12,19 +12,19 @@ typedef struct Array {
 
 // The following should be in the Gillian-C stdlib
 /*@
-pred OARRAY(+p, +size, content) {
+pred OARRAY(p, size; content) {
   (size == 0) * (content == nil);
   (0 <# size)  * ARRAY(p, int, size, content) * ((len content) == size)
 }
 
-pred OUNINIT(+p, +size) {
+pred OUNINIT(p, size;) {
   (size == 0);
   (0 <# size) * UNDEFS(p, size)
 }
 */
 
 /*@
-pred valid_array(+ar, content) {
+pred valid_array(ar; content) {
   (ar -> struct Array { #buffer; long(#capacity); long(#size) }) *
   (0 <# #capacity) *
   (#size <=# #capacity) *

--- a/Gillian-C/examples/verification/array.c
+++ b/Gillian-C/examples/verification/array.c
@@ -28,16 +28,16 @@ pred valid_array(ar; content) {
   (ar -> struct Array { #buffer; long(#capacity); long(#size) }) *
   (0 <# #capacity) *
   (#size <=# #capacity) *
-  OARRAY(#buffer, #size, content) *
-  OUNINIT(#buffer p+ (#size * 4), (#capacity - #size) * 4) *
+  OARRAY(#buffer, #size; content) *
+  OUNINIT(#buffer p+ (#size * 4), (#capacity - #size) * 4;) *
   MALLOCED(#buffer, #capacity * 4)
 }
 */
 
 /*@ spec push(ar, value) {
   requires: (ar == #ar) * (value == int(#value)) *
-            valid_array(#ar, #content)
-  ensures:  valid_array(#ar, #content @ [#value])
+            valid_array(#ar; #content)
+  ensures:  valid_array(#ar; #content @ [#value])
 }*/
 void push(Array *ar, int value) {
     if (ar->size == ar->capacity) {
@@ -54,8 +54,8 @@ void push(Array *ar, int value) {
 
 /* spec remove(ar, index) {
   requires: (ar == #ar) * (index == long(#index)) *
-            valid_array(#ar, #content) * (0 <=# #index) * (#index <# (len #content))
-  ensures:  valid_array(#ar, lsub(#content, 0, #index) @ lsub(#content, #index + 1, (len #content) - #index - 1))
+            valid_array(#ar; #content) * (0 <=# #index) * (#index <# (len #content))
+  ensures:  valid_array(#ar; lsub(#content, 0, #index) @ lsub(#content, #index + 1, (len #content) - #index - 1))
 }
 */
 void remove(Array *ar, size_t index) {

--- a/Gillian-C/examples/verification/array.c
+++ b/Gillian-C/examples/verification/array.c
@@ -17,7 +17,7 @@ pred OARRAY(p, size; content) {
   (0 <# size)  * ARRAY(p, int, size, content) * ((len content) == size)
 }
 
-pred OUNINIT(p, size;) {
+pred OUNINIT(p, size) {
   (size == 0);
   (0 <# size) * UNDEFS(p, size)
 }
@@ -29,7 +29,7 @@ pred valid_array(ar; content) {
   (0 <# #capacity) *
   (#size <=# #capacity) *
   OARRAY(#buffer, #size; content) *
-  OUNINIT(#buffer p+ (#size * 4), (#capacity - #size) * 4;) *
+  OUNINIT(#buffer p+ (#size * 4), (#capacity - #size) * 4) *
   MALLOCED(#buffer, #capacity * 4)
 }
 */

--- a/Gillian-C/examples/verification/bst.c
+++ b/Gillian-C/examples/verification/bst.c
@@ -13,20 +13,20 @@ typedef struct bstn {
 
   x -m> struct bstn { int(#val); #left; #right } *
   (not (#left == NULL)) * (not (#right == NULL)) *
-  BST(#right, #KR) * BST(#left, #KL) *
+  BST(#right; #KR) * BST(#left; #KL) *
   (forall #z : Int. (#z --e-- #KL) => (#z <# #val)) *
   (forall #z : Int. (#z --e-- #KR) => (#val <# #z)) *
   (K == -u- (#KL, -{ #val }-, #KR));
 
   x -m> struct bstn { int(#val); NULL; #right } *
   (not (#right == NULL)) *
-  BST(#right, #KR) *
+  BST(#right; #KR) *
   (forall #z : Int. #z --e-- #KR => #val <# #z) *
   (K == -u- (-{ #val }-, #KR));
 
   x -m> struct bstn { int(#val); #left; NULL } *
   (not (#left == NULL)) *
-  BST(#left, #KL) *
+  BST(#left; #KL) *
   (forall #z : Int. #z --e-- #KL => #z <# #val) *
   (K == -u- (-{ #val }-, #KL));
 
@@ -36,7 +36,7 @@ typedef struct bstn {
 
 /*@ spec makeNode(v) {
   requires: (v == #v) * (#v == int(#vv))
-  ensures:  BST(ret, -{ #vv }-)
+  ensures:  BST(ret; -{ #vv }-)
 }*/
 BST *makeNode(int v) {
     BST *new_node = malloc(sizeof(BST));
@@ -47,8 +47,8 @@ BST *makeNode(int v) {
 }
 
 /*@ spec insert(v, t) {
-  requires: (v == int(#vv)) * (t == #t) * BST(#t, #K)
-  ensures:  BST(ret, -u- (#K, -{ #vv }-))
+  requires: (v == int(#vv)) * (t == #t) * BST(#t; #K)
+  ensures:  BST(ret; -u- (#K, -{ #vv }-))
 }*/
 BST *insert(int v, BST *t) {
     BST *tmp;
@@ -68,9 +68,9 @@ BST *insert(int v, BST *t) {
 }
 
 /*@ spec find(v, t) {
-  requires: (v == int(#vv)) * (t == #t) * BST(#t, #K)
-  ensures:  BST(#t, #K) * (#vv --e-- #K) * (ret == TRUE);
-            BST(#t, #K) * (not (#vv --e-- #K)) * (ret == FALSE)
+  requires: (v == int(#vv)) * (t == #t) * BST(#t; #K)
+  ensures:  BST(#t; #K) * (#vv --e-- #K) * (ret == TRUE);
+            BST(#t; #K) * (not (#vv --e-- #K)) * (ret == FALSE)
 } */
 int find(int v, BST *t) {
     if (t == NULL) {
@@ -85,8 +85,8 @@ int find(int v, BST *t) {
 }
 
 /*@ spec find_min(t) {
-  requires: (t == #t) * BST(#t, #K) * (not (#t == NULL))
-  ensures:  BST(#t, #K) * (ret == int(#r)) * (#r --e-- #K) *
+  requires: (t == #t) * BST(#t; #K) * (not (#t == NULL))
+  ensures:  BST(#t; #K) * (ret == int(#r)) * (#r --e-- #K) *
             (forall #x : Int. (#x --e-- #K) => (#r <=# #x))
 } */
 int find_min(BST *t) {
@@ -102,8 +102,8 @@ int find_min(BST *t) {
 }
 
 /* spec remove(v, t) {
-  requires: (v == int(#v)) * (t == #t) * BST(#t, #K)
-  ensures:  (ret == #t_new) * BST(#t_new, #K_new) * (#K_new == #K -d- -{ #v }-)
+  requires: (v == int(#v)) * (t == #t) * BST(#t; #K)
+  ensures:  (ret == #t_new) * BST(#t_new; #K_new) * (#K_new == #K -d- -{ #v }-)
 } */
 BST *remove(int v, BST *t) {
     BST *ret_node;

--- a/Gillian-C/examples/verification/bst.c
+++ b/Gillian-C/examples/verification/bst.c
@@ -8,7 +8,7 @@ typedef struct bstn {
     struct bstn *right;
 } BST;
 
-/*@ pred BST(+x, K) {
+/*@ pred BST(x; K) {
   (x == NULL) * (K == -{ }-);
 
   x -m> struct bstn { int(#val); #left; #right } *

--- a/Gillian-C/examples/verification/dll.c
+++ b/Gillian-C/examples/verification/dll.c
@@ -6,7 +6,7 @@ typedef struct dln {
     struct dln *next;
 } DLL;
 
-/*@ pred DLL(+x, alpha) {
+/*@ pred DLL(x; alpha) {
   (x == NULL) * (alpha == nil);
   (x -m> struct dln {#val; #prev; #next}) *
   DLL(#next, #beta) * (alpha == #val :: #beta) *

--- a/Gillian-C/examples/verification/dll.c
+++ b/Gillian-C/examples/verification/dll.c
@@ -9,10 +9,10 @@ typedef struct dln {
 /*@ pred DLL(x; alpha) {
   (x == NULL) * (alpha == nil);
   (x -m> struct dln {#val; #prev; #next}) *
-  DLL(#next, #beta) * (alpha == #val :: #beta) *
+  DLL(#next; #beta) * (alpha == #val :: #beta) *
   (not (#prev == NULL)) * (not (#next == NULL));
   (x -m> struct dln {#val; NULL; #next}) *
-  DLL(#next, #beta) * (alpha == #val :: #beta) *
+  DLL(#next; #beta) * (alpha == #val :: #beta) *
   (not (#next == NULL));
   (x -m> struct dln {#val; NULL; NULL}) * (alpha == [ #val ]);
   (x -m> struct dln {#val; #prev; NULL}) * (alpha == [ #val ]) *
@@ -21,7 +21,7 @@ typedef struct dln {
 
 /*@ spec makeNode(x) {
   requires: (#x == int(#z)) * (#x == x)
-  ensures:  DLL(ret, [#x])
+  ensures:  DLL(ret; [#x])
 } */
 DLL *makeNode(int x) {
     DLL *r = malloc(sizeof(DLL));
@@ -32,8 +32,8 @@ DLL *makeNode(int x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: (x == #x) * (y == #y) * DLL(#x, #alpha) * DLL(#y, #beta)
-  ensures:  DLL(ret, #alpha @ #beta)
+  requires: (x == #x) * (y == #y) * DLL(#x; #alpha) * DLL(#y; #beta)
+  ensures:  DLL(ret; #alpha @ #beta)
 } */
 DLL *listConcat(DLL *x, DLL *y) {
     if (y == NULL) {
@@ -44,7 +44,7 @@ DLL *listConcat(DLL *x, DLL *y) {
         } else {
             __builtin_annot(
                 "assert [[bind #vx, #px, #nx, #gamma]] "
-                "(x -m> struct dln {#vx; #px; #nx}) * DLL(#nx, #gamma) * "
+                "(x -m> struct dln {#vx; #px; #nx}) * DLL(#nx; #gamma) * "
                 "(#alpha == #h :: #gamma)");
             __builtin_annot("unfold DLL(#nx, #gamma)");
             if (x->next == NULL) {
@@ -62,8 +62,8 @@ DLL *listConcat(DLL *x, DLL *y) {
 }
 
 /*@ spec listPrepend(x, v) {
-  requires: (x == #x) * (v == #v) * DLL(#x, #alpha) * (#v == int(#z))
-  ensures:  DLL(ret, #v :: #alpha)
+  requires: (x == #x) * (v == #v) * DLL(#x; #alpha) * (#v == int(#z))
+  ensures:  DLL(ret; #v :: #alpha)
 } */
 DLL *listPrepend(DLL *x, int v) {
     DLL *node_v = makeNode(v);
@@ -78,14 +78,14 @@ DLL *listPrepend(DLL *x, int v) {
 }
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * (v == #v) * DLL(#x, #alpha) * (#v == int(#z))
-  ensures:  DLL(ret, #alpha @ [ #v ])
+  requires: (x == #x) * (v == #v) * DLL(#x; #alpha) * (#v == int(#z))
+  ensures:  DLL(ret; #alpha @ [ #v ])
 } */
 DLL *listAppend(DLL *x, int v) { return listConcat(x, makeNode(v)); }
 
 /*@ spec listCopy(x) {
-  requires: (x == #x) * DLL(#x, #alpha)
-  ensures:  DLL(#x, #alpha) * DLL(ret, #alpha)
+  requires: (x == #x) * DLL(#x; #alpha)
+  ensures:  DLL(#x; #alpha) * DLL(ret; #alpha)
 } */
 DLL *listCopy(DLL *x) {
     if (x == NULL) {

--- a/Gillian-C/examples/verification/priQ.c
+++ b/Gillian-C/examples/verification/priQ.c
@@ -11,11 +11,11 @@ typedef struct pqn {
     struct pqn *next;
 } PQN;
 
-/*@ pred Node(+x, pri, val, next) {
+/*@ pred Node(x; pri, val, next) {
   x -m> struct pqn { int(pri); int(val); next } * (0 <# pri)
 } */
 
-/*@ pred PriQ(+x, max_pri, max_val, length){
+/*@ pred PriQ(x; max_pri, max_val, length){
   (x == NULL) * (max_pri == 0) * (length == 0) * (max_val == NULL);
 
   Node(x, max_pri, max_val, #next) * (0 <# max_pri) * (not (#next == NULL)) *

--- a/Gillian-C/examples/verification/priQ.c
+++ b/Gillian-C/examples/verification/priQ.c
@@ -18,16 +18,16 @@ typedef struct pqn {
 /*@ pred PriQ(x; max_pri, max_val, length){
   (x == NULL) * (max_pri == 0) * (length == 0) * (max_val == NULL);
 
-  Node(x, max_pri, max_val, #next) * (0 <# max_pri) * (not (#next == NULL)) *
-  PriQ(#next, #next_pri, #next_val, #len_next) * (#next_pri <=# max_pri) *
+  Node(x; max_pri, max_val, #next) * (0 <# max_pri) * (not (#next == NULL)) *
+  PriQ(#next; #next_pri, #next_val, #len_next) * (#next_pri <=# max_pri) *
   (length == #len_next + 1);
 
-  Node(x, max_pri, max_val, NULL) * (0 <# max_pri) * (length == 1)
+  Node(x; max_pri, max_val, NULL) * (0 <# max_pri) * (length == 1)
 } */
 
 /*@ spec makeNode(pri, val) {
   requires: (pri == int(#pri)) * (val == int(#val)) * (0 <# #pri)
-  ensures:  Node(ret, #pri, #val, NULL)
+  ensures:  Node(ret; #pri, #val, NULL)
 } */
 PQN *makeNode(int pri, int val) {
     PQN *r = malloc(sizeof(PQN));
@@ -39,27 +39,27 @@ PQN *makeNode(int pri, int val) {
 
 /*@ spec insert(queue, node) {
   requires: (#node == node) * (#queue == queue) *
-            PriQ(#queue, #qpri, #qval, #qlen) *
-            Node(#node, #npri, #nval, NULL) *
+            PriQ(#queue; #qpri, #qval, #qlen) *
+            Node(#node; #npri, #nval, NULL) *
             (#qpri <# #npri)
-  ensures:  PriQ(ret, #npri, #nval, #qlen + 1)
+  ensures:  PriQ(ret; #npri, #nval, #qlen + 1)
 
   OR
 
   requires: (#node == node) * (#queue == queue) *
-            PriQ(#queue, #qpri, #qval, #qlen) *
-            Node(#node, #npri, #nval, NULL) *
+            PriQ(#queue; #qpri, #qval, #qlen) *
+            Node(#node; #npri, #nval, NULL) *
             (#npri <=# #qpri)
-  ensures:  PriQ(ret, #qpri, #qval, #qlen + 1)
+  ensures:  PriQ(ret; #qpri, #qval, #qlen + 1)
 
   OR
 
   requires: (#node == node) * (#queue == queue) *
-            PriQ(#queue, #qpri, #qval, #qlen) *
-            Node(#node, #npri, #nval, NULL)
+            PriQ(#queue; #qpri, #qval, #qlen) *
+            Node(#node; #npri, #nval, NULL)
 
-  ensures:  PriQ(ret, #qpri, #qval, #qlen + 1) * (#npri <=# #qpri);
-            PriQ(ret, #npri, #nval, #qlen + 1) * (#qpri <# #npri)
+  ensures:  PriQ(ret; #qpri, #qval, #qlen + 1) * (#npri <=# #qpri);
+            PriQ(ret; #npri, #nval, #qlen + 1) * (#qpri <# #npri)
 } */
 
 PQN *insert(PQN *queue, PQN *node) {
@@ -78,23 +78,23 @@ PQN *insert(PQN *queue, PQN *node) {
 
 /*@ spec enqueue(queue, pri, val) {
   requires: (int(#npri) == pri) * (int(#nval) == val) * (#queue == queue) *
-            PriQ(#queue, #qpri, #qval,  #qlen) *
+            PriQ(#queue; #qpri, #qval,  #qlen) *
             (#qpri <# #npri) * (0 <# #npri)
-  ensures:  PriQ(ret, #npri, #nval, #qlen + 1)
+  ensures:  PriQ(ret; #npri, #nval, #qlen + 1)
 
   OR
 
   requires: (int(#npri) == pri) * (int(#nval) == val) * (#queue == queue) *
-            PriQ(#queue, #qpri, #qval, #qlen) *
+            PriQ(#queue; #qpri, #qval, #qlen) *
             (#npri <=# #qpri) * (0 <# #npri)
-  ensures:  PriQ(ret, #qpri, #qval, #qlen + 1)
+  ensures:  PriQ(ret; #qpri, #qval, #qlen + 1)
 } */
 PQN *enqueue(PQN *queue, int pri, int val) {
     return insert(queue, makeNode(pri, val));
 }
 
 /*@ spec peek(queue) {
-  requires: (queue == #queue) * PriQ(#queue, #qpri, #qval, #qlen)
+  requires: (queue == #queue) * PriQ(#queue; #qpri, #qval, #qlen)
   ensures:  ret -m> int(#qval);
             (#qval == NULL) * (ret == NULL)
 } */
@@ -110,9 +110,9 @@ int *peek(PQN *queue) {
 
 /*@ spec dequeue(queue) {
   requires: (queue == #queue) *
-            Node(#queue, #max_pri, #max_val, #next) *
-            PriQ(#next, #next_pri, #next_val, #len_next)
-  ensures:  PriQ(ret, #next_pri, #next_val, #len_next)
+            Node(#queue; #max_pri, #max_val, #next) *
+            PriQ(#next; #next_pri, #next_val, #len_next)
+  ensures:  PriQ(ret; #next_pri, #next_val, #len_next)
 } */
 PQN *dequeue(PQN *queue) {
     PQN *rest = queue->next;

--- a/Gillian-C/examples/verification/sll.c
+++ b/Gillian-C/examples/verification/sll.c
@@ -5,13 +5,13 @@ typedef struct ln {
     struct ln *next;
 } SLL;
 
-/*@ pred list(+p, alpha) {
+/*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
   list(#tail,#beta);
   (p == NULL) * (alpha == nil)
 }
 
-pred listSeg(+p, +q, alpha) {
+pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *

--- a/Gillian-C/examples/verification/sll.c
+++ b/Gillian-C/examples/verification/sll.c
@@ -7,7 +7,7 @@ typedef struct ln {
 
 /*@ pred list(p; alpha) {
   (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-  list(#tail,#beta);
+  list(#tail;#beta);
   (p == NULL) * (alpha == nil)
 }
 
@@ -15,12 +15,12 @@ pred listSeg(p, q; alpha) {
     ( p == q ) * (alpha == nil);
 
     (p -m> struct ln { #head; #tail } * (alpha == #head::#beta)) *
-    listSeg(#tail, q, #beta)
+    listSeg(#tail, q; #beta)
 }
 
 lemma lsegToList(p, alpha) {
-    hypothesis: listSeg(#p, NULL, #alpha)
-    conclusions: list(#p, #alpha)
+    hypothesis: listSeg(#p, NULL; #alpha)
+    conclusions: list(#p; #alpha)
     proof:
       unfold listSeg(#p, NULL, #alpha) [[bind #head: #head,
                                            #tail: #tail,
@@ -32,8 +32,8 @@ lemma lsegToList(p, alpha) {
 }
 
 lemma listSegAppend(p, q, alpha, a, end) {
-    hypothesis: listSeg(#p, #q, #alpha) * (#q -m> struct ln { #a; #end })
-    conclusions: listSeg(#p, #end, #alpha @ [#a])
+    hypothesis: listSeg(#p, #q; #alpha) * (#q -m> struct ln { #a; #end })
+    conclusions: listSeg(#p, #end; #alpha @ [#a])
     proof:
       unfold listSeg(#p, #q, #alpha)[[bind #head: #head,
                                            #tail: #tail,
@@ -46,8 +46,8 @@ lemma listSegAppend(p, q, alpha, a, end) {
 */
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures:  list(ret, #alpha @ [ #v ])
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures:  list(ret; #alpha @ [ #v ])
 } */
 SLL *listAppend(SLL *x, int v) {
     if (x == NULL) {
@@ -57,7 +57,7 @@ SLL *listAppend(SLL *x, int v) {
         return el;
     } else {
         SLL *tailp = listAppend(x->next, v);
-        __builtin_annot("assert [[bind #t]] list(tailp, #t)");
+        __builtin_annot("assert [[bind #t]] list(tailp; #t)");
         __builtin_annot("unfold list(tailp, #t)");
         __builtin_annot("fold list(tailp, #t)");
         x->next = tailp;
@@ -69,8 +69,8 @@ SLL *listAppend(SLL *x, int v) {
   requires: (x -m> struct ln { #head; NULL }) *
             (x == #v) *
             (z == #z) *
-            list(#z, #alpha)
-  ensures: list(ret, #head::#alpha)
+            list(#z; #alpha)
+  ensures: list(ret; #head::#alpha)
 } */
 SLL *listPrepend(SLL *x, SLL *z) {
     __builtin_annot("unfold list(#z, #alpha)");
@@ -79,8 +79,8 @@ SLL *listPrepend(SLL *x, SLL *z) {
 }
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * list(#x, #alpha) * (v == #v) * (#v == int(#z))
-  ensures: list(ret, #v::#alpha)
+  requires: (x == #x) * list(#x; #alpha) * (v == #v) * (#v == int(#z))
+  ensures: list(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {
@@ -92,8 +92,8 @@ SLL* listPrependV(SLL *x, int v) {
 }
 
 /*@ spec listLength(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(#x, #alpha) * (ret == int(#r)) * (#r == len #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(#x; #alpha) * (ret == int(#r)) * (#r == len #alpha)
 } */
 int listLength(SLL *x) {
     if (x == NULL) {
@@ -104,7 +104,7 @@ int listLength(SLL *x) {
 }
 
 /*@ spec listDispose(x) {
-  requires: list(#x, #alpha) * (x == #x)
+  requires: list(#x; #alpha) * (x == #x)
   ensures:  emp
 } */
 void listDispose(SLL *x) {
@@ -118,8 +118,8 @@ void listDispose(SLL *x) {
 }
 
 /*@ spec listCopy(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(ret, #alpha) * list(#x, #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(ret; #alpha) * list(#x; #alpha)
 } */
 SLL *listCopy(SLL *x) {
     SLL *r;
@@ -133,8 +133,8 @@ SLL *listCopy(SLL *x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: list(#x, #alpha) * (x == #x) * list(#y, #beta) * (y == #y)
-  ensures:  list(ret, #alpha @ #beta)
+  requires: list(#x; #alpha) * (x == #x) * list(#y; #beta) * (y == #y)
+  ensures:  list(ret; #alpha @ #beta)
 } */
 SLL *listConcat(SLL *x, SLL *y) {
     SLL *r;
@@ -142,7 +142,7 @@ SLL *listConcat(SLL *x, SLL *y) {
         r = y;
     } else {
         SLL *c = listConcat(x->next, y);
-        __builtin_annot("assert [[bind #gamma]] list(c, #gamma)");
+        __builtin_annot("assert [[bind #gamma]] list(c; #gamma)");
         __builtin_annot("unfold list(c, #gamma)");
         __builtin_annot("fold list(c, #gamma)");
         x->next = c;

--- a/Gillian-C/examples/verification/sort.c
+++ b/Gillian-C/examples/verification/sort.c
@@ -5,7 +5,7 @@ typedef struct ln {
   struct ln* next;
 } SLL;
 
-/*@ pred UList(+x, E) {
+/*@ pred UList(x; E) {
   (x == NULL) * (E == -{}-);
 
   (x -m> struct ln { int(#val); NULL }) * (E == -{ #val }-);
@@ -15,7 +15,7 @@ typedef struct ln {
   (E == -u-(-{ #val }-, #Ep))
 } */
 
-/*@ pred OUList(+x, E) {
+/*@ pred OUList(x; E) {
   (x == NULL) * (E == -{ }-);
 
   (x -m> struct ln { int(#val); NULL }) * (E == -{ #val }-);

--- a/Gillian-C/examples/verification/sort.c
+++ b/Gillian-C/examples/verification/sort.c
@@ -11,7 +11,7 @@ typedef struct ln {
   (x -m> struct ln { int(#val); NULL }) * (E == -{ #val }-);
 
   (x -m> struct ln { int(#val); #next }) * (not (#next == NULL)) *
-  UList(#next, #Ep) *
+  UList(#next; #Ep) *
   (E == -u-(-{ #val }-, #Ep))
 } */
 
@@ -21,14 +21,14 @@ typedef struct ln {
   (x -m> struct ln { int(#val); NULL }) * (E == -{ #val }-);
 
   (x -m> struct ln { int(#val); #next }) * (not (#next == NULL)) *
-  OUList(#next, #Ep) *
+  OUList(#next; #Ep) *
   (E == -u-(-{ #val }-, #Ep)) *
   (forall #z : Int. (#z --e-- #Ep => #val <# #z))
 } */
 
 /*@ spec makeNode(v) {
   requires: (v == int(#v))
-  ensures:  OUList(ret, -{ #v }-)
+  ensures:  OUList(ret; -{ #v }-)
 } */
 SLL* makeNode(int v) {
   SLL* r = malloc(sizeof(SLL));
@@ -39,8 +39,8 @@ SLL* makeNode(int v) {
 
 /*@ spec listPrepend(x, v) {
   requires: (v == int(#v)) * (x == #x) *
-            OUList(#x, #E) * (forall #z : Int. (#z --e-- #E => #v <# #z))
-  ensures: OUList(ret, -u-(-{#v}-, #E))
+            OUList(#x; #E) * (forall #z : Int. (#z --e-- #E => #v <# #z))
+  ensures: OUList(ret; -u-(-{#v}-, #E))
 } */
 SLL* listPrepend(SLL* x, int v) {
   SLL* new_node = makeNode(v);
@@ -51,8 +51,8 @@ SLL* listPrepend(SLL* x, int v) {
 }
 
 /*@ spec insert(l, v) {
-  requires: (l == #l) * (v == int(#v)) * OUList(#l, #E)
-  ensures: OUList(ret, -u-(-{#v}-, #E))
+  requires: (l == #l) * (v == int(#v)) * OUList(#l; #E)
+  ensures: OUList(ret; -u-(-{#v}-, #E))
 } */
 SLL* insert(SLL* l, int v) {
   if (l == NULL) {
@@ -70,8 +70,8 @@ SLL* insert(SLL* l, int v) {
 }
 
 /*@ spec sort(l) {
-  requires: (l == #l) * UList(#l, #E)
-  ensures: OUList(ret, #E)
+  requires: (l == #l) * UList(#l; #E)
+  ensures: OUList(ret; #E)
 } */
 SLL* sort(SLL* l) {
   if (l == NULL) {

--- a/Gillian-C/examples/verification/vector.c
+++ b/Gillian-C/examples/verification/vector.c
@@ -13,7 +13,7 @@ struct vector_s {
 typedef struct vector_s Vector;
 
 /*@
-    pred nounfold vector(+p, cap, alpha) {
+    pred nounfold vector(p; cap, alpha) {
         p -m> struct vector_s { long(0); long(0); NULL } *
         (cap == 0) * (alpha == nil);
     

--- a/Gillian-C/examples/verification/vector.c
+++ b/Gillian-C/examples/verification/vector.c
@@ -29,7 +29,7 @@ typedef struct vector_s Vector;
 
 /*@ spec vector_new_capacity(capacity) {
     requires: (capacity == long(#capacity)) * (0 <=# #capacity)
-    ensures: vector(ret, #capacity, nil)
+    ensures: vector(ret; #capacity, nil)
 }*/
 Vector* vector_new_capacity(size_t capacity) {
     Vector* vec = malloc(sizeof(Vector));
@@ -46,8 +46,8 @@ Vector* vector_new_capacity(size_t capacity) {
 }
 
 /*@ spec vector_len(vec) {
-    requires: (vec == #vec) * vector (#vec, #capacity, #content)
-    ensures: vector(#vec, #capacity, #content) * (#sz == len(#content)) * (ret == long(#sz))
+    requires: (vec == #vec) * vector (#vec; #capacity, #content)
+    ensures: vector(#vec; #capacity, #content) * (#sz == len(#content)) * (ret == long(#sz))
 }*/
 size_t vector_len(Vector *vec) {
     return vec->size;
@@ -55,14 +55,14 @@ size_t vector_len(Vector *vec) {
 
 /*@ spec vector_new() {
     requires: emp
-    ensures: vector(ret, 8, nil)
+    ensures: vector(ret; 8, nil)
 }*/
 Vector *vector_new() { return vector_new_capacity(DEFAULT_CAPACITY); }
 
 /*@ spec vector_realloc_buffer(vec, new_capacity) {
     requires: (vec == #vec) * (new_capacity == long(#nc)) *
-              vector(#vec, #cap, #alpha) * (#cap <=# #nc)
-    ensures: vector(#vec, #nc, #alpha)
+              vector(#vec; #cap, #alpha) * (#cap <=# #nc)
+    ensures: vector(#vec; #nc, #alpha)
 }*/
 void vector_realloc_buffer(Vector *vec, size_t new_capacity) {
     if (new_capacity) {

--- a/Gillian-C/lib/Constr.ml
+++ b/Gillian-C/lib/Constr.ml
@@ -39,26 +39,37 @@ end
 module Others = struct
   open CConstants
 
-  let pred name params = Asrt.Pred (name, params)
+  (* The in/out split below must match the runtime predicate definitions, since
+     the engine trusts the split carried by the assertion. All-ins predicates
+     use [pred]; predicates with out-parameters spell out [ins] and [outs]. *)
+  let pred name ins outs = Asrt.Pred (name, ins, outs)
+  let pred_in name ins = Asrt.Pred (name, ins, [])
 
-  let malloced_abst ~ptr ~total_size =
-    pred Internal_Predicates.malloced [ ptr; total_size ]
+  (* [i__malloced] is, unfortunately, declared with a different in/out split
+     depending on the architecture: [(p; bytes)] in 64-bit, [(p, bytes;)] in
+     32-bit. *)
+  let malloced_pred p bytes =
+    if Compcert.Archi.ptr64 then
+      pred Internal_Predicates.malloced [ p ] [ bytes ]
+    else pred_in Internal_Predicates.malloced [ p; bytes ]
+
+  let malloced_abst ~ptr ~total_size = malloced_pred ptr total_size
 
   let malloced ~ptr ~total_size =
     let loc, ofs = ptr in
     let size = Expr.int_z total_size in
-    pred Internal_Predicates.malloced [ Expr.list [ loc; ofs ]; size ]
+    malloced_pred (Expr.list [ loc; ofs ]) size
 
   let zeros_ptr_size ~ptr ~size =
-    pred Internal_Predicates.zeros_ptr_size [ ptr; size ]
+    pred_in Internal_Predicates.zeros_ptr_size [ ptr; size ]
 
   let undefs_ptr_size ~ptr ~size =
-    pred Internal_Predicates.undefs_ptr_size [ ptr; size ]
+    pred_in Internal_Predicates.undefs_ptr_size [ ptr; size ]
 
   let array_ptr ~ptr ~chunk ~size ~content =
     let chunk_str = Expr.string (Chunk.to_string chunk) in
-    pred Internal_Predicates.array_ptr [ ptr; size; chunk_str; content ]
+    pred Internal_Predicates.array_ptr [ ptr; size; chunk_str ] [ content ]
 
   let ptr_add ~ptr ~to_add ~res =
-    pred Internal_Predicates.ptr_add [ ptr; to_add; res ]
+    pred Internal_Predicates.ptr_add [ ptr; to_add ] [ res ]
 end

--- a/Gillian-C/lib/annot_parser.mly
+++ b/Gillian-C/lib/annot_parser.mly
@@ -364,8 +364,8 @@ assertion:
     { CAssert.Undefs (ptr, size)}
   | MALLOCED; LBRACE; ptr = expression; COMMA; ofs = expression; RBRACE
     { CAssert.Malloced(ptr, ofs) }
-  | pname = IDENTIFIER; LBRACE; el = separated_list(COMMA, expression); RBRACE
-    { CAssert.Pred (pname, el) }
+  | pname = IDENTIFIER; LBRACE; ins = separated_list(COMMA, expression); SCOLON; outs = separated_list(COMMA, expression); RBRACE
+    { CAssert.Pred (pname, ins, outs) }
 
 formula:
   | LBRACE; formula; RBRACE { $2 }

--- a/Gillian-C/lib/annot_parser.mly
+++ b/Gillian-C/lib/annot_parser.mly
@@ -1,19 +1,5 @@
 %{
   open CLogic
-
-  let process_pred_params params_ins =
-      let (params, ins) = List.split params_ins in
-      (* ins looks like [true, false, true] *)
-      let ins = List.mapi (fun i is_in -> if is_in then Some i else None) ins in
-      (* ins looks like [Some 0, None, Some 2] *)
-      let ins = List.filter Option.is_some ins in
-      (* ins looks like [Some 0, Some 2] *)
-      let ins = List.map Option.get ins in
-      (* ins looks like [0, 2] *)
-      (* if ins is empty then everything is an in *)
-  		let ins = if (List.length ins) > 0 then ins else (List.mapi (fun i _ -> i) params) in
-      (params, ins)
-
 %}
 
 (* punctuation *)
@@ -291,30 +277,36 @@ spec_annot:
 
 abstract_predicate:
   | ABSTRACT; pure=option(PURE); PREDICATE; pname = IDENTIFIER; LBRACE;
-    params_ins = separated_list(COMMA, pred_params_ins);
+    ins = separated_list(COMMA, pred_param);
+    SCOLON;
+    outs = separated_list(COMMA, pred_param);
     RBRACE;
     {
-      let (params, pred_ins) = process_pred_params params_ins in
+      let params = ins @ outs in
+      let ins_number = List.length ins in
       CAbsPred. {
         pure = Option.is_some(pure);
         name = pname;
         params;
-        ins = pred_ins;
+        ins_number;
       }
     }
 
 predicate:
   | pure=option(PURE); PREDICATE; no_unfold=option(NOUNFOLD); pname = IDENTIFIER; LBRACE;
-    params_ins = separated_list(COMMA, pred_params_ins);
+    ins = separated_list(COMMA, pred_param);
+    SCOLON;
+    outs = separated_list(COMMA, pred_param);
     RBRACE; LCBRACE;
     defs = separated_nonempty_list(SCOLON, pred_definition);
     RCBRACE;
     {
-      let (params, pred_ins) = process_pred_params params_ins in
+      let params = ins @ outs in
+      let ins_number = List.length ins in
       CPred.{
         name = pname;
-        params = params;
-        ins = pred_ins;
+        params;
+        ins_number;
         definitions = defs;
         no_unfold = Option.is_some(no_unfold);
         pure = Option.is_some(pure);
@@ -334,10 +326,9 @@ existentials:
   | COLON; lvs = separated_nonempty_list(COMMA, lvar_with_gil_type); { lvs }
 
 
-pred_params_ins:
-  | inp = option(PLUS); x = IDENTIFIER; typ = option(with_gil_type)
-    { let isin = Option.is_some inp in
-      ((x, typ), isin) }
+pred_param:
+  | x = IDENTIFIER; typ = option(with_gil_type)
+    { (x, typ) }
 
 typ:
   | INT16T { Chunk.Mint16unsigned }

--- a/Gillian-C/lib/annot_parser.mly
+++ b/Gillian-C/lib/annot_parser.mly
@@ -278,8 +278,7 @@ spec_annot:
 abstract_predicate:
   | ABSTRACT; pure=option(PURE); PREDICATE; pname = IDENTIFIER; LBRACE;
     ins = separated_list(COMMA, pred_param);
-    SCOLON;
-    outs = separated_list(COMMA, pred_param);
+    outs = outs(pred_param);
     RBRACE;
     {
       let params = ins @ outs in
@@ -295,8 +294,7 @@ abstract_predicate:
 predicate:
   | pure=option(PURE); PREDICATE; no_unfold=option(NOUNFOLD); pname = IDENTIFIER; LBRACE;
     ins = separated_list(COMMA, pred_param);
-    SCOLON;
-    outs = separated_list(COMMA, pred_param);
+    outs = outs(pred_param);
     RBRACE; LCBRACE;
     defs = separated_nonempty_list(SCOLON, pred_definition);
     RCBRACE;
@@ -364,7 +362,10 @@ assertion:
     { CAssert.Undefs (ptr, size)}
   | MALLOCED; LBRACE; ptr = expression; COMMA; ofs = expression; RBRACE
     { CAssert.Malloced(ptr, ofs) }
-  | pname = IDENTIFIER; LBRACE; ins = separated_list(COMMA, expression); SCOLON; outs = separated_list(COMMA, expression); RBRACE
+  | pname = IDENTIFIER; LBRACE;
+    ins = separated_list(COMMA, expression);
+    outs = outs(expression);
+    RBRACE
     { CAssert.Pred (pname, ins, outs) }
 
 formula:
@@ -587,3 +588,12 @@ any_C_token:
   | AND
   | OR
   { () }
+
+%inline outs(X):
+  xs = option_preceded_separated_list(SCOLON, COMMA, X)
+  { xs }
+
+%inline option_preceded_separated_list(PREC, SEP, X):
+  | PREC; xs = separated_list(SEP, X) { xs }
+  | { [] }
+

--- a/Gillian-C/lib/cLogic.ml
+++ b/Gillian-C/lib/cLogic.ml
@@ -204,7 +204,7 @@ module CAssert = struct
         constr : CConstructor.t;
         typ : points_to_type;
       }
-    | Pred of string * CExpr.t list
+    | Pred of string * CExpr.t list * CExpr.t list
     | Emp
 
   let rec pp fmt a =
@@ -229,7 +229,9 @@ module CAssert = struct
         in
         Format.fprintf fmt "(%a -%s> %a)" CExpr.pp ptr (string_of_typ typ)
           CConstructor.pp constr
-    | Pred (s, el) -> Format.fprintf fmt "%s(%a)" s (pp_list CExpr.pp) el
+    | Pred (s, ins, outs) ->
+        Format.fprintf fmt "%s(%a; %a)" s (pp_list CExpr.pp) ins
+          (pp_list CExpr.pp) outs
     | Emp -> Format.fprintf fmt "emp"
 end
 

--- a/Gillian-C/lib/cLogic.ml
+++ b/Gillian-C/lib/cLogic.ml
@@ -357,9 +357,9 @@ module CPred = struct
     let outs = List.filteri (fun i _ -> i >= ins_number) params in
     let pp_outs f = function
       | [] -> ()
-      | outs -> Fmt.pf f " %a" Fmt.(list ~sep:(any ", ") pp_param) outs
+      | outs -> Fmt.pf f "; %a" Fmt.(list ~sep:(any ", ") pp_param) outs
     in
-    Fmt.pf fmt "%a;%a" Fmt.(list ~sep:(any ", ") pp_param) ins pp_outs outs
+    Fmt.pf fmt "%a%a" Fmt.(list ~sep:(any ", ") pp_param) ins pp_outs outs
 
   let pp_def fmt (da, a) =
     Format.fprintf fmt "%a%a"

--- a/Gillian-C/lib/cLogic.ml
+++ b/Gillian-C/lib/cLogic.ml
@@ -307,23 +307,23 @@ module CAbsPred = struct
     pure : bool;
     name : string;
     params : (string * GilType.t option) list;
-    ins : int list;
+    ins_number : int;
   }
 
-  let pp_params fmt (params, ins) =
+  (* Prints params as [in1, ..., ink; out1, ..., outm] *)
+  let pp_params fmt (params, ins_number) =
     let pp_typ_opt f = function
       | None -> ()
       | Some t -> Format.fprintf f ": %s" (GilType.str t)
     in
-    let plus f k = if List.mem k ins then Format.fprintf f "+" else () in
-    let rec aux k = function
+    let pp_param f (a, typ) = Fmt.pf f "%s%a" a pp_typ_opt typ in
+    let ins = List.filteri (fun i _ -> i < ins_number) params in
+    let outs = List.filteri (fun i _ -> i >= ins_number) params in
+    let pp_outs f = function
       | [] -> ()
-      | [ (a, typ) ] -> Format.fprintf fmt "%a%s%a" plus k a pp_typ_opt typ
-      | (a, typ) :: r ->
-          Format.fprintf fmt "%a%s%a, " plus k a pp_typ_opt typ;
-          aux (k + 1) r
+      | outs -> Fmt.pf f " %a" Fmt.(list ~sep:(any ", ") pp_param) outs
     in
-    aux 0 params
+    Fmt.pf fmt "%a;%a" Fmt.(list ~sep:(any ", ") pp_param) ins pp_outs outs
 
   let pp fmt pred =
     let pp_pure f = function
@@ -331,7 +331,7 @@ module CAbsPred = struct
       | false -> ()
     in
     Fmt.pf fmt "abstract %apred %s(%a)" pp_pure pred.pure pred.name pp_params
-      (pred.params, pred.ins)
+      (pred.params, pred.ins_number)
 end
 
 module CPred = struct
@@ -340,24 +340,24 @@ module CPred = struct
     name : string;
     params : (string * GilType.t option) list;
     definitions : (assert_annot option * CAssert.t) list;
-    ins : int list;
+    ins_number : int;
     no_unfold : bool;
   }
 
-  let pp_params fmt (params, ins) =
+  (* Prints params as [in1, ..., ink; out1, ..., outm] *)
+  let pp_params fmt (params, ins_number) =
     let pp_typ_opt f = function
       | None -> ()
       | Some t -> Format.fprintf f ": %s" (GilType.str t)
     in
-    let plus f k = if List.mem k ins then Format.fprintf f "+" else () in
-    let rec aux k = function
+    let pp_param f (a, typ) = Fmt.pf f "%s%a" a pp_typ_opt typ in
+    let ins = List.filteri (fun i _ -> i < ins_number) params in
+    let outs = List.filteri (fun i _ -> i >= ins_number) params in
+    let pp_outs f = function
       | [] -> ()
-      | [ (a, typ) ] -> Format.fprintf fmt "%a%s%a" plus k a pp_typ_opt typ
-      | (a, typ) :: r ->
-          Format.fprintf fmt "%a%s%a, " plus k a pp_typ_opt typ;
-          aux (k + 1) r
+      | outs -> Fmt.pf f " %a" Fmt.(list ~sep:(any ", ") pp_param) outs
     in
-    aux 0 params
+    Fmt.pf fmt "%a;%a" Fmt.(list ~sep:(any ", ") pp_param) ins pp_outs outs
 
   let pp_def fmt (da, a) =
     Format.fprintf fmt "%a%a"
@@ -372,7 +372,8 @@ module CPred = struct
     Format.fprintf fmt "@[<v 2>%apred %s %s(%a) {@\n%a@]@\n}" pp_pure pred.pure
       pred.name
       (if pred.no_unfold then "nounfold" else "")
-      pp_params (pred.params, pred.ins)
+      pp_params
+      (pred.params, pred.ins_number)
       (pp_list ~sep:(Fmt.any ";@\n") pp_def)
       pred.definitions
 end

--- a/Gillian-C/lib/gil_logic_gen.ml
+++ b/Gillian-C/lib/gil_logic_gen.ml
@@ -199,7 +199,8 @@ let assert_of_hole (low, high) =
 
 let gen_pred_of_struct cenv ann struct_name =
   let pred_name = pred_name_of_struct struct_name in
-  let pred_ins = [ 0; 1 ] in
+  (* The location and offset (the first two parameters) are the ins *)
+  let ins_number = 2 in
   let id = id_of_string struct_name in
   let comp_opt = Maps.PTree.get id cenv in
   let comp =
@@ -265,7 +266,7 @@ let gen_pred_of_struct cenv ann struct_name =
         pred_source_path = None;
         pred_loc = None;
         pred_internal = true;
-        pred_ins;
+        ins_number;
         pred_num_params;
         pred_params;
         pred_facts = [ (* FIXME: there are probably some facts to get *) ];
@@ -647,12 +648,8 @@ let trans_asrt_annot da =
 
 let trans_abs_pred ~filepath cl_pred =
   let CAbsPred.
-        {
-          name = pred_name;
-          params = pred_params;
-          ins = pred_ins;
-          pure = pred_pure;
-        } =
+        { name = pred_name; params = pred_params; ins_number; pure = pred_pure }
+      =
     cl_pred
   in
   let pred_num_params = List.length pred_params in
@@ -664,7 +661,7 @@ let trans_abs_pred ~filepath cl_pred =
       pred_internal = false;
       pred_num_params;
       pred_params;
-      pred_ins;
+      ins_number;
       pred_definitions = [];
       pred_facts = [];
       pred_guard = None;
@@ -680,7 +677,7 @@ let trans_pred ~ann ~filepath cl_pred =
           name = pred_name;
           params = pred_params;
           definitions;
-          ins = pred_ins;
+          ins_number;
           no_unfold;
           pure = pred_pure;
         } =
@@ -705,7 +702,7 @@ let trans_pred ~ann ~filepath cl_pred =
       pred_internal = false;
       pred_num_params;
       pred_params;
-      pred_ins;
+      ins_number;
       pred_definitions;
       (* FIXME: ADD SUPPORT FOR FACTS *)
       pred_facts = [];

--- a/Gillian-C/lib/gil_logic_gen.ml
+++ b/Gillian-C/lib/gil_logic_gen.ml
@@ -143,8 +143,8 @@ let assert_of_member cenv members id typ =
       in
       let list_is_components = pvmember#==(Expr.list args_without_ins) in
       let ofs = Expr.Infix.(pvofs + fo) in
-      let args = pvloc :: ofs :: args_without_ins in
-      let pred_call = Asrt.Pred (pred_name, args) in
+      (* Struct predicates have the location and offset as their two ins. *)
+      let pred_call = Asrt.Pred (pred_name, [ pvloc; ofs ], args_without_ins) in
       [ list_is_components; pred_call ]
   | Tarray (ty, n, _) ->
       let n = ValueTranslation.int_of_z n in
@@ -166,12 +166,13 @@ let assert_of_member cenv members id typ =
         let open Internal_Predicates in
         let open VTypes in
         match typ with
-        | Tint _ -> (mk int_type lvval, Asrt.Pred (int_get, [ pvmember; lvval ]))
+        | Tint _ ->
+            (mk int_type lvval, Asrt.Pred (int_get, [ pvmember ], [ lvval ]))
         | Tlong _ ->
-            (mk long_type lvval, Asrt.Pred (long_get, [ pvmember; lvval ]))
+            (mk long_type lvval, Asrt.Pred (long_get, [ pvmember ], [ lvval ]))
         | Tfloat _ ->
-            (mk float_type lvval, Asrt.Pred (float_get, [ pvmember; lvval ]))
-        | Tpointer _ -> (pvmember, Asrt.Pred (is_ptr_opt, [ pvmember ]))
+            (mk float_type lvval, Asrt.Pred (float_get, [ pvmember ], [ lvval ]))
+        | Tpointer _ -> (pvmember, Asrt.Pred (is_ptr_opt, [ pvmember ], []))
         | _ ->
             failwith
               (Printf.sprintf "unhandled struct field type for now : %s"
@@ -448,7 +449,9 @@ let trans_constr ?fname:_ ~(typ : CAssert.points_to_type) ann s c =
   let tloc = types ObjectType in
   (* let mk_num n = Expr.Lit (Num (float_of_int n)) in *)
   (* let zero = mk_num 0 in *)
-  let ptr_call p l o = Asrt.Pred (Internal_Predicates.ptr_get, [ p; l; o ]) in
+  let ptr_call p l o =
+    Asrt.Pred (Internal_Predicates.ptr_get, [ p ], [ l; o ])
+  in
   let sz = function
     | CSVal.Sint _ -> 4
     | Slong _ -> 8
@@ -545,7 +548,7 @@ let trans_constr ?fname:_ ~(typ : CAssert.points_to_type) ann s c =
         split3_expr_comp (List.map trans_expr el)
       in
       let pr =
-        Asrt.Pred (struct_pred, [ locv; ofsv ] @ params_fields) :: more_asrt
+        Asrt.Pred (struct_pred, [ locv; ofsv ], params_fields) :: more_asrt
       in
       pr @ to_assert @ [ malloc_chunk siz ]
 
@@ -584,9 +587,10 @@ let rec trans_asrt ~fname ~ann asrt =
     | Pure f ->
         let ma, _, fp = trans_form f in
         Pure fp :: ma
-    | Pred (p, cel) ->
-        let ap, _, gel = split3_expr_comp (List.map trans_expr cel) in
-        Pred (p, gel) :: ap
+    | Pred (p, c_ins, c_outs) ->
+        let ap_in, _, g_ins = split3_expr_comp (List.map trans_expr c_ins) in
+        let ap_out, _, g_outs = split3_expr_comp (List.map trans_expr c_outs) in
+        Pred (p, g_ins, g_outs) :: (ap_in @ ap_out)
     | Emp -> [ Asrt.Emp ]
     | PointsTo { ptr = s; constr = c; typ } -> trans_constr ~fname ~typ ann s c
   in
@@ -872,17 +876,17 @@ let bounds signedness bit_size =
   (Expr.int_z min, Expr.int_z max)
 
 let predicate_from_triple (e, csmt, ct) =
-  let pred pname = Asrt.Pred (pname, [ e ]) in
+  let pred pname = Asrt.Pred (pname, [ e ], []) in
   let open Internal_Predicates in
   match (csmt, ct) with
   | _, Ctypes.Tpointer (Tfunction _, _) -> pred is_ptr_to_0
   | _, Ctypes.Tpointer _ -> pred is_ptr_opt
   | AST.Tint, Tint (size, signedness, _) ->
       let min, max = bounds signedness (bit_size size) in
-      Asrt.Pred (Internal_Predicates.is_bounded_int, [ e; min; max ])
+      Asrt.Pred (Internal_Predicates.is_bounded_int, [ e; min; max ], [])
   | AST.Tlong, Tlong (signedness, _) ->
       let min, max = bounds signedness 64 in
-      Asrt.Pred (Internal_Predicates.is_bounded_long, [ e; min; max ])
+      Asrt.Pred (Internal_Predicates.is_bounded_long, [ e; min; max ], [])
   | AST.Tsingle, _ -> pred is_single
   | AST.Tfloat, _ -> pred is_float
   | _ ->

--- a/Gillian-C/runtime/logic_archi32.gil
+++ b/Gillian-C/runtime/logic_archi32.gil
@@ -1,34 +1,34 @@
 #internal
 
-pred i__is_ptr_to_0_opt (e: List;):
+pred i__is_ptr_to_0_opt (e: List):
   e == {{ "int", 0i }},
-  i__is_ptr_to_0(e;);
+  i__is_ptr_to_0(e);
   
-pred i__is_ptr_opt (e: List;):
+pred i__is_ptr_opt (e: List):
   e == {{ "int", 0i }},
-  i__is_ptr(e;);
+  i__is_ptr(e);
   
-pred i__is_ptr_to_int_opt (e: List;):
+pred i__is_ptr_to_int_opt (e: List):
   e == {{ "int", 0i }},
   i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0, "int32"; {{ "int", #i }}, "Freeable");
   
-pred i__is_ptr_to_float_opt (e: List;):
+pred i__is_ptr_to_float_opt (e: List):
   e == {{ "int", 0i }},
   i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0, "float32"; {{ "float", #i }}, "Freeable");
   
-pred i__is_ptr_to_long_opt (e: List;):
+pred i__is_ptr_to_long_opt (e: List):
   e == {{ "int", 0i }},
   i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0, "int64"; {{ "long", #i }}, "Freeable");
   
-pred i__is_ptr_to_single_opt (e: List;):
+pred i__is_ptr_to_single_opt (e: List):
   e == {{ "int", 0i }},
   i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0, "float64"; {{ "single", #i }}, "Freeable");
   
-  pred i__malloced(p: List, bytes: Int;):
-  i__is_ptr_to_0(p;) *
+  pred i__malloced(p: List, bytes: Int):
+  i__is_ptr_to_0(p) *
   <mem_single>(#l, -4i, "int32"; {{ "int", bytes }}, "Freeable") *
   <mem_bounds>(#l; {{-4i, bytes}});

--- a/Gillian-C/runtime/logic_archi32.gil
+++ b/Gillian-C/runtime/logic_archi32.gil
@@ -2,33 +2,33 @@
 
 pred i__is_ptr_to_0_opt (e: List;):
   e == {{ "int", 0i }},
-  i__is_ptr_to_0(e);
+  i__is_ptr_to_0(e;);
   
 pred i__is_ptr_opt (e: List;):
   e == {{ "int", 0i }},
-  i__is_ptr(e);
+  i__is_ptr(e;);
   
 pred i__is_ptr_to_int_opt (e: List;):
   e == {{ "int", 0i }},
-  i__ptr_to_0(e, #l) *
+  i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0, "int32"; {{ "int", #i }}, "Freeable");
   
 pred i__is_ptr_to_float_opt (e: List;):
   e == {{ "int", 0i }},
-  i__ptr_to_0(e, #l) *
+  i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0, "float32"; {{ "float", #i }}, "Freeable");
   
 pred i__is_ptr_to_long_opt (e: List;):
   e == {{ "int", 0i }},
-  i__ptr_to_0(e, #l) *
+  i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0, "int64"; {{ "long", #i }}, "Freeable");
   
 pred i__is_ptr_to_single_opt (e: List;):
   e == {{ "int", 0i }},
-  i__ptr_to_0(e, #l) *
+  i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0, "float64"; {{ "single", #i }}, "Freeable");
   
   pred i__malloced(p: List, bytes: Int;):
-  i__is_ptr_to_0(p) *
+  i__is_ptr_to_0(p;) *
   <mem_single>(#l, -4i, "int32"; {{ "int", bytes }}, "Freeable") *
   <mem_bounds>(#l; {{-4i, bytes}});

--- a/Gillian-C/runtime/logic_archi32.gil
+++ b/Gillian-C/runtime/logic_archi32.gil
@@ -1,34 +1,34 @@
 #internal
 
-pred i__is_ptr_to_0_opt (e: List):
+pred i__is_ptr_to_0_opt (e: List;):
   e == {{ "int", 0i }},
   i__is_ptr_to_0(e);
   
-pred i__is_ptr_opt (e: List):
+pred i__is_ptr_opt (e: List;):
   e == {{ "int", 0i }},
   i__is_ptr(e);
   
-pred i__is_ptr_to_int_opt (+e: List):
+pred i__is_ptr_to_int_opt (e: List;):
   e == {{ "int", 0i }},
   i__ptr_to_0(e, #l) *
   <mem_single>(#l, 0, "int32"; {{ "int", #i }}, "Freeable");
   
-pred i__is_ptr_to_float_opt (+e: List):
+pred i__is_ptr_to_float_opt (e: List;):
   e == {{ "int", 0i }},
   i__ptr_to_0(e, #l) *
   <mem_single>(#l, 0, "float32"; {{ "float", #i }}, "Freeable");
   
-pred i__is_ptr_to_long_opt (+e: List):
+pred i__is_ptr_to_long_opt (e: List;):
   e == {{ "int", 0i }},
   i__ptr_to_0(e, #l) *
   <mem_single>(#l, 0, "int64"; {{ "long", #i }}, "Freeable");
   
-pred i__is_ptr_to_single_opt (+e: List):
+pred i__is_ptr_to_single_opt (e: List;):
   e == {{ "int", 0i }},
   i__ptr_to_0(e, #l) *
   <mem_single>(#l, 0, "float64"; {{ "single", #i }}, "Freeable");
   
-  pred i__malloced(+p: List, +bytes: Int):
+  pred i__malloced(p: List, bytes: Int;):
   i__is_ptr_to_0(p) *
   <mem_single>(#l, -4i, "int32"; {{ "int", bytes }}, "Freeable") *
   <mem_bounds>(#l; {{-4i, bytes}});

--- a/Gillian-C/runtime/logic_archi64.gil
+++ b/Gillian-C/runtime/logic_archi64.gil
@@ -1,34 +1,34 @@
 #internal
 
-pred i__is_ptr_to_0_opt (e: List):
+pred i__is_ptr_to_0_opt (e: List;):
   i__is_ptr_to_0(e),
   (e == {{ "long", 0i }});
 
-pred i__is_ptr_opt (e: List):
+pred i__is_ptr_opt (e: List;):
   i__is_ptr(e),
   (e == {{ "long", 0i }});
 
-pred i__is_ptr_to_int_opt (+e: List):
+pred i__is_ptr_to_int_opt (e: List;):
   i__ptr_to_0(e, #l) *
   <mem_single>(#l, 0i, "int32"; {{ "int", #i }}, "Freeable"),
   (e == {{ "long", 0i }});
 
-pred i__is_ptr_to_float_opt (+e: List):
+pred i__is_ptr_to_float_opt (e: List;):
   i__ptr_to_0(e, #l) *
   <mem_single>(#l, 0i, "float32"; {{ "float", #i }}, "Freeable"),
   (e == {{ "long", 0i }});
 
-pred i__is_ptr_to_long_opt (+e: List):
+pred i__is_ptr_to_long_opt (e: List;):
   i__ptr_to_0(e, #l) *
   <mem_single>(#l, 0i, "int64"; {{ "long", #i }}, "Freeable"),
   (e == {{ "long", 0i }});
 
-pred i__is_ptr_to_single_opt (+e: List):
+pred i__is_ptr_to_single_opt (e: List;):
   i__ptr_to_0(e, #l) *
   <mem_single>(#l, 0i, "float32"; {{ "single", #i }}, "Freeable"),
   (e == {{ "long", 0i }});
 
-pred i__malloced(+p: List, bytes: Int):
+pred i__malloced(p: List; bytes: Int):
   i__ptr(p, #l, 0i) *
   <mem_single>(#l, -8i, "int64"; {{ "long", bytes }}, "Freeable") *
   <mem_bounds>(#l; {{ -8i, bytes }});

--- a/Gillian-C/runtime/logic_archi64.gil
+++ b/Gillian-C/runtime/logic_archi64.gil
@@ -1,34 +1,34 @@
 #internal
 
 pred i__is_ptr_to_0_opt (e: List;):
-  i__is_ptr_to_0(e),
+  i__is_ptr_to_0(e;),
   (e == {{ "long", 0i }});
 
 pred i__is_ptr_opt (e: List;):
-  i__is_ptr(e),
+  i__is_ptr(e;),
   (e == {{ "long", 0i }});
 
 pred i__is_ptr_to_int_opt (e: List;):
-  i__ptr_to_0(e, #l) *
+  i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0i, "int32"; {{ "int", #i }}, "Freeable"),
   (e == {{ "long", 0i }});
 
 pred i__is_ptr_to_float_opt (e: List;):
-  i__ptr_to_0(e, #l) *
+  i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0i, "float32"; {{ "float", #i }}, "Freeable"),
   (e == {{ "long", 0i }});
 
 pred i__is_ptr_to_long_opt (e: List;):
-  i__ptr_to_0(e, #l) *
+  i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0i, "int64"; {{ "long", #i }}, "Freeable"),
   (e == {{ "long", 0i }});
 
 pred i__is_ptr_to_single_opt (e: List;):
-  i__ptr_to_0(e, #l) *
+  i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0i, "float32"; {{ "single", #i }}, "Freeable"),
   (e == {{ "long", 0i }});
 
 pred i__malloced(p: List; bytes: Int):
-  i__ptr(p, #l, 0i) *
+  i__ptr(p; #l, 0i) *
   <mem_single>(#l, -8i, "int64"; {{ "long", bytes }}, "Freeable") *
   <mem_bounds>(#l; {{ -8i, bytes }});

--- a/Gillian-C/runtime/logic_archi64.gil
+++ b/Gillian-C/runtime/logic_archi64.gil
@@ -1,29 +1,29 @@
 #internal
 
-pred i__is_ptr_to_0_opt (e: List;):
-  i__is_ptr_to_0(e;),
+pred i__is_ptr_to_0_opt (e: List):
+  i__is_ptr_to_0(e),
   (e == {{ "long", 0i }});
 
-pred i__is_ptr_opt (e: List;):
-  i__is_ptr(e;),
+pred i__is_ptr_opt (e: List):
+  i__is_ptr(e),
   (e == {{ "long", 0i }});
 
-pred i__is_ptr_to_int_opt (e: List;):
+pred i__is_ptr_to_int_opt (e: List):
   i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0i, "int32"; {{ "int", #i }}, "Freeable"),
   (e == {{ "long", 0i }});
 
-pred i__is_ptr_to_float_opt (e: List;):
+pred i__is_ptr_to_float_opt (e: List):
   i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0i, "float32"; {{ "float", #i }}, "Freeable"),
   (e == {{ "long", 0i }});
 
-pred i__is_ptr_to_long_opt (e: List;):
+pred i__is_ptr_to_long_opt (e: List):
   i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0i, "int64"; {{ "long", #i }}, "Freeable"),
   (e == {{ "long", 0i }});
 
-pred i__is_ptr_to_single_opt (e: List;):
+pred i__is_ptr_to_single_opt (e: List):
   i__ptr_to_0(e; #l) *
   <mem_single>(#l, 0i, "float32"; {{ "single", #i }}, "Freeable"),
   (e == {{ "long", 0i }});

--- a/Gillian-C/runtime/logic_common.gil
+++ b/Gillian-C/runtime/logic_common.gil
@@ -51,19 +51,19 @@ pred i__ptr (e: List; l: Obj, o: Int):
 (* arrays *)
 
 pred i__zeros_ptr_size(ptr: List, size: Int;):
-  i__ptr(ptr, #l, #o) *
+  i__ptr(ptr; #l, #o) *
   <mem_zeros>(#l, #o, #o i+ size; "Freeable");
 
 pred i__undefs_ptr_size(ptr: List, size: Int;):
-  i__ptr(ptr, #l, #o) *
+  i__ptr(ptr; #l, #o) *
   <mem_hole>(#l, #o, #o i+ size; "Freeable");
 
 pred i__array_ptr(ptr: List, size: Int, chk: Str; content: List):
-  i__ptr(ptr, #l, #o) * (size == l-len content) * (0i i<=# size) *
+  i__ptr(ptr; #l, #o) * (size == l-len content) * (0i i<=# size) *
   <mem_array>(#l, #o, size, chk; content, "Freeable");
 
 (* Pointer arithmetic *)
 
 pred i__ptr_add(ptr: List, to_add:Int; res: List):
-  i__ptr(ptr, #l, #o) *
+  i__ptr(ptr; #l, #o) *
   (res == {{ #l, #o i+ to_add }});

--- a/Gillian-C/runtime/logic_common.gil
+++ b/Gillian-C/runtime/logic_common.gil
@@ -2,68 +2,68 @@
 
 (* Type testers *)
 
-pred i__is_int (e: List):
+pred i__is_int (e: List;):
   (e == {{ "int", #k }}) * types(#k : Int);
 
-pred i__is_long (e: List):
+pred i__is_long (e: List;):
   (e == {{ "long", #k }}) * types(#k : Int);
 
-pred i__is_single (e: List):
+pred i__is_single (e: List;):
   (e == {{ "single", #k }}) * types(#k : Num);
 
-pred i__is_float (e: List):
+pred i__is_float (e: List;):
   (e == {{ "float", #k }}) * types(#k : Num);
 
-pred i__is_ptr_to_0 (e: List):
+pred i__is_ptr_to_0 (e: List;):
   (e == {{ #loc, 0i }}) *
   types(#loc : Obj);
 
-pred i__is_ptr (e: List):
+pred i__is_ptr (e: List;):
   (e == {{ #loc, #ofs }}) * (0i i<=# #ofs) *
   types(#loc : Obj, #ofs : Int);
   
-pred i__is_bounded_int(e: List, min: Int, max: Int):
+pred i__is_bounded_int(e: List, min: Int, max: Int;):
   (e == {{ "int", #k }}) * types(#k : Int) * (min i<=# #k) * (#k i<=# max);
 
-pred i__is_bounded_long(e: List, min: Int, max: Int):
+pred i__is_bounded_long(e: List, min: Int, max: Int;):
   (e == {{ "long", #k }}) * types(#k : Int) * (min i<=# #k) * (#k i<=# max);
 
 (* Actual value getters *)
 
-pred i__int (+e: List, k : Int):
+pred i__int (e: List; k : Int):
   (e == {{ "int", k }});
 
-pred i__long (+e: List, k : Int):
+pred i__long (e: List; k : Int):
   (e == {{ "long", k }});
 
-pred i__single (+e: List, k : Num):
+pred i__single (e: List; k : Num):
   (e == {{ "single", k }});
 
-pred i__float (+e: List, k : Num):
+pred i__float (e: List; k : Num):
   (e == {{ "float", k }});
 
-pred i__ptr_to_0 (+e : List, l : Obj):
+pred i__ptr_to_0 (e : List; l : Obj):
   (e == {{ l, 0i }});
 
-pred i__ptr (+e: List, l: Obj, o: Int):
+pred i__ptr (e: List; l: Obj, o: Int):
   (e == {{ l, o }}) * (0i i<=# o);
 
 (* arrays *)
 
-pred i__zeros_ptr_size(+ptr: List, +size: Int):
+pred i__zeros_ptr_size(ptr: List, size: Int;):
   i__ptr(ptr, #l, #o) *
   <mem_zeros>(#l, #o, #o i+ size; "Freeable");
 
-pred i__undefs_ptr_size(+ptr: List, +size: Int):
+pred i__undefs_ptr_size(ptr: List, size: Int;):
   i__ptr(ptr, #l, #o) *
   <mem_hole>(#l, #o, #o i+ size; "Freeable");
 
-pred i__array_ptr(+ptr: List, +size: Int, +chk: Str, content: List):
+pred i__array_ptr(ptr: List, size: Int, chk: Str; content: List):
   i__ptr(ptr, #l, #o) * (size == l-len content) * (0i i<=# size) *
   <mem_array>(#l, #o, size, chk; content, "Freeable");
 
 (* Pointer arithmetic *)
 
-pred i__ptr_add(+ptr: List, +to_add:Int, res: List):
+pred i__ptr_add(ptr: List, to_add:Int; res: List):
   i__ptr(ptr, #l, #o) *
   (res == {{ #l, #o i+ to_add }});

--- a/Gillian-C/runtime/logic_common.gil
+++ b/Gillian-C/runtime/logic_common.gil
@@ -2,30 +2,30 @@
 
 (* Type testers *)
 
-pred i__is_int (e: List;):
+pred i__is_int (e: List):
   (e == {{ "int", #k }}) * types(#k : Int);
 
-pred i__is_long (e: List;):
+pred i__is_long (e: List):
   (e == {{ "long", #k }}) * types(#k : Int);
 
-pred i__is_single (e: List;):
+pred i__is_single (e: List):
   (e == {{ "single", #k }}) * types(#k : Num);
 
-pred i__is_float (e: List;):
+pred i__is_float (e: List):
   (e == {{ "float", #k }}) * types(#k : Num);
 
-pred i__is_ptr_to_0 (e: List;):
+pred i__is_ptr_to_0 (e: List):
   (e == {{ #loc, 0i }}) *
   types(#loc : Obj);
 
-pred i__is_ptr (e: List;):
+pred i__is_ptr (e: List):
   (e == {{ #loc, #ofs }}) * (0i i<=# #ofs) *
   types(#loc : Obj, #ofs : Int);
   
-pred i__is_bounded_int(e: List, min: Int, max: Int;):
+pred i__is_bounded_int(e: List, min: Int, max: Int):
   (e == {{ "int", #k }}) * types(#k : Int) * (min i<=# #k) * (#k i<=# max);
 
-pred i__is_bounded_long(e: List, min: Int, max: Int;):
+pred i__is_bounded_long(e: List, min: Int, max: Int):
   (e == {{ "long", #k }}) * types(#k : Int) * (min i<=# #k) * (#k i<=# max);
 
 (* Actual value getters *)
@@ -50,11 +50,11 @@ pred i__ptr (e: List; l: Obj, o: Int):
 
 (* arrays *)
 
-pred i__zeros_ptr_size(ptr: List, size: Int;):
+pred i__zeros_ptr_size(ptr: List, size: Int):
   i__ptr(ptr; #l, #o) *
   <mem_zeros>(#l, #o, #o i+ size; "Freeable");
 
-pred i__undefs_ptr_size(ptr: List, size: Int;):
+pred i__undefs_ptr_size(ptr: List, size: Int):
   i__ptr(ptr; #l, #o) *
   <mem_hole>(#l, #o, #o i+ size; "Freeable");
 

--- a/Gillian-C2/examples/verification/array.c
+++ b/Gillian-C2/examples/verification/array.c
@@ -12,19 +12,19 @@ typedef struct Array {
 
 // The following should be in the Gillian-C stdlib
 /*@
-pred OARRAY(+p, +size, content) {
+pred OARRAY(p, size; content) {
   (size == 0) * (content == nil);
   (0 <# size)  * ARRAY(p, int, size, content) * ((len content) == size)
 }
 
-pred OUNINIT(+p, +size) {
+pred OUNINIT(p, size;) {
   (size == 0);
   (0 <# size) * UNDEFS(p, size)
 }
 */
 
 /*@
-pred valid_array(+ar, content) {
+pred valid_array(ar; content) {
   (ar -> struct Array { #buffer; long(#capacity); long(#size) }) *
   (0 <# #capacity) *
   (#size <=# #capacity) *

--- a/Gillian-C2/examples/verification/array.c
+++ b/Gillian-C2/examples/verification/array.c
@@ -28,16 +28,16 @@ pred valid_array(ar; content) {
   (ar -> struct Array { #buffer; long(#capacity); long(#size) }) *
   (0 <# #capacity) *
   (#size <=# #capacity) *
-  OARRAY(#buffer, #size, content) *
-  OUNINIT(#buffer p+ (#size * 4), (#capacity - #size) * 4) *
+  OARRAY(#buffer, #size; content) *
+  OUNINIT(#buffer p+ (#size * 4), (#capacity - #size) * 4;) *
   MALLOCED(#buffer, #capacity * 4)
 }
 */
 
 /*@ spec push(ar, value) {
   requires: (ar == #ar) * (value == int(#value)) *
-            valid_array(#ar, #content)
-  ensures:  valid_array(#ar, #content @ [#value])
+            valid_array(#ar; #content)
+  ensures:  valid_array(#ar; #content @ [#value])
 }*/
 void push(Array *ar, int value) {
     if (ar->size == ar->capacity) {
@@ -54,8 +54,8 @@ void push(Array *ar, int value) {
 
 /* spec remove(ar, index) {
   requires: (ar == #ar) * (index == long(#index)) *
-            valid_array(#ar, #content) * (0 <=# #index) * (#index <# (len #content))
-  ensures:  valid_array(#ar, lsub(#content, 0, #index) @ lsub(#content, #index + 1, (len #content) - #index - 1))
+            valid_array(#ar; #content) * (0 <=# #index) * (#index <# (len #content))
+  ensures:  valid_array(#ar; lsub(#content, 0, #index) @ lsub(#content, #index + 1, (len #content) - #index - 1))
 }
 */
 void remove(Array *ar, size_t index) {

--- a/Gillian-C2/examples/verification/array.c
+++ b/Gillian-C2/examples/verification/array.c
@@ -17,7 +17,7 @@ pred OARRAY(p, size; content) {
   (0 <# size)  * ARRAY(p, int, size, content) * ((len content) == size)
 }
 
-pred OUNINIT(p, size;) {
+pred OUNINIT(p, size) {
   (size == 0);
   (0 <# size) * UNDEFS(p, size)
 }
@@ -29,7 +29,7 @@ pred valid_array(ar; content) {
   (0 <# #capacity) *
   (#size <=# #capacity) *
   OARRAY(#buffer, #size; content) *
-  OUNINIT(#buffer p+ (#size * 4), (#capacity - #size) * 4;) *
+  OUNINIT(#buffer p+ (#size * 4), (#capacity - #size) * 4) *
   MALLOCED(#buffer, #capacity * 4)
 }
 */

--- a/Gillian-C2/examples/verification/cc_slist.c
+++ b/Gillian-C2/examples/verification/cc_slist.c
@@ -14,7 +14,7 @@ typedef struct cc_slist_s {
 /*@ pred sll(p; alpha) {
   (p -m> struct snode_s { #head; #tail } * (alpha == #head::#beta)) *
   sll(#tail;#beta) *
-  i__is_size_t(len alpha;);
+  i__is_size_t(len alpha);
   (p == NULL) * (alpha == nil)
 }
 
@@ -22,7 +22,7 @@ pred lseg(p, q; alpha) {
     (p == q) * (alpha == nil);
 
     (p -m> struct snode_s { #head; #tail }) * (alpha == #head::#beta) *
-    lseg(#tail, q; #beta) * i__is_size_t(len alpha;)
+    lseg(#tail, q; #beta) * i__is_size_t(len alpha)
 }
 
 pred cc_sll_ht(h, t, size; alpha) {
@@ -40,7 +40,7 @@ pred cc_sll(x; alpha) {
 }
 
 lemma lseg_append(p, q, alpha, a, end) {
-    hypothesis: lseg(#p, #q; #alpha) * (#q -m> struct snode_s { #a; #end }) * i__is_size_t((len #alpha) + 1;)
+    hypothesis: lseg(#p, #q; #alpha) * (#q -m> struct snode_s { #a; #end }) * i__is_size_t((len #alpha) + 1)
     conclusions: lseg(#p, #end; #alpha @ [#a])
     proof:
       unfold lseg(#p, #q, #alpha)[[bind #head: #head,
@@ -53,7 +53,7 @@ lemma lseg_append(p, q, alpha, a, end) {
 }
 
 lemma lseg_concat(p, q, r, alpha, gamma) {
-    hypothesis: lseg(#p, #q; #alpha) * lseg(#q, #r; #gamma) * i__is_size_t(len (#alpha @ #gamma);)
+    hypothesis: lseg(#p, #q; #alpha) * lseg(#q, #r; #gamma) * i__is_size_t(len (#alpha @ #gamma))
     conclusions: lseg(#p, #r; #alpha @ #gamma)
     proof:
       unfold lseg(#p, #q, #alpha)[[bind #head: #head,
@@ -68,7 +68,7 @@ lemma lseg_concat(p, q, r, alpha, gamma) {
 
 /*@ spec cc_slist_add_last(x, v) {
   requires: (x == #x) * cc_sll(#x; #alpha)
-          * (v == #v) * i__is_size_t((len #alpha) + 1;)
+          * (v == #v) * i__is_size_t((len #alpha) + 1)
   ensures:  cc_sll(#x; #alpha @ [ #v ])
 } */
 void cc_slist_add_last(CC_SList *x, int v) {
@@ -97,7 +97,7 @@ void cc_slist_add_last(CC_SList *x, int v) {
 /*@ spec cc_slist_splice(x, y) {
   requires: (x == #x) * cc_sll(#x; #alpha)
           * (y == #y) * cc_sll(#y; #beta)
-          * i__is_size_t((len #alpha) + (len #beta);)
+          * i__is_size_t((len #alpha) + (len #beta))
   ensures:  cc_sll(#x; #alpha @ #beta) * cc_sll(#y; [])
 } */
 void cc_slist_splice(CC_SList *x, CC_SList *y) {

--- a/Gillian-C2/examples/verification/cc_slist.c
+++ b/Gillian-C2/examples/verification/cc_slist.c
@@ -13,7 +13,7 @@ typedef struct cc_slist_s {
 
 /*@ pred sll(p; alpha) {
   (p -m> struct snode_s { #head; #tail } * (alpha == #head::#beta)) *
-  sll(#tail,#beta) *
+  sll(#tail;#beta) *
   i__is_size_t(len alpha);
   (p == NULL) * (alpha == nil)
 }
@@ -22,26 +22,26 @@ pred lseg(p, q; alpha) {
     (p == q) * (alpha == nil);
 
     (p -m> struct snode_s { #head; #tail }) * (alpha == #head::#beta) *
-    lseg(#tail, q, #beta) * i__is_size_t(len alpha)
+    lseg(#tail, q; #beta) * i__is_size_t(len alpha)
 }
 
 pred cc_sll_ht(h, t, size; alpha) {
     (h == NULL) * (t == NULL) * (size == 0) * (alpha == []);
 
-    lseg(h, t, #beta) *
-    sll(t, [ #last ]) *
+    lseg(h, t; #beta) *
+    sll(t; [ #last ]) *
     (alpha == #beta @ [ #last ]) *
     (size == len alpha)
 }
 
 pred cc_sll(x; alpha) {
     (x -m> struct cc_slist_s { #size; #h; #t }) *
-    cc_sll_ht(#h, #t, #size, alpha)
+    cc_sll_ht(#h, #t, #size; alpha)
 }
 
 lemma lseg_append(p, q, alpha, a, end) {
-    hypothesis: lseg(#p, #q, #alpha) * (#q -m> struct snode_s { #a; #end }) * i__is_size_t((len #alpha) + 1)
-    conclusions: lseg(#p, #end, #alpha @ [#a])
+    hypothesis: lseg(#p, #q; #alpha) * (#q -m> struct snode_s { #a; #end }) * i__is_size_t((len #alpha) + 1)
+    conclusions: lseg(#p, #end; #alpha @ [#a])
     proof:
       unfold lseg(#p, #q, #alpha)[[bind #head: #head,
                                         #tail: #tail,
@@ -53,8 +53,8 @@ lemma lseg_append(p, q, alpha, a, end) {
 }
 
 lemma lseg_concat(p, q, r, alpha, gamma) {
-    hypothesis: lseg(#p, #q, #alpha) * lseg(#q, #r, #gamma) * i__is_size_t(len (#alpha @ #gamma))
-    conclusions: lseg(#p, #r, #alpha @ #gamma)
+    hypothesis: lseg(#p, #q; #alpha) * lseg(#q, #r; #gamma) * i__is_size_t(len (#alpha @ #gamma))
+    conclusions: lseg(#p, #r; #alpha @ #gamma)
     proof:
       unfold lseg(#p, #q, #alpha)[[bind #head: #head,
                                         #tail: #tail,
@@ -67,9 +67,9 @@ lemma lseg_concat(p, q, r, alpha, gamma) {
 */
 
 /*@ spec cc_slist_add_last(x, v) {
-  requires: (x == #x) * cc_sll(#x, #alpha)
+  requires: (x == #x) * cc_sll(#x; #alpha)
           * (v == #v) * i__is_size_t((len #alpha) + 1)
-  ensures:  cc_sll(#x, #alpha @ [ #v ])
+  ensures:  cc_sll(#x; #alpha @ [ #v ])
 } */
 void cc_slist_add_last(CC_SList *x, int v) {
   SNode *node = calloc(1, sizeof(SNode));
@@ -95,10 +95,10 @@ void cc_slist_add_last(CC_SList *x, int v) {
 
 
 /*@ spec cc_slist_splice(x, y) {
-  requires: (x == #x) * cc_sll(#x, #alpha)
-          * (y == #y) * cc_sll(#y, #beta)
+  requires: (x == #x) * cc_sll(#x; #alpha)
+          * (y == #y) * cc_sll(#y; #beta)
           * i__is_size_t((len #alpha) + (len #beta))
-  ensures:  cc_sll(#x, #alpha @ #beta) * cc_sll(#y, [])
+  ensures:  cc_sll(#x; #alpha @ #beta) * cc_sll(#y; [])
 } */
 void cc_slist_splice(CC_SList *x, CC_SList *y) {
   if (y->size == 0)

--- a/Gillian-C2/examples/verification/cc_slist.c
+++ b/Gillian-C2/examples/verification/cc_slist.c
@@ -14,7 +14,7 @@ typedef struct cc_slist_s {
 /*@ pred sll(p; alpha) {
   (p -m> struct snode_s { #head; #tail } * (alpha == #head::#beta)) *
   sll(#tail;#beta) *
-  i__is_size_t(len alpha);
+  i__is_size_t(len alpha;);
   (p == NULL) * (alpha == nil)
 }
 
@@ -22,7 +22,7 @@ pred lseg(p, q; alpha) {
     (p == q) * (alpha == nil);
 
     (p -m> struct snode_s { #head; #tail }) * (alpha == #head::#beta) *
-    lseg(#tail, q; #beta) * i__is_size_t(len alpha)
+    lseg(#tail, q; #beta) * i__is_size_t(len alpha;)
 }
 
 pred cc_sll_ht(h, t, size; alpha) {
@@ -40,7 +40,7 @@ pred cc_sll(x; alpha) {
 }
 
 lemma lseg_append(p, q, alpha, a, end) {
-    hypothesis: lseg(#p, #q; #alpha) * (#q -m> struct snode_s { #a; #end }) * i__is_size_t((len #alpha) + 1)
+    hypothesis: lseg(#p, #q; #alpha) * (#q -m> struct snode_s { #a; #end }) * i__is_size_t((len #alpha) + 1;)
     conclusions: lseg(#p, #end; #alpha @ [#a])
     proof:
       unfold lseg(#p, #q, #alpha)[[bind #head: #head,
@@ -53,7 +53,7 @@ lemma lseg_append(p, q, alpha, a, end) {
 }
 
 lemma lseg_concat(p, q, r, alpha, gamma) {
-    hypothesis: lseg(#p, #q; #alpha) * lseg(#q, #r; #gamma) * i__is_size_t(len (#alpha @ #gamma))
+    hypothesis: lseg(#p, #q; #alpha) * lseg(#q, #r; #gamma) * i__is_size_t(len (#alpha @ #gamma);)
     conclusions: lseg(#p, #r; #alpha @ #gamma)
     proof:
       unfold lseg(#p, #q, #alpha)[[bind #head: #head,
@@ -68,7 +68,7 @@ lemma lseg_concat(p, q, r, alpha, gamma) {
 
 /*@ spec cc_slist_add_last(x, v) {
   requires: (x == #x) * cc_sll(#x; #alpha)
-          * (v == #v) * i__is_size_t((len #alpha) + 1)
+          * (v == #v) * i__is_size_t((len #alpha) + 1;)
   ensures:  cc_sll(#x; #alpha @ [ #v ])
 } */
 void cc_slist_add_last(CC_SList *x, int v) {
@@ -97,7 +97,7 @@ void cc_slist_add_last(CC_SList *x, int v) {
 /*@ spec cc_slist_splice(x, y) {
   requires: (x == #x) * cc_sll(#x; #alpha)
           * (y == #y) * cc_sll(#y; #beta)
-          * i__is_size_t((len #alpha) + (len #beta))
+          * i__is_size_t((len #alpha) + (len #beta);)
   ensures:  cc_sll(#x; #alpha @ #beta) * cc_sll(#y; [])
 } */
 void cc_slist_splice(CC_SList *x, CC_SList *y) {

--- a/Gillian-C2/examples/verification/cc_slist.c
+++ b/Gillian-C2/examples/verification/cc_slist.c
@@ -11,21 +11,21 @@ typedef struct cc_slist_s {
     SNode *tail;
 } CC_SList;
 
-/*@ pred sll(+p, alpha) {
+/*@ pred sll(p; alpha) {
   (p -m> struct snode_s { #head; #tail } * (alpha == #head::#beta)) *
   sll(#tail,#beta) *
   i__is_size_t(len alpha);
   (p == NULL) * (alpha == nil)
 }
 
-pred lseg(+p, +q, alpha) {
+pred lseg(p, q; alpha) {
     (p == q) * (alpha == nil);
 
     (p -m> struct snode_s { #head; #tail }) * (alpha == #head::#beta) *
     lseg(#tail, q, #beta) * i__is_size_t(len alpha)
 }
 
-pred cc_sll_ht(+h, +t, +size, alpha) {
+pred cc_sll_ht(h, t, size; alpha) {
     (h == NULL) * (t == NULL) * (size == 0) * (alpha == []);
 
     lseg(h, t, #beta) *
@@ -34,7 +34,7 @@ pred cc_sll_ht(+h, +t, +size, alpha) {
     (size == len alpha)
 }
 
-pred cc_sll(+x, alpha) {
+pred cc_sll(x; alpha) {
     (x -m> struct cc_slist_s { #size; #h; #t }) *
     cc_sll_ht(#h, #t, #size, alpha)
 }

--- a/Gillian-C2/examples/verification/dll.c
+++ b/Gillian-C2/examples/verification/dll.c
@@ -14,7 +14,7 @@ pred DLL(x; alpha) {
   DLL(#next; #beta) *
   (alpha == #val :: #beta) *
   (not (#next == NULL)) *
-  i__is_size_t(len alpha);
+  i__is_size_t(len alpha;);
 
   (x -m> struct dln {#val; #prev; NULL}) *
   (alpha == [ #val ])
@@ -35,7 +35,7 @@ DLL* makeNode(int x) {
 
 /*@ spec listConcat(x, y) {
   requires: (x == #x) * (y == #y) * DLL(#x; #alpha) * DLL(#y; #beta) *
-            i__is_size_t((len #alpha) + (len #beta))
+            i__is_size_t((len #alpha) + (len #beta);)
   ensures:  DLL(ret; #alpha @ #beta)
 } */
 DLL* listConcat(DLL *x, DLL *y) {
@@ -65,7 +65,7 @@ DLL* listConcat(DLL *x, DLL *y) {
 }
 
 /*@ spec listPrepend(x, v) {
-  requires: (x == #x) * (v == #v) * DLL(#x; #alpha) * i__is_size_t(1 + len #alpha)
+  requires: (x == #x) * (v == #v) * DLL(#x; #alpha) * i__is_size_t(1 + len #alpha;)
   ensures:  DLL(ret; #v :: #alpha)
 } */
 DLL* listPrepend(DLL *x, int v) {
@@ -81,7 +81,7 @@ DLL* listPrepend(DLL *x, int v) {
 }
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * (v == #v) * DLL(#x; #alpha) * i__is_size_t(1 + len #alpha)
+  requires: (x == #x) * (v == #v) * DLL(#x; #alpha) * i__is_size_t(1 + len #alpha;)
   ensures:  DLL(ret; #alpha @ [ #v ])
 } */
 DLL* listAppend(DLL *x, int v) { return listConcat(x, makeNode(v)); }

--- a/Gillian-C2/examples/verification/dll.c
+++ b/Gillian-C2/examples/verification/dll.c
@@ -14,7 +14,7 @@ pred DLL(x; alpha) {
   DLL(#next; #beta) *
   (alpha == #val :: #beta) *
   (not (#next == NULL)) *
-  i__is_size_t(len alpha;);
+  i__is_size_t(len alpha);
 
   (x -m> struct dln {#val; #prev; NULL}) *
   (alpha == [ #val ])
@@ -35,7 +35,7 @@ DLL* makeNode(int x) {
 
 /*@ spec listConcat(x, y) {
   requires: (x == #x) * (y == #y) * DLL(#x; #alpha) * DLL(#y; #beta) *
-            i__is_size_t((len #alpha) + (len #beta);)
+            i__is_size_t((len #alpha) + (len #beta))
   ensures:  DLL(ret; #alpha @ #beta)
 } */
 DLL* listConcat(DLL *x, DLL *y) {
@@ -65,7 +65,7 @@ DLL* listConcat(DLL *x, DLL *y) {
 }
 
 /*@ spec listPrepend(x, v) {
-  requires: (x == #x) * (v == #v) * DLL(#x; #alpha) * i__is_size_t(1 + len #alpha;)
+  requires: (x == #x) * (v == #v) * DLL(#x; #alpha) * i__is_size_t(1 + len #alpha)
   ensures:  DLL(ret; #v :: #alpha)
 } */
 DLL* listPrepend(DLL *x, int v) {
@@ -81,7 +81,7 @@ DLL* listPrepend(DLL *x, int v) {
 }
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * (v == #v) * DLL(#x; #alpha) * i__is_size_t(1 + len #alpha;)
+  requires: (x == #x) * (v == #v) * DLL(#x; #alpha) * i__is_size_t(1 + len #alpha)
   ensures:  DLL(ret; #alpha @ [ #v ])
 } */
 DLL* listAppend(DLL *x, int v) { return listConcat(x, makeNode(v)); }

--- a/Gillian-C2/examples/verification/dll.c
+++ b/Gillian-C2/examples/verification/dll.c
@@ -11,7 +11,7 @@ pred DLL(x; alpha) {
   (x == NULL) * (alpha == nil);
 
   (x -m> struct dln {#val; #prev; #next}) *
-  DLL(#next, #beta) *
+  DLL(#next; #beta) *
   (alpha == #val :: #beta) *
   (not (#next == NULL)) *
   i__is_size_t(len alpha);
@@ -23,7 +23,7 @@ pred DLL(x; alpha) {
 
 /*@ spec makeNode(x) {
   requires: (#x == x)
-  ensures:  DLL(ret, [#x])
+  ensures:  DLL(ret; [#x])
 } */
 DLL* makeNode(int x) {
     DLL *r = malloc(sizeof(DLL));
@@ -34,9 +34,9 @@ DLL* makeNode(int x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: (x == #x) * (y == #y) * DLL(#x, #alpha) * DLL(#y, #beta) *
+  requires: (x == #x) * (y == #y) * DLL(#x; #alpha) * DLL(#y; #beta) *
             i__is_size_t((len #alpha) + (len #beta))
-  ensures:  DLL(ret, #alpha @ #beta)
+  ensures:  DLL(ret; #alpha @ #beta)
 } */
 DLL* listConcat(DLL *x, DLL *y) {
     if (y == NULL) {
@@ -47,7 +47,7 @@ DLL* listConcat(DLL *x, DLL *y) {
         } else {
             __GILLIAN(
                 "assert [[bind #vx, #px, #nx, #gamma]] "
-                "(x -m> struct dln {#vx; #px; #nx}) * DLL(#nx, #gamma) * "
+                "(x -m> struct dln {#vx; #px; #nx}) * DLL(#nx; #gamma) * "
                 "(#alpha == #h :: #gamma)");
             __GILLIAN("unfold DLL(#nx, #gamma)");
             if (x->next == NULL) {
@@ -65,8 +65,8 @@ DLL* listConcat(DLL *x, DLL *y) {
 }
 
 /*@ spec listPrepend(x, v) {
-  requires: (x == #x) * (v == #v) * DLL(#x, #alpha) * i__is_size_t(1 + len #alpha)
-  ensures:  DLL(ret, #v :: #alpha)
+  requires: (x == #x) * (v == #v) * DLL(#x; #alpha) * i__is_size_t(1 + len #alpha)
+  ensures:  DLL(ret; #v :: #alpha)
 } */
 DLL* listPrepend(DLL *x, int v) {
     DLL *node_v = makeNode(v);
@@ -81,14 +81,14 @@ DLL* listPrepend(DLL *x, int v) {
 }
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * (v == #v) * DLL(#x, #alpha) * i__is_size_t(1 + len #alpha)
-  ensures:  DLL(ret, #alpha @ [ #v ])
+  requires: (x == #x) * (v == #v) * DLL(#x; #alpha) * i__is_size_t(1 + len #alpha)
+  ensures:  DLL(ret; #alpha @ [ #v ])
 } */
 DLL* listAppend(DLL *x, int v) { return listConcat(x, makeNode(v)); }
 
 /*@ spec listCopy(x) {
-  requires: (x == #x) * DLL(#x, #alpha)
-  ensures:  DLL(#x, #alpha) * DLL(ret, #alpha)
+  requires: (x == #x) * DLL(#x; #alpha)
+  ensures:  DLL(#x; #alpha) * DLL(ret; #alpha)
 } */
 DLL* listCopy(DLL *x) {
     if (x == NULL) {

--- a/Gillian-C2/examples/verification/dll.c
+++ b/Gillian-C2/examples/verification/dll.c
@@ -7,7 +7,7 @@ typedef struct dln {
 } DLL;
 
 /*@
-pred DLL(+x, alpha) {
+pred DLL(x; alpha) {
   (x == NULL) * (alpha == nil);
 
   (x -m> struct dln {#val; #prev; #next}) *

--- a/Gillian-C2/examples/verification/list_std.gil
+++ b/Gillian-C2/examples/verification/list_std.gil
@@ -9,24 +9,24 @@ pred ptr(p: List; l: Obj, o: Int):
   (p == {{ l, o }});
 
 pred dll_ptr(p; head, tail, length):
-     ptr(p, #l, #o) *
+     ptr(p; #l, #o) *
           <mem_single>(#l, #o, "u64"; head, "Freeable") *
           <mem_single>(#l, #o i+ 8i, "u64"; tail, "Freeable") *
           <mem_single>(#l, #o i+ 16i, "u64"; length, "Freeable");
 
 pred DLL_segl(head, next, tail, prev; content: List):
      (head == next) * (tail == prev) * (content == nil),
-     ptr(head, #l, #o) *
+     ptr(head; #l, #o) *
           <mem_single>(#l, #o, "u64"; #u, "Freeable") *
           <mem_single>(#l, #o i+ 8i, "u64"; #v, "Freeable") *
           <mem_single>(#l, #o i+ 16i, "u32"; #e, "Freeable") *
           (content == (l+({{ #e }}, #contentp))) *
-          DLL_segl(#u, next, tail, head, #contentp);
+          DLL_segl(#u, next, tail, head; #contentp);
 
 pred DLL(dll; content, len):
-     dll_ptr(dll, #head, #tail, len) *
+     dll_ptr(dll; #head, #tail, len) *
      (len == l-len(content)) *
-     DLL_segl(#head, 0i, #tail, 0i, content);
+     DLL_segl(#head, 0i, #tail, 0i; content);
      facts: (l-len(content) == len);
       
 proc as_ptr(var_1__self) {
@@ -193,16 +193,16 @@ proc node_new(i___ret, var_1__element) {
 };
 
 pred Box_NewNode(node; v):
-     ptr(node, #l, #o) *
+     ptr(node; #l, #o) *
           <mem_single>(#l, #o, "u64"; 0i, "Freeable") *
           <mem_single>(#l, #o i+ 8i, "u64"; 0i, "Freeable") *
           <mem_single>(#l, #o i+ 16i, "u32"; v, "Freeable");
 
 spec push_front_node(var_1__self, var_2__node)
   [[ (var_1__self == #self) * (var_2__node == #node) *
-     DLL(#self, #content, #size) * Box_NewNode(#node, #v) *
+     DLL(#self; #content, #size) * Box_NewNode(#node; #v) *
      (0i i<=# #size) * (#size i<# 18446744073709551615i) ]]
-  [[ DLL(#self, l+({{ #v }}, #content), #size i+ 1i) ]]
+  [[ DLL(#self; l+({{ #v }}, #content), #size i+ 1i) ]]
   normal
 
 proc push_front_node(var_1__self, var_2__node) {
@@ -321,10 +321,10 @@ proc push_front_node(var_1__self, var_2__node) {
 
 spec push_front(var_1__self, var_2__elt)
      [[ (var_1__self == #self) * (var_2__elt == #elt) *
-          DLL(#self, #content, #size) * is_u32(#elt) *
+          DLL(#self; #content, #size) * is_u32(#elt;) *
           (0i i<=# #size) * (#size i<# 18446744073709551615i) ]]
      (* Adding 1 to the size does not overflow *)
-     [[ DLL(#self, l+({{ #elt }}, #content), #size i+ 1i) ]]
+     [[ DLL(#self; l+({{ #elt }}, #content), #size i+ 1i) ]]
      normal
 
 proc push_front(var_1__self, var_2__elt) {

--- a/Gillian-C2/examples/verification/list_std.gil
+++ b/Gillian-C2/examples/verification/list_std.gil
@@ -2,7 +2,7 @@ import "archi64_constants.gil", "internals.gil",
        "global_environment_common.gil", "internal_casts.gil",
        "internal_binops.gil", "internal_unops.gil", "internal_stdlib.gil";  
    
-pred is_u32(e;):
+pred is_u32(e):
      (0i i<=# e) * (e i<=# 4294967296i);
 
 pred ptr(p: List; l: Obj, o: Int):
@@ -321,7 +321,7 @@ proc push_front_node(var_1__self, var_2__node) {
 
 spec push_front(var_1__self, var_2__elt)
      [[ (var_1__self == #self) * (var_2__elt == #elt) *
-          DLL(#self; #content, #size) * is_u32(#elt;) *
+          DLL(#self; #content, #size) * is_u32(#elt) *
           (0i i<=# #size) * (#size i<# 18446744073709551615i) ]]
      (* Adding 1 to the size does not overflow *)
      [[ DLL(#self; l+({{ #elt }}, #content), #size i+ 1i) ]]

--- a/Gillian-C2/examples/verification/list_std.gil
+++ b/Gillian-C2/examples/verification/list_std.gil
@@ -2,19 +2,19 @@ import "archi64_constants.gil", "internals.gil",
        "global_environment_common.gil", "internal_casts.gil",
        "internal_binops.gil", "internal_unops.gil", "internal_stdlib.gil";  
    
-pred is_u32(+e):
+pred is_u32(e;):
      (0i i<=# e) * (e i<=# 4294967296i);
 
-pred ptr(+p: List, l: Obj, o: Int):
+pred ptr(p: List; l: Obj, o: Int):
   (p == {{ l, o }});
 
-pred dll_ptr(+p, head, tail, length):
+pred dll_ptr(p; head, tail, length):
      ptr(p, #l, #o) *
           <mem_single>(#l, #o, "u64"; head, "Freeable") *
           <mem_single>(#l, #o i+ 8i, "u64"; tail, "Freeable") *
           <mem_single>(#l, #o i+ 16i, "u64"; length, "Freeable");
 
-pred DLL_segl(+head, +next, +tail, +prev, content: List):
+pred DLL_segl(head, next, tail, prev; content: List):
      (head == next) * (tail == prev) * (content == nil),
      ptr(head, #l, #o) *
           <mem_single>(#l, #o, "u64"; #u, "Freeable") *
@@ -23,7 +23,7 @@ pred DLL_segl(+head, +next, +tail, +prev, content: List):
           (content == (l+({{ #e }}, #contentp))) *
           DLL_segl(#u, next, tail, head, #contentp);
 
-pred DLL(+dll, content, len):
+pred DLL(dll; content, len):
      dll_ptr(dll, #head, #tail, len) *
      (len == l-len(content)) *
      DLL_segl(#head, 0i, #tail, 0i, content);
@@ -192,7 +192,7 @@ proc node_new(i___ret, var_1__element) {
        return
 };
 
-pred Box_NewNode(+node, v):
+pred Box_NewNode(node; v):
      ptr(node, #l, #o) *
           <mem_single>(#l, #o, "u64"; 0i, "Freeable") *
           <mem_single>(#l, #o i+ 8i, "u64"; 0i, "Freeable") *

--- a/Gillian-C2/examples/verification/list_unbounded.gil
+++ b/Gillian-C2/examples/verification/list_unbounded.gil
@@ -3,16 +3,16 @@ import "archi64_constants.gil", "internals.gil",
        "internal_binops.gil", "internal_stdlib.gil";
 
 
-pred Ptr(+p: List, l: Obj, o: Int):
+pred Ptr(p: List; l: Obj, o: Int):
   (p == {{ l, o }});
   
-pred is_ptr(+p: List):
+pred is_ptr(p: List;):
   (p == {{ #l, #o }}) * types(#l: Obj, #o: Int);
   
-pred is_u32(+v : Int):
+pred is_u32(v : Int;):
       (0i i<=# v) * (v i<=# 4294967295i);
 
-pred SLL(+p: List, sz: Int):
+pred SLL(p: List; sz: Int):
   (* First case is the Empty case *)
   Ptr(p, #l, #o) * (* p is a pointer *)
     (* Discriminant is zero *)

--- a/Gillian-C2/examples/verification/list_unbounded.gil
+++ b/Gillian-C2/examples/verification/list_unbounded.gil
@@ -14,7 +14,7 @@ pred is_u32(v : Int;):
 
 pred SLL(p: List; sz: Int):
   (* First case is the Empty case *)
-  Ptr(p, #l, #o) * (* p is a pointer *)
+  Ptr(p; #l, #o) * (* p is a pointer *)
     (* Discriminant is zero *)
     <mem_single>(#l, #o, "u32"; 0i, "Freeable") *
     (* The rest is uninitialized *)
@@ -23,25 +23,25 @@ pred SLL(p: List; sz: Int):
     (sz == 0i),
 
   (* Second case is a Node(u32, Box<List>)) *)
-  Ptr(p, #l, #o) * (* p is a pointer *)
+  Ptr(p; #l, #o) * (* p is a pointer *)
     (* Discriminant is zero *)
     <mem_single>(#l, #o, "u32"; 1i, "Freeable") *
     (* It has a value, but we discard it *)
-    is_u32(#val) * <mem_single>(#l, #o i+ 4i, "u32"; #val, "Freeable") * 
+    is_u32(#val;) * <mem_single>(#l, #o i+ 4i, "u32"; #val, "Freeable") * 
     (* There's a std::alloc::Global field, and some
        phantom data, but they're ZSTs so we ignore them *)
     (* Now comes the box to the rest *)
-    is_ptr(#next) * <mem_single>(#l, #o i+ 8i, "u64"; #next, "Freeable") *
-    SLL(#next, #sz_next) *
+    is_ptr(#next;) * <mem_single>(#l, #o i+ 8i, "u64"; #next, "Freeable") *
+    SLL(#next; #sz_next) *
     (* The size of the list is the size of the rest plus one *)
     (sz == (#sz_next i+ 1i)) *
     (0i i<# sz);
 
 
 spec list_length(self)
-  [[ (self == #self) * SLL(#self, #sz) *
+  [[ (self == #self) * SLL(#self; #sz) *
      (0i i<=# #sz) * (#sz i<# 18446744073709551615i) ]]
-  [[ SLL(#self, #sz) * (ret == #sz) ]]
+  [[ SLL(#self; #sz) * (ret == #sz) ]]
   normal
 
 

--- a/Gillian-C2/examples/verification/list_unbounded.gil
+++ b/Gillian-C2/examples/verification/list_unbounded.gil
@@ -6,10 +6,10 @@ import "archi64_constants.gil", "internals.gil",
 pred Ptr(p: List; l: Obj, o: Int):
   (p == {{ l, o }});
   
-pred is_ptr(p: List;):
+pred is_ptr(p: List):
   (p == {{ #l, #o }}) * types(#l: Obj, #o: Int);
   
-pred is_u32(v : Int;):
+pred is_u32(v : Int):
       (0i i<=# v) * (v i<=# 4294967295i);
 
 pred SLL(p: List; sz: Int):
@@ -27,11 +27,11 @@ pred SLL(p: List; sz: Int):
     (* Discriminant is zero *)
     <mem_single>(#l, #o, "u32"; 1i, "Freeable") *
     (* It has a value, but we discard it *)
-    is_u32(#val;) * <mem_single>(#l, #o i+ 4i, "u32"; #val, "Freeable") * 
+    is_u32(#val) * <mem_single>(#l, #o i+ 4i, "u32"; #val, "Freeable") * 
     (* There's a std::alloc::Global field, and some
        phantom data, but they're ZSTs so we ignore them *)
     (* Now comes the box to the rest *)
-    is_ptr(#next;) * <mem_single>(#l, #o i+ 8i, "u64"; #next, "Freeable") *
+    is_ptr(#next) * <mem_single>(#l, #o i+ 8i, "u64"; #next, "Freeable") *
     SLL(#next; #sz_next) *
     (* The size of the list is the size of the rest plus one *)
     (sz == (#sz_next i+ 1i)) *

--- a/Gillian-C2/examples/verification/llen.c
+++ b/Gillian-C2/examples/verification/llen.c
@@ -9,15 +9,15 @@ typedef struct ln {
 pred list(p; alpha) {
   p -m> struct ln { #head; #tail } *
     (alpha == #head::#beta) *
-    list(#tail,#beta) *
+    list(#tail;#beta) *
     i__is_int(len alpha);
   (p == NULL) * (alpha == nil)
 }
 */
 
 /*@ spec listLength(x) {
-  requires: list(#x, #alpha) * (x == #x)
-  ensures:  list(#x, #alpha) * (ret == int(#r)) * (#r == len #alpha)
+  requires: list(#x; #alpha) * (x == #x)
+  ensures:  list(#x; #alpha) * (ret == int(#r)) * (#r == len #alpha)
 } */
 int listLength(SLL *x) {
     if (x == NULL) {

--- a/Gillian-C2/examples/verification/llen.c
+++ b/Gillian-C2/examples/verification/llen.c
@@ -6,7 +6,7 @@ typedef struct ln {
 } SLL;
 
 /*@
-pred list(+p, alpha) {
+pred list(p; alpha) {
   p -m> struct ln { #head; #tail } *
     (alpha == #head::#beta) *
     list(#tail,#beta) *

--- a/Gillian-C2/examples/verification/llen.c
+++ b/Gillian-C2/examples/verification/llen.c
@@ -10,7 +10,7 @@ pred list(p; alpha) {
   p -m> struct ln { #head; #tail } *
     (alpha == #head::#beta) *
     list(#tail;#beta) *
-    i__is_int(len alpha);
+    i__is_int(len alpha;);
   (p == NULL) * (alpha == nil)
 }
 */

--- a/Gillian-C2/examples/verification/llen.c
+++ b/Gillian-C2/examples/verification/llen.c
@@ -10,7 +10,7 @@ pred list(p; alpha) {
   p -m> struct ln { #head; #tail } *
     (alpha == #head::#beta) *
     list(#tail;#beta) *
-    i__is_int(len alpha;);
+    i__is_int(len alpha);
   (p == NULL) * (alpha == nil)
 }
 */

--- a/Gillian-C2/examples/verification/sll.c
+++ b/Gillian-C2/examples/verification/sll.c
@@ -10,7 +10,7 @@ pred sll(p; alpha) {
   (p -m> struct ln { #head; #tail }) *
   (alpha == #head::#beta) *
   sll(#tail; #beta) *
-  i__is_size_t(len alpha);
+  i__is_size_t(len alpha;);
 
   (p == NULL) * (alpha == [])
 }
@@ -19,7 +19,7 @@ pred lseg(p, q; alpha) {
     (p -m> struct ln { #head; #tail }) *
     (alpha == #head::#beta) *
     lseg(#tail, q; #beta) *
-    i__is_size_t(len alpha);
+    i__is_size_t(len alpha;);
 
     (p == q) * (alpha == [])
 }
@@ -39,7 +39,7 @@ lemma lseg_to_list(p, alpha) {
 
 lemma lseg_append(p, q, alpha, a, end) {
     hypothesis: lseg(#p, #q; #alpha)
-                * (#q -m> struct ln { #a; #end }) * i__is_size_t(1 + len #alpha)
+                * (#q -m> struct ln { #a; #end }) * i__is_size_t(1 + len #alpha;)
     conclusions: lseg(#p, #end; #alpha @ [#a])
     proof:
       unfold lseg(#p, #q, #alpha)[[bind #head: #head,
@@ -53,7 +53,7 @@ lemma lseg_append(p, q, alpha, a, end) {
 */
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * sll(#x; #alpha) * (v == #v) * i__is_size_t(1 + len #alpha)
+  requires: (x == #x) * sll(#x; #alpha) * (v == #v) * i__is_size_t(1 + len #alpha;)
   ensures:  sll(ret; #alpha @ [ #v ])
 } */
 SLL* listAppend(SLL *x, int v) {
@@ -74,7 +74,7 @@ SLL* listAppend(SLL *x, int v) {
             (x == #v) *
             (z == #z) *
             sll(#z; #alpha) *
-            i__is_size_t(1 + len #alpha)
+            i__is_size_t(1 + len #alpha;)
   ensures: sll(ret; #head::#alpha)
 } */
 SLL* listPrepend(SLL *x, SLL *z) {
@@ -83,7 +83,7 @@ SLL* listPrepend(SLL *x, SLL *z) {
 }
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * sll(#x; #alpha) * (v == #v) * i__is_size_t(1 + len #alpha)
+  requires: (x == #x) * sll(#x; #alpha) * (v == #v) * i__is_size_t(1 + len #alpha;)
   ensures: sll(ret; #v::#alpha)
 }
 */
@@ -136,7 +136,7 @@ SLL* listCopy(SLL *x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: sll(#x; #alpha) * (x == #x) * sll(#y; #beta) * (y == #y) * i__is_size_t((len #alpha) + (len #beta))
+  requires: sll(#x; #alpha) * (x == #x) * sll(#y; #beta) * (y == #y) * i__is_size_t((len #alpha) + (len #beta);)
   ensures:  sll(ret; #alpha @ #beta)
 } */
 SLL* listConcat(SLL *x, SLL *y) {

--- a/Gillian-C2/examples/verification/sll.c
+++ b/Gillian-C2/examples/verification/sll.c
@@ -6,7 +6,7 @@ typedef struct ln {
 } SLL;
 
 /*@
-pred sll(+p, alpha) {
+pred sll(p; alpha) {
   (p -m> struct ln { #head; #tail }) *
   (alpha == #head::#beta) *
   sll(#tail, #beta) *
@@ -15,7 +15,7 @@ pred sll(+p, alpha) {
   (p == NULL) * (alpha == [])
 }
 
-pred lseg(+p, +q, alpha) {
+pred lseg(p, q; alpha) {
     (p -m> struct ln { #head; #tail }) *
     (alpha == #head::#beta) *
     lseg(#tail, q, #beta) *

--- a/Gillian-C2/examples/verification/sll.c
+++ b/Gillian-C2/examples/verification/sll.c
@@ -10,7 +10,7 @@ pred sll(p; alpha) {
   (p -m> struct ln { #head; #tail }) *
   (alpha == #head::#beta) *
   sll(#tail; #beta) *
-  i__is_size_t(len alpha;);
+  i__is_size_t(len alpha);
 
   (p == NULL) * (alpha == [])
 }
@@ -19,7 +19,7 @@ pred lseg(p, q; alpha) {
     (p -m> struct ln { #head; #tail }) *
     (alpha == #head::#beta) *
     lseg(#tail, q; #beta) *
-    i__is_size_t(len alpha;);
+    i__is_size_t(len alpha);
 
     (p == q) * (alpha == [])
 }
@@ -39,7 +39,7 @@ lemma lseg_to_list(p, alpha) {
 
 lemma lseg_append(p, q, alpha, a, end) {
     hypothesis: lseg(#p, #q; #alpha)
-                * (#q -m> struct ln { #a; #end }) * i__is_size_t(1 + len #alpha;)
+                * (#q -m> struct ln { #a; #end }) * i__is_size_t(1 + len #alpha)
     conclusions: lseg(#p, #end; #alpha @ [#a])
     proof:
       unfold lseg(#p, #q, #alpha)[[bind #head: #head,
@@ -53,7 +53,7 @@ lemma lseg_append(p, q, alpha, a, end) {
 */
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * sll(#x; #alpha) * (v == #v) * i__is_size_t(1 + len #alpha;)
+  requires: (x == #x) * sll(#x; #alpha) * (v == #v) * i__is_size_t(1 + len #alpha)
   ensures:  sll(ret; #alpha @ [ #v ])
 } */
 SLL* listAppend(SLL *x, int v) {
@@ -74,7 +74,7 @@ SLL* listAppend(SLL *x, int v) {
             (x == #v) *
             (z == #z) *
             sll(#z; #alpha) *
-            i__is_size_t(1 + len #alpha;)
+            i__is_size_t(1 + len #alpha)
   ensures: sll(ret; #head::#alpha)
 } */
 SLL* listPrepend(SLL *x, SLL *z) {
@@ -83,7 +83,7 @@ SLL* listPrepend(SLL *x, SLL *z) {
 }
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * sll(#x; #alpha) * (v == #v) * i__is_size_t(1 + len #alpha;)
+  requires: (x == #x) * sll(#x; #alpha) * (v == #v) * i__is_size_t(1 + len #alpha)
   ensures: sll(ret; #v::#alpha)
 }
 */
@@ -136,7 +136,7 @@ SLL* listCopy(SLL *x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: sll(#x; #alpha) * (x == #x) * sll(#y; #beta) * (y == #y) * i__is_size_t((len #alpha) + (len #beta);)
+  requires: sll(#x; #alpha) * (x == #x) * sll(#y; #beta) * (y == #y) * i__is_size_t((len #alpha) + (len #beta))
   ensures:  sll(ret; #alpha @ #beta)
 } */
 SLL* listConcat(SLL *x, SLL *y) {

--- a/Gillian-C2/examples/verification/sll.c
+++ b/Gillian-C2/examples/verification/sll.c
@@ -9,7 +9,7 @@ typedef struct ln {
 pred sll(p; alpha) {
   (p -m> struct ln { #head; #tail }) *
   (alpha == #head::#beta) *
-  sll(#tail, #beta) *
+  sll(#tail; #beta) *
   i__is_size_t(len alpha);
 
   (p == NULL) * (alpha == [])
@@ -18,15 +18,15 @@ pred sll(p; alpha) {
 pred lseg(p, q; alpha) {
     (p -m> struct ln { #head; #tail }) *
     (alpha == #head::#beta) *
-    lseg(#tail, q, #beta) *
+    lseg(#tail, q; #beta) *
     i__is_size_t(len alpha);
 
     (p == q) * (alpha == [])
 }
 
 lemma lseg_to_list(p, alpha) {
-    hypothesis: lseg(#p, NULL, #alpha)
-    conclusions: sll(#p, #alpha)
+    hypothesis: lseg(#p, NULL; #alpha)
+    conclusions: sll(#p; #alpha)
     proof:
       unfold lseg(#p, NULL, #alpha) [[bind #head: #head,
                                            #tail: #tail,
@@ -38,9 +38,9 @@ lemma lseg_to_list(p, alpha) {
 }
 
 lemma lseg_append(p, q, alpha, a, end) {
-    hypothesis: lseg(#p, #q, #alpha)
+    hypothesis: lseg(#p, #q; #alpha)
                 * (#q -m> struct ln { #a; #end }) * i__is_size_t(1 + len #alpha)
-    conclusions: lseg(#p, #end, #alpha @ [#a])
+    conclusions: lseg(#p, #end; #alpha @ [#a])
     proof:
       unfold lseg(#p, #q, #alpha)[[bind #head: #head,
                                         #tail: #tail,
@@ -53,8 +53,8 @@ lemma lseg_append(p, q, alpha, a, end) {
 */
 
 /*@ spec listAppend(x, v) {
-  requires: (x == #x) * sll(#x, #alpha) * (v == #v) * i__is_size_t(1 + len #alpha)
-  ensures:  sll(ret, #alpha @ [ #v ])
+  requires: (x == #x) * sll(#x; #alpha) * (v == #v) * i__is_size_t(1 + len #alpha)
+  ensures:  sll(ret; #alpha @ [ #v ])
 } */
 SLL* listAppend(SLL *x, int v) {
     if (x == NULL) {
@@ -73,9 +73,9 @@ SLL* listAppend(SLL *x, int v) {
   requires: (x -m> struct ln { #head; NULL }) *
             (x == #v) *
             (z == #z) *
-            sll(#z, #alpha) *
+            sll(#z; #alpha) *
             i__is_size_t(1 + len #alpha)
-  ensures: sll(ret, #head::#alpha)
+  ensures: sll(ret; #head::#alpha)
 } */
 SLL* listPrepend(SLL *x, SLL *z) {
     x->next = z;
@@ -83,8 +83,8 @@ SLL* listPrepend(SLL *x, SLL *z) {
 }
 
 /*@ spec listPrependV(x, v) {
-  requires: (x == #x) * sll(#x, #alpha) * (v == #v) * i__is_size_t(1 + len #alpha)
-  ensures: sll(ret, #v::#alpha)
+  requires: (x == #x) * sll(#x; #alpha) * (v == #v) * i__is_size_t(1 + len #alpha)
+  ensures: sll(ret; #v::#alpha)
 }
 */
 SLL* listPrependV(SLL *x, int v) {
@@ -95,8 +95,8 @@ SLL* listPrependV(SLL *x, int v) {
 }
 
 /*@ spec listLength(x) {
-  requires: sll(#x, #alpha) * (x == #x)
-  ensures:  sll(#x, #alpha) * (ret == len #alpha)
+  requires: sll(#x; #alpha) * (x == #x)
+  ensures:  sll(#x; #alpha) * (ret == len #alpha)
 } */
 size_t listLength(SLL *x) {
     if (x == NULL) {
@@ -107,7 +107,7 @@ size_t listLength(SLL *x) {
 }
 
 /*@ spec listDispose(x) {
-  requires: sll(#x, #alpha) * (x == #x)
+  requires: sll(#x; #alpha) * (x == #x)
   ensures:  emp
 } */
 void listDispose(SLL *x) {
@@ -121,8 +121,8 @@ void listDispose(SLL *x) {
 }
 
 /*@ spec listCopy(x) {
-  requires: sll(#x, #alpha) * (x == #x)
-  ensures:  sll(ret, #alpha) * sll(#x, #alpha)
+  requires: sll(#x; #alpha) * (x == #x)
+  ensures:  sll(ret; #alpha) * sll(#x; #alpha)
 } */
 SLL* listCopy(SLL *x) {
     SLL *r;
@@ -136,8 +136,8 @@ SLL* listCopy(SLL *x) {
 }
 
 /*@ spec listConcat(x, y) {
-  requires: sll(#x, #alpha) * (x == #x) * sll(#y, #beta) * (y == #y) * i__is_size_t((len #alpha) + (len #beta))
-  ensures:  sll(ret, #alpha @ #beta)
+  requires: sll(#x; #alpha) * (x == #x) * sll(#y; #beta) * (y == #y) * i__is_size_t((len #alpha) + (len #beta))
+  ensures:  sll(ret; #alpha @ #beta)
 } */
 SLL* listConcat(SLL *x, SLL *y) {
     SLL *r;

--- a/Gillian-C2/lib/compiler/c2_annot_parser.mly
+++ b/Gillian-C2/lib/compiler/c2_annot_parser.mly
@@ -374,8 +374,8 @@ assertion:
     { CAssert.Undefs (ptr, size)}
   | MALLOCED; LBRACE; ptr = expression; COMMA; ofs = expression; RBRACE
     { CAssert.Malloced(ptr, ofs) }
-  | pname = IDENTIFIER; LBRACE; el = separated_list(COMMA, expression); RBRACE
-    { CAssert.Pred (pname, el) }
+  | pname = IDENTIFIER; LBRACE; ins = separated_list(COMMA, expression); SCOLON; outs = separated_list(COMMA, expression); RBRACE
+    { CAssert.Pred (pname, ins, outs) }
 
 formula:
   | LBRACE; formula; RBRACE { $2 }

--- a/Gillian-C2/lib/compiler/c2_annot_parser.mly
+++ b/Gillian-C2/lib/compiler/c2_annot_parser.mly
@@ -288,8 +288,7 @@ spec_annot:
 abstract_predicate:
   | ABSTRACT; pure=option(PURE); PREDICATE; pname = IDENTIFIER; LBRACE;
     ins = separated_list(COMMA, pred_param);
-    SCOLON;
-    outs = separated_list(COMMA, pred_param);
+    outs = outs(pred_param);
     RBRACE;
     {
       let params = ins @ outs in
@@ -305,8 +304,7 @@ abstract_predicate:
 predicate:
   | pure=option(PURE); PREDICATE; no_unfold=option(NOUNFOLD); pname = IDENTIFIER; LBRACE;
     ins = separated_list(COMMA, pred_param);
-    SCOLON;
-    outs = separated_list(COMMA, pred_param);
+    outs = outs(pred_param);
     RBRACE; LCBRACE;
     defs = separated_nonempty_list(SCOLON, pred_definition);
     RCBRACE;
@@ -374,7 +372,9 @@ assertion:
     { CAssert.Undefs (ptr, size)}
   | MALLOCED; LBRACE; ptr = expression; COMMA; ofs = expression; RBRACE
     { CAssert.Malloced(ptr, ofs) }
-  | pname = IDENTIFIER; LBRACE; ins = separated_list(COMMA, expression); SCOLON; outs = separated_list(COMMA, expression); RBRACE
+  | pname = IDENTIFIER; LBRACE;
+    ins = separated_list(COMMA, expression);
+    outs = outs(expression); RBRACE
     { CAssert.Pred (pname, ins, outs) }
 
 formula:
@@ -597,3 +597,12 @@ any_C_token:
   | AND
   | OR
   { () }
+
+%inline outs(X):
+  xs = option_preceded_separated_list(SCOLON, COMMA, X)
+  { xs }
+
+%inline option_preceded_separated_list(PREC, SEP, X):
+  | PREC; xs = separated_list(SEP, X) { xs }
+  | { [] }
+

--- a/Gillian-C2/lib/compiler/c2_annot_parser.mly
+++ b/Gillian-C2/lib/compiler/c2_annot_parser.mly
@@ -9,18 +9,6 @@
   let char_chunk = Machine_model.char_chunk machine
   let ptr_chunk = Machine_model.ptr_chunk machine
 
-  let process_pred_params params_ins =
-      let (params, ins) = List.split params_ins in
-      (* ins looks like [true, false, true] *)
-      let ins = List.mapi (fun i is_in -> if is_in then Some i else None) ins in
-      (* ins looks like [Some 0, None, Some 2] *)
-      let ins = List.filter Option.is_some ins in
-      (* ins looks like [Some 0, Some 2] *)
-      let ins = List.map Option.get ins in
-      (* ins looks like [0, 2] *)
-      (* if ins is empty then everything is an in *)
-  		let ins = if (List.length ins) > 0 then ins else (List.mapi (fun i _ -> i) params) in
-      (params, ins)
 
 %}
 
@@ -299,30 +287,36 @@ spec_annot:
 
 abstract_predicate:
   | ABSTRACT; pure=option(PURE); PREDICATE; pname = IDENTIFIER; LBRACE;
-    params_ins = separated_list(COMMA, pred_params_ins);
+    ins = separated_list(COMMA, pred_param);
+    SCOLON;
+    outs = separated_list(COMMA, pred_param);
     RBRACE;
     {
-      let (params, pred_ins) = process_pred_params params_ins in
+      let params = ins @ outs in
+      let ins_number = List.length ins in
       CAbsPred. {
         pure = Option.is_some(pure);
         name = pname;
         params;
-        ins = pred_ins;
+        ins_number;
       }
     }
 
 predicate:
   | pure=option(PURE); PREDICATE; no_unfold=option(NOUNFOLD); pname = IDENTIFIER; LBRACE;
-    params_ins = separated_list(COMMA, pred_params_ins);
+    ins = separated_list(COMMA, pred_param);
+    SCOLON;
+    outs = separated_list(COMMA, pred_param);
     RBRACE; LCBRACE;
     defs = separated_nonempty_list(SCOLON, pred_definition);
     RCBRACE;
     {
-      let (params, pred_ins) = process_pred_params params_ins in
+      let params = ins @ outs in
+      let ins_number = List.length ins in
       CPred.{
         name = pname;
-        params = params;
-        ins = pred_ins;
+        params;
+        ins_number;
         definitions = defs;
         no_unfold = Option.is_some(no_unfold);
         pure = Option.is_some(pure);
@@ -342,10 +336,9 @@ existentials:
   | COLON; lvs = separated_nonempty_list(COMMA, lvar_with_gil_type); { lvs }
 
 
-pred_params_ins:
-  | inp = option(PLUS); x = IDENTIFIER; typ = option(with_gil_type)
-    { let isin = Option.is_some inp in
-      ((x, typ), isin) }
+pred_param:
+  | x = IDENTIFIER; typ = option(with_gil_type)
+    { (x, typ) }
 
 typ:
   | INT16T { Chunk.U16 }

--- a/Gillian-C2/lib/compiler/c2_lprog.ml
+++ b/Gillian-C2/lib/compiler/c2_lprog.ml
@@ -329,23 +329,23 @@ module CAbsPred = struct
     pure : bool;
     name : string;
     params : (string * GilType.t option) list;
-    ins : int list;
+    ins_number : int;
   }
 
-  let pp_params fmt (params, ins) =
+  (* Prints params as [in1, ..., ink; out1, ..., outm] *)
+  let pp_params fmt (params, ins_number) =
     let pp_typ_opt f = function
       | None -> ()
       | Some t -> Format.fprintf f ": %s" (GilType.str t)
     in
-    let plus f k = if List.mem k ins then Format.fprintf f "+" else () in
-    let rec aux k = function
+    let pp_param f (a, typ) = Fmt.pf f "%s%a" a pp_typ_opt typ in
+    let ins = List.filteri (fun i _ -> i < ins_number) params in
+    let outs = List.filteri (fun i _ -> i >= ins_number) params in
+    let pp_outs f = function
       | [] -> ()
-      | [ (a, typ) ] -> Format.fprintf fmt "%a%s%a" plus k a pp_typ_opt typ
-      | (a, typ) :: r ->
-          Format.fprintf fmt "%a%s%a, " plus k a pp_typ_opt typ;
-          aux (k + 1) r
+      | outs -> Fmt.pf f " %a" Fmt.(list ~sep:(any ", ") pp_param) outs
     in
-    aux 0 params
+    Fmt.pf fmt "%a;%a" Fmt.(list ~sep:(any ", ") pp_param) ins pp_outs outs
 
   let pp fmt pred =
     let pp_pure f = function
@@ -353,7 +353,7 @@ module CAbsPred = struct
       | false -> ()
     in
     Fmt.pf fmt "abstract %apred %s(%a)" pp_pure pred.pure pred.name pp_params
-      (pred.params, pred.ins)
+      (pred.params, pred.ins_number)
 end
 
 module CPred = struct
@@ -362,24 +362,24 @@ module CPred = struct
     name : string;
     params : (string * GilType.t option) list;
     definitions : (assert_annot option * CAssert.t) list;
-    ins : int list;
+    ins_number : int;
     no_unfold : bool;
   }
 
-  let pp_params fmt (params, ins) =
+  (* Prints params as [in1, ..., ink; out1, ..., outm] *)
+  let pp_params fmt (params, ins_number) =
     let pp_typ_opt f = function
       | None -> ()
       | Some t -> Format.fprintf f ": %s" (GilType.str t)
     in
-    let plus f k = if List.mem k ins then Format.fprintf f "+" else () in
-    let rec aux k = function
+    let pp_param f (a, typ) = Fmt.pf f "%s%a" a pp_typ_opt typ in
+    let ins = List.filteri (fun i _ -> i < ins_number) params in
+    let outs = List.filteri (fun i _ -> i >= ins_number) params in
+    let pp_outs f = function
       | [] -> ()
-      | [ (a, typ) ] -> Format.fprintf fmt "%a%s%a" plus k a pp_typ_opt typ
-      | (a, typ) :: r ->
-          Format.fprintf fmt "%a%s%a, " plus k a pp_typ_opt typ;
-          aux (k + 1) r
+      | outs -> Fmt.pf f " %a" Fmt.(list ~sep:(any ", ") pp_param) outs
     in
-    aux 0 params
+    Fmt.pf fmt "%a;%a" Fmt.(list ~sep:(any ", ") pp_param) ins pp_outs outs
 
   let pp_def fmt (da, a) =
     Format.fprintf fmt "%a%a"
@@ -394,7 +394,8 @@ module CPred = struct
     Format.fprintf fmt "@[<v 2>%apred %s %s(%a) {@\n%a@]@\n}" pp_pure pred.pure
       pred.name
       (if pred.no_unfold then "nounfold" else "")
-      pp_params (pred.params, pred.ins)
+      pp_params
+      (pred.params, pred.ins_number)
       (pp_list ~sep:(Fmt.any ";@\n") pp_def)
       pred.definitions
 end

--- a/Gillian-C2/lib/compiler/c2_lprog.ml
+++ b/Gillian-C2/lib/compiler/c2_lprog.ml
@@ -379,9 +379,9 @@ module CPred = struct
     let outs = List.filteri (fun i _ -> i >= ins_number) params in
     let pp_outs f = function
       | [] -> ()
-      | outs -> Fmt.pf f " %a" Fmt.(list ~sep:(any ", ") pp_param) outs
+      | outs -> Fmt.pf f "; %a" Fmt.(list ~sep:(any ", ") pp_param) outs
     in
-    Fmt.pf fmt "%a;%a" Fmt.(list ~sep:(any ", ") pp_param) ins pp_outs outs
+    Fmt.pf fmt "%a%a" Fmt.(list ~sep:(any ", ") pp_param) ins pp_outs outs
 
   let pp_def fmt (da, a) =
     Format.fprintf fmt "%a%a"

--- a/Gillian-C2/lib/compiler/c2_lprog.ml
+++ b/Gillian-C2/lib/compiler/c2_lprog.ml
@@ -226,7 +226,7 @@ module CAssert = struct
         constr : CConstructor.t;
         typ : points_to_type;
       }
-    | Pred of string * CExpr.t list
+    | Pred of string * CExpr.t list * CExpr.t list
     | Emp
 
   let rec pp fmt a =
@@ -251,7 +251,9 @@ module CAssert = struct
         in
         Format.fprintf fmt "(%a -%s> %a)" CExpr.pp ptr (string_of_typ typ)
           CConstructor.pp constr
-    | Pred (s, el) -> Format.fprintf fmt "%s(%a)" s (pp_list CExpr.pp) el
+    | Pred (s, ins, outs) ->
+        Format.fprintf fmt "%s(%a; %a)" s (pp_list CExpr.pp) ins
+          (pp_list CExpr.pp) outs
     | Emp -> Format.fprintf fmt "emp"
 end
 

--- a/Gillian-C2/lib/compiler/constr.ml
+++ b/Gillian-C2/lib/compiler/constr.ml
@@ -34,26 +34,29 @@ end
 module Others = struct
   open Constants
 
-  let pred name params = Asrt.Pred (name, params)
+  (* The in/out split must match the runtime predicate definitions, since the
+     engine trusts the split carried by the assertion. *)
+  let pred name ins outs = Asrt.Pred (name, ins, outs)
+  let pred_in name ins = Asrt.Pred (name, ins, [])
 
   let malloced_abst ~ptr ~total_size =
-    pred Internal_Predicates.malloced [ ptr; total_size ]
+    pred Internal_Predicates.malloced [ ptr ] [ total_size ]
 
   let malloced ~ptr ~total_size =
     let loc, ofs = ptr in
     let size = Expr.int_z total_size in
-    pred Internal_Predicates.malloced [ Expr.list [ loc; ofs ]; size ]
+    pred Internal_Predicates.malloced [ Expr.list [ loc; ofs ] ] [ size ]
 
   let zeros_ptr_size ~ptr ~size =
-    pred Internal_Predicates.zeros_ptr_size [ ptr; size ]
+    pred_in Internal_Predicates.zeros_ptr_size [ ptr; size ]
 
   let undefs_ptr_size ~ptr ~size =
-    pred Internal_Predicates.undefs_ptr_size [ ptr; size ]
+    pred_in Internal_Predicates.undefs_ptr_size [ ptr; size ]
 
   let array_ptr ~ptr ~chunk ~size ~content =
     let chunk_str = Expr.string (Chunk.to_string chunk) in
-    pred Internal_Predicates.array_ptr [ ptr; size; chunk_str; content ]
+    pred Internal_Predicates.array_ptr [ ptr; size; chunk_str ] [ content ]
 
   let ptr_add ~ptr ~to_add ~res =
-    pred Internal_Predicates.ptr_add [ ptr; to_add; res ]
+    pred Internal_Predicates.ptr_add [ ptr; to_add ] [ res ]
 end

--- a/Gillian-C2/lib/compiler/gil_logic_gen.ml
+++ b/Gillian-C2/lib/compiler/gil_logic_gen.ml
@@ -129,8 +129,8 @@ let convert_struct_field
             ([], 0) components
         in
         let field_arg_list = pvmember#==(Expr.list field_args) in
-        let args = pvloc :: ofs :: field_args in
-        let pred_call = Asrt.Pred (pred_name, args) in
+        (* Struct predicates have the location and offset as their two ins. *)
+        let pred_call = Asrt.Pred (pred_name, [ pvloc; ofs ], field_args) in
         (Some GilType.ListType, [ field_arg_list; pred_call ])
     | Array (type_', len) ->
         let chunk =
@@ -165,14 +165,14 @@ let convert_struct_field
                     | I_ssize_t -> is_ssize_t
                     | I_bool -> is_bool
                   in
-                  let asrt = Asrt.Pred (pred, [ pvmember ]) in
+                  let asrt = Asrt.Pred (pred, [ pvmember ], []) in
                   Some (Some IntType, [ asrt ])
               | Signedbv _ | Unsignedbv _ | Enum _ | EnumTag _ ->
                   Some (Some IntType, [])
               | Double | Float -> Some (Some NumberType, [])
               | Pointer _ ->
                   let is_ptr_asrt =
-                    Asrt.Pred (Internal_Predicates.is_ptr, [ pvmember ])
+                    Asrt.Pred (Internal_Predicates.is_ptr, [ pvmember ], [])
                   in
                   Some (Some ListType, [ is_ptr_asrt ])
               | _ -> None
@@ -412,7 +412,9 @@ let trans_constr ~(ctx : Ctx.t) ~(typ : CAssert.points_to_type) ~pvar_map s c =
   let gen_ofs_var () = Expr.LVar (fresh_lvar ()) in
   let te = trans_expr ~pvar_map in
   let tse = trans_simpl_expr ~pvar_map in
-  let ptr_call p l o = Asrt.Pred (Internal_Predicates.ptr_get, [ p; l; o ]) in
+  let ptr_call p l o =
+    Asrt.Pred (Internal_Predicates.ptr_get, [ p ], [ l; o ])
+  in
   let sz x = CSVal.size_of ~ctx x |> Z.of_int in
   let interpret_s ~typ s =
     match typ with
@@ -489,7 +491,7 @@ let trans_constr ~(ctx : Ctx.t) ~(typ : CAssert.points_to_type) ~pvar_map s c =
       in
       let more_asrt, _, params_fields = split3_expr_comp (List.map te el) in
       let pr =
-        Asrt.Pred (struct_pred, [ locv; ofsv ] @ params_fields) :: more_asrt
+        Asrt.Pred (struct_pred, [ locv; ofsv ], params_fields) :: more_asrt
       in
       pr @ to_assert @ [ malloc_chunk size ]
 
@@ -531,9 +533,10 @@ let rec trans_asrt ~ctx ~pvar_map asrt =
     | Pure f ->
         let ma, _, fp = trans_form ~pvar_map f in
         Pure fp :: ma
-    | Pred (p, cel) ->
-        let ap, _, gel = split3_expr_comp (List.map te cel) in
-        Pred (p, gel) :: ap
+    | Pred (p, c_ins, c_outs) ->
+        let ap_in, _, g_ins = split3_expr_comp (List.map te c_ins) in
+        let ap_out, _, g_outs = split3_expr_comp (List.map te c_outs) in
+        Pred (p, g_ins, g_outs) :: (ap_in @ ap_out)
     | Emp -> [ Asrt.Emp ]
     | PointsTo { ptr = s; constr = c; typ } ->
         trans_constr ~pvar_map ~ctx ~typ s c
@@ -681,7 +684,7 @@ let get_param_typasrt param =
     | _ -> None
   in
   match (pred, param.identifier) with
-  | Some pred, Some id -> Some (Asrt.Pred (pred, [ PVar id ]))
+  | Some pred, Some id -> Some (Asrt.Pred (pred, [ PVar id ], []))
   | _ -> None
 
 let trans_sspec ~ctx ~pvar_map ~params sspecs =
@@ -842,7 +845,7 @@ module Machine_preds = struct
       let perm = Expr.string Perm.(to_string Freeable) in
       Asrt.
         [
-          Pred (Internal_Predicates.ptr_get, [ PVar "p"; l; Expr.zero_i ]);
+          Pred (Internal_Predicates.ptr_get, [ PVar "p" ], [ l; Expr.zero_i ]);
           CorePred
             ( LActions.(str_ga Single),
               [ l; start; chunk ],

--- a/Gillian-C2/lib/compiler/gil_logic_gen.ml
+++ b/Gillian-C2/lib/compiler/gil_logic_gen.ml
@@ -209,7 +209,8 @@ let convert_struct_param ~ctx ~offset ~struct_name = function
 
 let gen_pred_of_struct ctx ann struct_name =
   let pred_name = pred_name_of_struct struct_name in
-  let pred_ins = [ 0; 1 ] in
+  (* The location and offset (the first two parameters) are the ins *)
+  let ins_number = 2 in
   let components =
     let struct_tag = "tag-" ^ struct_name in
     Ctx.resolve_struct_components ctx (Ctx.tag_lookup ctx struct_tag)
@@ -237,7 +238,7 @@ let gen_pred_of_struct ctx ann struct_name =
         pred_source_path = None;
         pred_loc = None;
         pred_internal = true;
-        pred_ins;
+        ins_number;
         pred_num_params;
         pred_params;
         pred_facts = [ (* FIXME: there are probably some facts to get *) ];
@@ -596,12 +597,8 @@ let trans_asrt_annot da =
 
 let trans_abs_pred ~filepath cl_pred =
   let CAbsPred.
-        {
-          name = pred_name;
-          params = pred_params;
-          ins = pred_ins;
-          pure = pred_pure;
-        } =
+        { name = pred_name; params = pred_params; ins_number; pure = pred_pure }
+      =
     cl_pred
   in
   let pred_num_params = List.length pred_params in
@@ -613,7 +610,7 @@ let trans_abs_pred ~filepath cl_pred =
       pred_internal = false;
       pred_num_params;
       pred_params;
-      pred_ins;
+      ins_number;
       pred_definitions = [];
       pred_facts = [];
       pred_guard = None;
@@ -630,7 +627,7 @@ let trans_pred ~ctx ~pvar_map ~filepath cl_pred =
           name = pred_name;
           params = pred_params;
           definitions;
-          ins = pred_ins;
+          ins_number;
           no_unfold;
           pure = pred_pure;
         } =
@@ -655,7 +652,7 @@ let trans_pred ~ctx ~pvar_map ~filepath cl_pred =
       pred_internal = false;
       pred_num_params;
       pred_params;
-      pred_ins;
+      ins_number;
       pred_definitions;
       (* FIXME: ADD SUPPORT FOR FACTS *)
       pred_facts = [];
@@ -787,11 +784,11 @@ let add_trans_lemma ~ctx ~pvar_map filepath ann cl_lemma =
 
 module Machine_preds = struct
   let mk_pred pred_name params def =
-    let ins = ref [] in
+    let ins_number = ref 0 in
     let pred_params =
       params
-      |> List.mapi (fun i (p, ty, is_in) ->
-             let () = if is_in then ins := i :: !ins in
+      |> List.map (fun (p, ty, is_in) ->
+             let () = if is_in then incr ins_number in
              (p, ty))
     in
     Pred.
@@ -802,7 +799,7 @@ module Machine_preds = struct
         pred_internal = true;
         pred_num_params = List.length params;
         pred_params;
-        pred_ins = List.rev !ins;
+        ins_number = !ins_number;
         pred_definitions = [ (None, def) ];
         pred_facts = [];
         pred_guard = None;

--- a/Gillian-C2/lib/memory_model/predicates.ml
+++ b/Gillian-C2/lib/memory_model/predicates.ml
@@ -35,39 +35,42 @@ end
 module Others = struct
   open Kcommons.Constants
 
-  let pred name params = Asrt.Pred (name, params)
+  (* The in/out split must match the runtime predicate definitions, since the
+     engine trusts the split carried by the assertion. *)
+  let pred name ins outs = Asrt.Pred (name, ins, outs)
+  let pred_in name ins = Asrt.Pred (name, ins, [])
 
   let malloced_abst ~ptr ~total_size =
-    pred Internal_Predicates.malloced [ ptr; total_size ]
+    pred Internal_Predicates.malloced [ ptr ] [ total_size ]
 
   let malloced ~ptr ~total_size =
     let loc, ofs = ptr in
     let size = Expr.int_z total_size in
-    pred Internal_Predicates.malloced [ Expr.list [ loc; ofs ]; size ]
+    pred Internal_Predicates.malloced [ Expr.list [ loc; ofs ] ] [ size ]
 
   let zeros_ptr_size ~ptr ~size =
-    pred Internal_Predicates.zeros_ptr_size [ ptr; size ]
+    pred_in Internal_Predicates.zeros_ptr_size [ ptr; size ]
 
   let undefs_ptr_size ~ptr ~size =
-    pred Internal_Predicates.undefs_ptr_size [ ptr; size ]
+    pred_in Internal_Predicates.undefs_ptr_size [ ptr; size ]
 
   let array_ptr ~ptr ~chunk ~size ~content =
     let chunk_str = Expr.string (Chunk.to_string chunk) in
-    pred Internal_Predicates.array_ptr [ ptr; size; chunk_str; content ]
+    pred Internal_Predicates.array_ptr [ ptr; size; chunk_str ] [ content ]
 
   let ptr_add ~ptr ~to_add ~res =
-    pred Internal_Predicates.ptr_add [ ptr; to_add; res ]
+    pred Internal_Predicates.ptr_add [ ptr; to_add ] [ res ]
 
   let fun_ptr ~ptr ~symb =
-    pred Internal_Predicates.fun_ptr [ Lit (String symb); ptr ]
+    pred_in Internal_Predicates.fun_ptr [ Lit (String symb); ptr ]
 
   let glob_fun ~symb ~fname =
-    pred Internal_Predicates.glob_fun [ Lit (String symb); fname ]
+    pred_in Internal_Predicates.glob_fun [ Lit (String symb); fname ]
 
   let glob_var_unallocated ~symb ~vname =
-    pred Internal_Predicates.glob_var_unallocated [ Expr.string symb; vname ]
+    pred_in Internal_Predicates.glob_var_unallocated [ Expr.string symb; vname ]
 
   let glob_var_unallocated_loc ~symb ~loc ~vname =
-    pred Internal_Predicates.glob_var_unallocated_loc
+    pred_in Internal_Predicates.glob_var_unallocated_loc
       [ Expr.string symb; loc; vname ]
 end

--- a/Gillian-C2/runtime/genv_allocated_functions.gil
+++ b/Gillian-C2/runtime/genv_allocated_functions.gil
@@ -1,6 +1,6 @@
 #internal
 
-pred i__glob_fun(symb:Str, fname:Str;):
+pred i__glob_fun(symb:Str, fname:Str):
   <genv_symb>(symb; #l) * types(#l: Obj) *
   <genv_def>(#l; {{ "function", fname }}) *
   <mem_hole>(#l, 0i, 1i; "Nonempty");

--- a/Gillian-C2/runtime/genv_allocated_functions.gil
+++ b/Gillian-C2/runtime/genv_allocated_functions.gil
@@ -1,6 +1,6 @@
 #internal
 
-pred i__glob_fun(+symb:Str, +fname:Str):
+pred i__glob_fun(symb:Str, fname:Str;):
   <genv_symb>(symb; #l) * types(#l: Obj) *
   <genv_def>(#l; {{ "function", fname }}) *
   <mem_hole>(#l, 0i, 1i; "Nonempty");

--- a/Gillian-C2/runtime/genv_unallocated_functions.gil
+++ b/Gillian-C2/runtime/genv_unallocated_functions.gil
@@ -1,5 +1,5 @@
 #internal
 
-pred i__glob_fun(symb, fname;):
+pred i__glob_fun(symb, fname):
   <genv_symb>(symb; #l) *
   <genv_def>(#l; {{ "function", fname }});

--- a/Gillian-C2/runtime/genv_unallocated_functions.gil
+++ b/Gillian-C2/runtime/genv_unallocated_functions.gil
@@ -1,5 +1,5 @@
 #internal
 
-pred i__glob_fun(+symb, +fname):
+pred i__glob_fun(symb, fname;):
   <genv_symb>(symb; #l) *
   <genv_def>(#l; {{ "function", fname }});

--- a/Gillian-C2/runtime/logic_common.gil
+++ b/Gillian-C2/runtime/logic_common.gil
@@ -1,9 +1,9 @@
 #internal
 
-pred i__is_ptr (e: List):
+pred i__is_ptr (e: List;):
   (e == {{ #loc, #ofs }}) * (0i i<=# #ofs) *
   types(#loc : Obj, #ofs : Int);
 
-pred i__ptr (+e: List, l: Obj, o: Int):
+pred i__ptr (e: List; l: Obj, o: Int):
   (e == {{ l, o }}) * (0i i<=# o);
 

--- a/Gillian-C2/runtime/logic_common.gil
+++ b/Gillian-C2/runtime/logic_common.gil
@@ -1,6 +1,6 @@
 #internal
 
-pred i__is_ptr (e: List;):
+pred i__is_ptr (e: List):
   (e == {{ #loc, #ofs }}) * (0i i<=# #ofs) *
   types(#loc : Obj, #ofs : Int);
 

--- a/Gillian-JS/Examples/Amazon/AmazonLogic.jsil
+++ b/Gillian-JS/Examples/Amazon/AmazonLogic.jsil
@@ -7,18 +7,18 @@
  *************************************)
 
 (* Object properties as a table *)
-pred ObjectTableStructure(l:Obj, PVPairs:List;) :
+pred ObjectTableStructure(l:Obj, PVPairs:List) :
     (* Base case - no properties left *)
     (PVPairs == {{ }}),
 
     (* Recursive case - one property and the rest *)
     (PVPairs == {{ #prop, #value }} :: #restPVPairs) *
     DataProp(l, #prop; #value) * types(#value : Str) *
-    ObjectTableStructure(l, #restPVPairs;);
+    ObjectTableStructure(l, #restPVPairs);
 
 (* Complete Object-as-Table predicate *)
-nounfold pred ObjectTable(l:Obj, PVPairs:List;) :
-    ObjectTableStructure(l, PVPairs;) *
+nounfold pred ObjectTable(l:Obj, PVPairs:List) :
+    ObjectTableStructure(l, PVPairs) *
     FirstProj(PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet);
@@ -26,14 +26,14 @@ nounfold pred ObjectTable(l:Obj, PVPairs:List;) :
 (* Object-as-Table absent property *)
 lemma ObjectTableAbsentProperty(l, PVPairs, prop)
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     FirstProj(#PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet) *
     (! (#prop --e-- #pSet))
 ]]
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     ((#l, #prop) -> none) *
     empty_fields(#l : -u- (#pSet, -{ #prop }-))
 ]]
@@ -55,14 +55,14 @@ pred RemoveProp(PVPairs : List, prop : Str; found : Bool, value : Str, newPairs 
 (* Object-as-Table present property *)
 lemma ObjectTablePresentProperty(l, PVPairs, prop)
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     FirstProj(#PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     (#prop --e-- #pSet)
 ]]
 [[
     RemoveProp(#PVPairs, #prop; true, #value, #newPairs) *
-    ObjectTableStructure(#l, #newPairs;) *
+    ObjectTableStructure(#l, #newPairs) *
     DataProp(#l, #prop; #value) * types(#value : Str)
 ]]
 [*
@@ -72,7 +72,7 @@ lemma ObjectTablePresentProperty(l, PVPairs, prop)
         unfold ListToSet(#pList, #pSet)
     } else {
         sep_assert (#PVPairs == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (ObjectTableStructure(#l, #restPVPairs;));
+        sep_assert (ObjectTableStructure(#l, #restPVPairs));
         if (not (#fProp = #prop)) then {
             unfold FirstProj(#PVPairs, #pList);
             unfold ListToSet(#pList, #pSet);
@@ -84,20 +84,20 @@ lemma ObjectTablePresentProperty(l, PVPairs, prop)
 (* Appending property to Object-as-Table structure from the right *)
 lemma ObjectTableStructureAppendPVPair(l, PVPairs, prop, value)
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     FirstProj(#PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     (! (#prop --e-- #pSet)) *
     DataProp(#l, #prop; #value) * types(#value : Str)
 ]]
 [[
-    ObjectTableStructure(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }});)
+    ObjectTableStructure(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }}))
 ]]
 [*
     unfold ObjectTableStructure(#l, #PVPairs);
     if (not (#PVPairs = {{ }})) then {
         sep_assert (#PVPairs == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (ObjectTableStructure(#l, #restPVPairs;));
+        sep_assert (ObjectTableStructure(#l, #restPVPairs));
         unfold FirstProj(#PVPairs, #pList);
         unfold ListToSet(#pList, #pSet);
         apply ObjectTableStructureAppendPVPair(#l, #restPVPairs, #prop, #value);
@@ -108,7 +108,7 @@ lemma ObjectTableStructureAppendPVPair(l, PVPairs, prop, value)
 (* Appending property to Object-as-Table from the right *)
 lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     FirstProj(#PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     (! (#prop --e-- #pSet)) *
@@ -116,7 +116,7 @@ lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
     empty_fields(l : -u- (#pSet, -{ #prop }-))
 ]]
 [[
-    ObjectTable(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }});)
+    ObjectTable(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }}))
 ]]
 [*
     apply FirstProjAppendPair(#PVPairs, #pList, #prop, #value);
@@ -125,18 +125,18 @@ lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
  *]
 
 (* Frozen object properties *)
-pred FrozenObjectTableStructure(l:Obj, PVPairs:List;) :
+pred FrozenObjectTableStructure(l:Obj, PVPairs:List) :
     (* Base case - no properties left *)
     (PVPairs == {{ }}),
 
     (* Recursive case - one property and the rest *)
     (PVPairs == {{ #prop, #value }} :: #restPVPairs) *
     DataPropConst(l, #prop; #value, true) *
-    FrozenObjectTableStructure(l, #restPVPairs;);
+    FrozenObjectTableStructure(l, #restPVPairs);
 
 (* Frozen Object-as-Table predicate *)
-nounfold pred FrozenObjectTable(l:Obj, PVPairs:List;) :
-    FrozenObjectTableStructure(l, PVPairs;) *
+nounfold pred FrozenObjectTable(l:Obj, PVPairs:List) :
+    FrozenObjectTableStructure(l, PVPairs) *
     FirstProj(PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet);
@@ -151,16 +151,16 @@ nounfold pred FrozenObjectTable(l:Obj, PVPairs:List;) :
  ******************************)
 
 (* Live decoded encryption context *)
-pred LiveDecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
+pred LiveDecodedEncryptionContext(dECObj : Obj, ECKs : List) :
     JSObjWithProto(dECObj; null) *
     toUtf8PairMap(ECKs; #utf8ECKs) *
-    ObjectTable(dECObj, #utf8ECKs;);
+    ObjectTable(dECObj, #utf8ECKs);
 
 (* Decoded encryption context *)
-pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
+pred DecodedEncryptionContext(dECObj : Obj, ECKs : List) :
     JSObjGeneral(dECObj; null, "Object", false) *
     toUtf8PairMap(ECKs; #utf8ECKs) *
-    FrozenObjectTable(dECObj, #utf8ECKs;);
+    FrozenObjectTable(dECObj, #utf8ECKs);
 
 (*****************************
  *****************************
@@ -174,7 +174,7 @@ pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
 (***** EDK objects *****)
 
 (* Prototype of EDK objects *)
-pred EDKPrototype (;) :
+pred EDKPrototype () :
     JSObjGeneral($l_edk_proto; null, "Object", false) *
     empty_fields($l_edk_proto: -{ }-);
 
@@ -224,12 +224,12 @@ pred FrozenArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
 
 (* EDKs are first deserialised into a live array *)
 pred LiveDeserialisedEncryptedDataKeys (a:Obj; EDKs:List) :
-    ArrayStructure(a, l-len EDKs;) *
+    ArrayStructure(a, l-len EDKs) *
     ArrayOfDEDKsContents(a, 0; EDKs);
 
 (* Deserialised EDKs are ultimately provided as a frozen array *)
 pred DeserialisedEncryptedDataKeys (a:Obj; contents:List) :
-    FrozenArrayStructure(a, l-len contents;) *
+    FrozenArrayStructure(a, l-len contents) *
     FrozenArrayOfDEDKsContents(a, 0; contents);
 
 (***************************
@@ -243,7 +243,7 @@ pred DeserialisedEncryptedDataKeys (a:Obj; contents:List) :
 
 (* Deserialised main part of the message header *)
 nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
-    JSObject(messageHeader;) *
+    JSObject(messageHeader) *
     DataProp(messageHeader, "version"; version) *
     DataProp(messageHeader, "type"; type) *
     DataProp(messageHeader, "suiteId"; suiteId) *
@@ -251,7 +251,7 @@ nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, message
         Uint8Array(#ui8aMessageId; #abMessageId, 0, 16) *
         ArrayBuffer(#abMessageId; messageId) *
     DataProp(messageHeader, "encryptionContext"; #dECObj) *
-        DecodedEncryptionContext(#dECObj, ECKs;) *
+        DecodedEncryptionContext(#dECObj, ECKs) *
     DataProp(messageHeader, "encryptedDataKeys"; #dEDKs) *
         DeserialisedEncryptedDataKeys(#dEDKs; EDKs) *
     DataProp(messageHeader, "contentType"; contentType) *
@@ -261,7 +261,7 @@ nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, message
 (* Entire deserialised header *)
 nounfold pred HeaderInfo(headerInfo, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
                             frameLength, headerLength, rawHeaderData, headerIv, headerAuthTag) :
-    JSObject(headerInfo;) *
+    JSObject(headerInfo) *
     DataProp(headerInfo, "messageHeader"; #messageHeader) *
         MessageHeader(#messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) *
     DataProp(headerInfo, "headerLength"; headerLength) *
@@ -320,11 +320,11 @@ normal;
 [[
     (l == #l) *
     JSObjGeneral(#l; #proto, #class, #ext) *
-    ObjectTable(#l, #PVPairs;)
+    ObjectTable(#l, #PVPairs)
 ]]
 [[
     JSObjGeneral(#l; #proto, #class, false) *
-    FrozenObjectTable(#l, #PVPairs;)
+    FrozenObjectTable(#l, #PVPairs)
 ]]
 normal
 

--- a/Gillian-JS/Examples/Amazon/AmazonLogic.jsil
+++ b/Gillian-JS/Examples/Amazon/AmazonLogic.jsil
@@ -13,27 +13,27 @@ pred ObjectTableStructure(l:Obj, PVPairs:List;) :
 
     (* Recursive case - one property and the rest *)
     (PVPairs == {{ #prop, #value }} :: #restPVPairs) *
-    DataProp(l, #prop, #value) * types(#value : Str) *
-    ObjectTableStructure(l, #restPVPairs);
+    DataProp(l, #prop; #value) * types(#value : Str) *
+    ObjectTableStructure(l, #restPVPairs;);
 
 (* Complete Object-as-Table predicate *)
 nounfold pred ObjectTable(l:Obj, PVPairs:List;) :
-    ObjectTableStructure(l, PVPairs) *
-    FirstProj(PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(l, PVPairs;) *
+    FirstProj(PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet);
 
 (* Object-as-Table absent property *)
 lemma ObjectTableAbsentProperty(l, PVPairs, prop)
 [[
-    ObjectTableStructure(#l, #PVPairs) *
-    FirstProj(#PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(#l, #PVPairs;) *
+    FirstProj(#PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet) *
     (! (#prop --e-- #pSet))
 ]]
 [[
-    ObjectTableStructure(#l, #PVPairs) *
+    ObjectTableStructure(#l, #PVPairs;) *
     ((#l, #prop) -> none) *
     empty_fields(#l : -u- (#pSet, -{ #prop }-))
 ]]
@@ -45,25 +45,25 @@ pred RemoveProp(PVPairs : List, prop : Str; found : Bool, value : Str, newPairs 
     (PVPairs == {{ prop, value }} :: newPairs) * (found == true),
 
     (PVPairs == {{ #fstProp, #fstValue }} :: #restPVPairs) *
-    (! (#fstProp == prop)) * RemoveProp(#restPVPairs, prop, false, value, newPairs) *
+    (! (#fstProp == prop)) * RemoveProp(#restPVPairs, prop; false, value, newPairs) *
     (found == false),
 
     (PVPairs == {{ #fstProp, #fstValue }} :: #restPVPairs) *
-    (! (#fstProp == prop)) * RemoveProp(#restPVPairs, prop, true, value, #restNewPairs) *
+    (! (#fstProp == prop)) * RemoveProp(#restPVPairs, prop; true, value, #restNewPairs) *
     (found == true) * (newPairs == {{ #fstProp, #fstValue }} :: #restNewPairs);
 
 (* Object-as-Table present property *)
 lemma ObjectTablePresentProperty(l, PVPairs, prop)
 [[
-    ObjectTableStructure(#l, #PVPairs) *
-    FirstProj(#PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(#l, #PVPairs;) *
+    FirstProj(#PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     (#prop --e-- #pSet)
 ]]
 [[
-    RemoveProp(#PVPairs, #prop, true, #value, #newPairs) *
-    ObjectTableStructure(#l, #newPairs) *
-    DataProp(#l, #prop, #value) * types(#value : Str)
+    RemoveProp(#PVPairs, #prop; true, #value, #newPairs) *
+    ObjectTableStructure(#l, #newPairs;) *
+    DataProp(#l, #prop; #value) * types(#value : Str)
 ]]
 [*
     unfold ObjectTableStructure(#l, #PVPairs);
@@ -72,7 +72,7 @@ lemma ObjectTablePresentProperty(l, PVPairs, prop)
         unfold ListToSet(#pList, #pSet)
     } else {
         sep_assert (#PVPairs == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (ObjectTableStructure(#l, #restPVPairs));
+        sep_assert (ObjectTableStructure(#l, #restPVPairs;));
         if (not (#fProp = #prop)) then {
             unfold FirstProj(#PVPairs, #pList);
             unfold ListToSet(#pList, #pSet);
@@ -84,20 +84,20 @@ lemma ObjectTablePresentProperty(l, PVPairs, prop)
 (* Appending property to Object-as-Table structure from the right *)
 lemma ObjectTableStructureAppendPVPair(l, PVPairs, prop, value)
 [[
-    ObjectTableStructure(#l, #PVPairs) *
-    FirstProj(#PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(#l, #PVPairs;) *
+    FirstProj(#PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     (! (#prop --e-- #pSet)) *
-    DataProp(#l, #prop, #value) * types(#value : Str)
+    DataProp(#l, #prop; #value) * types(#value : Str)
 ]]
 [[
-    ObjectTableStructure(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }}))
+    ObjectTableStructure(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }});)
 ]]
 [*
     unfold ObjectTableStructure(#l, #PVPairs);
     if (not (#PVPairs = {{ }})) then {
         sep_assert (#PVPairs == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (ObjectTableStructure(#l, #restPVPairs));
+        sep_assert (ObjectTableStructure(#l, #restPVPairs;));
         unfold FirstProj(#PVPairs, #pList);
         unfold ListToSet(#pList, #pSet);
         apply ObjectTableStructureAppendPVPair(#l, #restPVPairs, #prop, #value);
@@ -108,15 +108,15 @@ lemma ObjectTableStructureAppendPVPair(l, PVPairs, prop, value)
 (* Appending property to Object-as-Table from the right *)
 lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
 [[
-    ObjectTableStructure(#l, #PVPairs) *
-    FirstProj(#PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(#l, #PVPairs;) *
+    FirstProj(#PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     (! (#prop --e-- #pSet)) *
-    DataProp(#l, #prop, #value) * types(#value : Str) *
+    DataProp(#l, #prop; #value) * types(#value : Str) *
     empty_fields(l : -u- (#pSet, -{ #prop }-))
 ]]
 [[
-    ObjectTable(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }}))
+    ObjectTable(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }});)
 ]]
 [*
     apply FirstProjAppendPair(#PVPairs, #pList, #prop, #value);
@@ -131,14 +131,14 @@ pred FrozenObjectTableStructure(l:Obj, PVPairs:List;) :
 
     (* Recursive case - one property and the rest *)
     (PVPairs == {{ #prop, #value }} :: #restPVPairs) *
-    DataPropConst(l, #prop, #value, true) *
-    FrozenObjectTableStructure(l, #restPVPairs);
+    DataPropConst(l, #prop; #value, true) *
+    FrozenObjectTableStructure(l, #restPVPairs;);
 
 (* Frozen Object-as-Table predicate *)
 nounfold pred FrozenObjectTable(l:Obj, PVPairs:List;) :
-    FrozenObjectTableStructure(l, PVPairs) *
-    FirstProj(PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    FrozenObjectTableStructure(l, PVPairs;) *
+    FirstProj(PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet);
 
 (******************************
@@ -152,15 +152,15 @@ nounfold pred FrozenObjectTable(l:Obj, PVPairs:List;) :
 
 (* Live decoded encryption context *)
 pred LiveDecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
-    JSObjWithProto(dECObj, null) *
-    toUtf8PairMap(ECKs, #utf8ECKs) *
-    ObjectTable(dECObj, #utf8ECKs);
+    JSObjWithProto(dECObj; null) *
+    toUtf8PairMap(ECKs; #utf8ECKs) *
+    ObjectTable(dECObj, #utf8ECKs;);
 
 (* Decoded encryption context *)
 pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
-    JSObjGeneral(dECObj, null, "Object", false) *
-    toUtf8PairMap(ECKs, #utf8ECKs) *
-    FrozenObjectTable(dECObj, #utf8ECKs);
+    JSObjGeneral(dECObj; null, "Object", false) *
+    toUtf8PairMap(ECKs; #utf8ECKs) *
+    FrozenObjectTable(dECObj, #utf8ECKs;);
 
 (*****************************
  *****************************
@@ -175,21 +175,21 @@ pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
 
 (* Prototype of EDK objects *)
 pred EDKPrototype (;) :
-    JSObjGeneral($l_edk_proto, null, "Object", false) *
+    JSObjGeneral($l_edk_proto; null, "Object", false) *
     empty_fields($l_edk_proto: -{ }-);
 
 (* EDK objects *)
 nounfold pred EncryptedDataKey(EDK; pId:Str, pInfo:Str, encryptedDataKey:List, rawInfo:List) :
-    JSObjGeneral(EDK, $l_edk_proto, "Object", false) *
-    readOnlyProperty(EDK, "providerId", pId) *
-    readOnlyProperty(EDK, "providerInfo", pInfo) *
-    readOnlyProperty(EDK, "encryptedDataKey", #aEDK) *
-        Uint8Array(#aEDK, #abEDK, 0, #viewSizeEDK) *
-        ArrayBuffer(#abEDK, encryptedDataKey) *
+    JSObjGeneral(EDK; $l_edk_proto, "Object", false) *
+    readOnlyProperty(EDK, "providerId"; pId) *
+    readOnlyProperty(EDK, "providerInfo"; pInfo) *
+    readOnlyProperty(EDK, "encryptedDataKey"; #aEDK) *
+        Uint8Array(#aEDK; #abEDK, 0, #viewSizeEDK) *
+        ArrayBuffer(#abEDK; encryptedDataKey) *
         (#viewSizeEDK == l-len encryptedDataKey) *
-    readOnlyProperty(EDK, "rawInfo", #aRInfo) *
-        Uint8Array(#aRInfo, #abRInfo, 0, #viewSizeRInfo) *
-        ArrayBuffer(#abRInfo, rawInfo) *
+    readOnlyProperty(EDK, "rawInfo"; #aRInfo) *
+        Uint8Array(#aRInfo; #abRInfo, 0, #viewSizeRInfo) *
+        ArrayBuffer(#abRInfo; rawInfo) *
         (#viewSizeRInfo == l-len rawInfo);
 
 (***** Arrays of deserialised EDKs *****)
@@ -199,38 +199,38 @@ pred ArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
-    DataProp(a, #index, #edk) *
-    EncryptedDataKey(#edk, #pId, #pInfo, #encryptedDataKey, #rawInfo) *
-    fromUtf8(#rawId, #pId) * fromUtf8(#pInfo, #rawInfo) *
+    DataProp(a, #index; #edk) *
+    EncryptedDataKey(#edk; #pId, #pInfo, #encryptedDataKey, #rawInfo) *
+    fromUtf8(#rawId; #pId) * fromUtf8(#pInfo; #rawInfo) *
     (#element == {{ #rawId, #rawInfo, #encryptedDataKey }}) *
     (contents == l+ ({{ #element }},  #rest)) *
     (#rest_start == start + 1) *
-    ArrayOfDEDKsContents(a, #rest_start, #rest);
+    ArrayOfDEDKsContents(a, #rest_start; #rest);
 
 (* Frozen array of deserialised EDKs *)
 pred FrozenArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
-    readOnlyProperty(a, #index, #edk) *
-    EncryptedDataKey(#edk, #pId, #pInfo, #encryptedDataKey, #rawInfo) *
-    fromUtf8(#rawId, #pId) * fromUtf8(#pInfo, #rawInfo) *
+    readOnlyProperty(a, #index; #edk) *
+    EncryptedDataKey(#edk; #pId, #pInfo, #encryptedDataKey, #rawInfo) *
+    fromUtf8(#rawId; #pId) * fromUtf8(#pInfo; #rawInfo) *
     (#edk == {{ #rawId, #rawInfo, #encryptedDataKey }}) *
     (contents == l+ ({{ #edk }}, #rest_contents)) *
     (#rest_start == start + 1) *
-    FrozenArrayOfDEDKsContents(a, #rest_start, #rest_contents);
+    FrozenArrayOfDEDKsContents(a, #rest_start; #rest_contents);
 
 (***** Deserialised EDKs *****)
 
 (* EDKs are first deserialised into a live array *)
 pred LiveDeserialisedEncryptedDataKeys (a:Obj; EDKs:List) :
-    ArrayStructure(a, l-len EDKs) *
-    ArrayOfDEDKsContents(a, 0, EDKs);
+    ArrayStructure(a, l-len EDKs;) *
+    ArrayOfDEDKsContents(a, 0; EDKs);
 
 (* Deserialised EDKs are ultimately provided as a frozen array *)
 pred DeserialisedEncryptedDataKeys (a:Obj; contents:List) :
-    FrozenArrayStructure(a, l-len contents) *
-    FrozenArrayOfDEDKsContents(a, 0, contents);
+    FrozenArrayStructure(a, l-len contents;) *
+    FrozenArrayOfDEDKsContents(a, 0; contents);
 
 (***************************
  ***************************
@@ -243,39 +243,39 @@ pred DeserialisedEncryptedDataKeys (a:Obj; contents:List) :
 
 (* Deserialised main part of the message header *)
 nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
-    JSObject(messageHeader) *
-    DataProp(messageHeader, "version", version) *
-    DataProp(messageHeader, "type", type) *
-    DataProp(messageHeader, "suiteId", suiteId) *
-    DataProp(messageHeader, "messageId", #ui8aMessageId) *
-        Uint8Array(#ui8aMessageId, #abMessageId, 0, 16) *
-        ArrayBuffer(#abMessageId, messageId) *
-    DataProp(messageHeader, "encryptionContext", #dECObj) *
-        DecodedEncryptionContext(#dECObj, ECKs) *
-    DataProp(messageHeader, "encryptedDataKeys", #dEDKs) *
-        DeserialisedEncryptedDataKeys(#dEDKs, EDKs) *
-    DataProp(messageHeader, "contentType", contentType) *
-    DataProp(messageHeader, "headerIvLength", headerIvLength) *
-    DataProp(messageHeader, "frameLength", frameLength);
+    JSObject(messageHeader;) *
+    DataProp(messageHeader, "version"; version) *
+    DataProp(messageHeader, "type"; type) *
+    DataProp(messageHeader, "suiteId"; suiteId) *
+    DataProp(messageHeader, "messageId"; #ui8aMessageId) *
+        Uint8Array(#ui8aMessageId; #abMessageId, 0, 16) *
+        ArrayBuffer(#abMessageId; messageId) *
+    DataProp(messageHeader, "encryptionContext"; #dECObj) *
+        DecodedEncryptionContext(#dECObj, ECKs;) *
+    DataProp(messageHeader, "encryptedDataKeys"; #dEDKs) *
+        DeserialisedEncryptedDataKeys(#dEDKs; EDKs) *
+    DataProp(messageHeader, "contentType"; contentType) *
+    DataProp(messageHeader, "headerIvLength"; headerIvLength) *
+    DataProp(messageHeader, "frameLength"; frameLength);
 
 (* Entire deserialised header *)
 nounfold pred HeaderInfo(headerInfo, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
                             frameLength, headerLength, rawHeaderData, headerIv, headerAuthTag) :
-    JSObject(headerInfo) *
-    DataProp(headerInfo, "messageHeader", #messageHeader) *
-        MessageHeader(#messageHeader, ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) *
-    DataProp(headerInfo, "headerLength", headerLength) *
-    DataProp(headerInfo, "algorithmSuite", #algoSuiteObject) *
-        AlgorithmSuiteObject(#algoSuiteObject, headerIvLength, #tagLength) *
-    DataProp(headerInfo, "rawHeader", #rawHeader) *
-        Uint8Array(#rawHeader, #rawBuffer, 0, headerLength) *
-        ArrayBuffer(#rawBuffer, rawHeaderData) *
-    DataProp(headerInfo, "headerIv", #ui8aHeaderIv) *
-        Uint8Array(#ui8aHeaderIv, #abHeaderIv, 0, headerIvLength) *
-        ArrayBuffer(#abHeaderIv, headerIv) *
-    DataProp(headerInfo, "headerAuthTag", #ui8aHeaderAuthTag) *
-        Uint8Array(#ui8aHeaderAuthTag, #abHeaderAuthTag, 0, #tagLength / 8) *
-        ArrayBuffer(#abHeaderAuthTag, headerAuthTag);
+    JSObject(headerInfo;) *
+    DataProp(headerInfo, "messageHeader"; #messageHeader) *
+        MessageHeader(#messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) *
+    DataProp(headerInfo, "headerLength"; headerLength) *
+    DataProp(headerInfo, "algorithmSuite"; #algoSuiteObject) *
+        AlgorithmSuiteObject(#algoSuiteObject; headerIvLength, #tagLength) *
+    DataProp(headerInfo, "rawHeader"; #rawHeader) *
+        Uint8Array(#rawHeader; #rawBuffer, 0, headerLength) *
+        ArrayBuffer(#rawBuffer; rawHeaderData) *
+    DataProp(headerInfo, "headerIv"; #ui8aHeaderIv) *
+        Uint8Array(#ui8aHeaderIv; #abHeaderIv, 0, headerIvLength) *
+        ArrayBuffer(#abHeaderIv; headerIv) *
+    DataProp(headerInfo, "headerAuthTag"; #ui8aHeaderAuthTag) *
+        Uint8Array(#ui8aHeaderAuthTag; #abHeaderAuthTag, 0, #tagLength / 8) *
+        ArrayBuffer(#abHeaderAuthTag; headerAuthTag);
 
 (******************************
  ******************************
@@ -293,13 +293,13 @@ axiomatic incomplete spec AP_map (xsc, vthis, cfun)
 (* Mapping EDKs into the resulting decoded EDK array *)
 [[
     (vthis == #vthis) * (cfun == #cfun) *
-    JSFunctionObject(#cfun, "aux_deserializeEncryptedDataKey", #a_sc, #a_len, #a_proto) *
-    ArrayOfArraysOfUInt8Arrays(#vthis, #EDKs)
+    JSFunctionObject(#cfun; "aux_deserializeEncryptedDataKey", #a_sc, #a_len, #a_proto) *
+    ArrayOfArraysOfUInt8Arrays(#vthis; #EDKs)
 ]]
 [[
-    JSFunctionObject(#cfun, "aux_deserializeEncryptedDataKey", #a_sc, #a_len, #a_proto) *
-    ArrayOfArraysOfUInt8Arrays(#vthis, #EDKs) *
-    types(ret : Obj) * LiveDeserialisedEncryptedDataKeys(ret, #EDKs)
+    JSFunctionObject(#cfun; "aux_deserializeEncryptedDataKey", #a_sc, #a_len, #a_proto) *
+    ArrayOfArraysOfUInt8Arrays(#vthis; #EDKs) *
+    types(ret : Obj) * LiveDeserialisedEncryptedDataKeys(ret; #EDKs)
 ]]
 normal
 
@@ -308,10 +308,10 @@ axiomatic spec Object_freeze(xsc, vthis, l)
 (* Freezing an array of deserialised EDKs *)
 <deserialised_EDKS>
 [[
-    (l == #l) * LiveDeserialisedEncryptedDataKeys(#l, #EDKs)
+    (l == #l) * LiveDeserialisedEncryptedDataKeys(#l; #EDKs)
 ]]
 [[
-    DeserialisedEncryptedDataKeys(#l, #EDKs) * (ret == #l)
+    DeserialisedEncryptedDataKeys(#l; #EDKs) * (ret == #l)
 ]]
 normal;
 
@@ -319,12 +319,12 @@ normal;
 <object_table : #PVPairs>
 [[
     (l == #l) *
-    JSObjGeneral(#l, #proto, #class, #ext) *
-    ObjectTable(#l, #PVPairs)
+    JSObjGeneral(#l; #proto, #class, #ext) *
+    ObjectTable(#l, #PVPairs;)
 ]]
 [[
-    JSObjGeneral(#l, #proto, #class, false) *
-    FrozenObjectTable(#l, #PVPairs)
+    JSObjGeneral(#l; #proto, #class, false) *
+    FrozenObjectTable(#l, #PVPairs;)
 ]]
 normal
 

--- a/Gillian-JS/Examples/Amazon/AmazonLogic.jsil
+++ b/Gillian-JS/Examples/Amazon/AmazonLogic.jsil
@@ -195,7 +195,7 @@ nounfold pred EncryptedDataKey(+EDK, pId:Str, pInfo:Str, encryptedDataKey:List, 
 (***** Arrays of deserialised EDKs *****)
 
 (* Live array of deserialised EDKs *)
-pred ArrayOfDEDKsContents(+a:Obj, contents:List, +start:Num) :
+pred ArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
@@ -205,10 +205,10 @@ pred ArrayOfDEDKsContents(+a:Obj, contents:List, +start:Num) :
     (#element == {{ #rawId, #rawInfo, #encryptedDataKey }}) *
     (contents == l+ ({{ #element }},  #rest)) *
     (#rest_start == start + 1) *
-    ArrayOfDEDKsContents(a, #rest, #rest_start);
+    ArrayOfDEDKsContents(a, #rest_start, #rest);
 
 (* Frozen array of deserialised EDKs *)
-pred FrozenArrayOfDEDKsContents(+a:Obj, contents:List, +start:Num) :
+pred FrozenArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
@@ -218,19 +218,19 @@ pred FrozenArrayOfDEDKsContents(+a:Obj, contents:List, +start:Num) :
     (#edk == {{ #rawId, #rawInfo, #encryptedDataKey }}) *
     (contents == l+ ({{ #edk }}, #rest_contents)) *
     (#rest_start == start + 1) *
-    FrozenArrayOfDEDKsContents(a, #rest_contents, #rest_start);
+    FrozenArrayOfDEDKsContents(a, #rest_start, #rest_contents);
 
 (***** Deserialised EDKs *****)
 
 (* EDKs are first deserialised into a live array *)
 pred LiveDeserialisedEncryptedDataKeys (+a:Obj, EDKs:List) :
     ArrayStructure(a, l-len EDKs) *
-    ArrayOfDEDKsContents(a, EDKs, 0);
+    ArrayOfDEDKsContents(a, 0, EDKs);
 
 (* Deserialised EDKs are ultimately provided as a frozen array *)
 pred DeserialisedEncryptedDataKeys (+a:Obj, contents:List) :
     FrozenArrayStructure(a, l-len contents) *
-    FrozenArrayOfDEDKsContents(a, contents, 0);
+    FrozenArrayOfDEDKsContents(a, 0, contents);
 
 (***************************
  ***************************
@@ -242,7 +242,7 @@ pred DeserialisedEncryptedDataKeys (+a:Obj, contents:List) :
  ***************************)
 
 (* Deserialised main part of the message header *)
-nounfold pred MessageHeader(+messageHeader, version, type, suiteId, messageId, +ECKs, EDKs, contentType, headerIvLength, frameLength) :
+nounfold pred MessageHeader(+messageHeader, +ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
     JSObject(messageHeader) *
     DataProp(messageHeader, "version", version) *
     DataProp(messageHeader, "type", type) *
@@ -259,11 +259,11 @@ nounfold pred MessageHeader(+messageHeader, version, type, suiteId, messageId, +
     DataProp(messageHeader, "frameLength", frameLength);
 
 (* Entire deserialised header *)
-nounfold pred HeaderInfo(+headerInfo, version, type, suiteId, messageId, +ECKs, EDKs, contentType, headerIvLength,
+nounfold pred HeaderInfo(+headerInfo, +ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
                             frameLength, headerLength, rawHeaderData, headerIv, headerAuthTag) :
     JSObject(headerInfo) *
     DataProp(headerInfo, "messageHeader", #messageHeader) *
-        MessageHeader(#messageHeader, version, type, suiteId, messageId, ECKs, EDKs, contentType, headerIvLength, frameLength) *
+        MessageHeader(#messageHeader, ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) *
     DataProp(headerInfo, "headerLength", headerLength) *
     DataProp(headerInfo, "algorithmSuite", #algoSuiteObject) *
         AlgorithmSuiteObject(#algoSuiteObject, headerIvLength, #tagLength) *

--- a/Gillian-JS/Examples/Amazon/AmazonLogic.jsil
+++ b/Gillian-JS/Examples/Amazon/AmazonLogic.jsil
@@ -7,7 +7,7 @@
  *************************************)
 
 (* Object properties as a table *)
-pred ObjectTableStructure(+l:Obj, +PVPairs:List) :
+pred ObjectTableStructure(l:Obj, PVPairs:List;) :
     (* Base case - no properties left *)
     (PVPairs == {{ }}),
 
@@ -17,7 +17,7 @@ pred ObjectTableStructure(+l:Obj, +PVPairs:List) :
     ObjectTableStructure(l, #restPVPairs);
 
 (* Complete Object-as-Table predicate *)
-nounfold pred ObjectTable(+l:Obj, +PVPairs:List) :
+nounfold pred ObjectTable(l:Obj, PVPairs:List;) :
     ObjectTableStructure(l, PVPairs) *
     FirstProj(PVPairs, #pList) *
     ListToSet(#pList, #pSet) *
@@ -39,7 +39,7 @@ lemma ObjectTableAbsentProperty(l, PVPairs, prop)
 ]]
 
 (* Removing a property from a list of prop-value pairs *)
-pred RemoveProp(+PVPairs : List, +prop : Str, found : Bool, value : Str, newPairs : List) :
+pred RemoveProp(PVPairs : List, prop : Str; found : Bool, value : Str, newPairs : List) :
     (PVPairs == {{ }}) * (found == false) * (value == "") * (newPairs == {{ }}),
 
     (PVPairs == {{ prop, value }} :: newPairs) * (found == true),
@@ -125,7 +125,7 @@ lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
  *]
 
 (* Frozen object properties *)
-pred FrozenObjectTableStructure(+l:Obj, +PVPairs:List) :
+pred FrozenObjectTableStructure(l:Obj, PVPairs:List;) :
     (* Base case - no properties left *)
     (PVPairs == {{ }}),
 
@@ -135,7 +135,7 @@ pred FrozenObjectTableStructure(+l:Obj, +PVPairs:List) :
     FrozenObjectTableStructure(l, #restPVPairs);
 
 (* Frozen Object-as-Table predicate *)
-nounfold pred FrozenObjectTable(+l:Obj, +PVPairs:List) :
+nounfold pred FrozenObjectTable(l:Obj, PVPairs:List;) :
     FrozenObjectTableStructure(l, PVPairs) *
     FirstProj(PVPairs, #pList) *
     ListToSet(#pList, #pSet) *
@@ -151,13 +151,13 @@ nounfold pred FrozenObjectTable(+l:Obj, +PVPairs:List) :
  ******************************)
 
 (* Live decoded encryption context *)
-pred LiveDecodedEncryptionContext(+dECObj : Obj, +ECKs : List) :
+pred LiveDecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
     JSObjWithProto(dECObj, null) *
     toUtf8PairMap(ECKs, #utf8ECKs) *
     ObjectTable(dECObj, #utf8ECKs);
 
 (* Decoded encryption context *)
-pred DecodedEncryptionContext(+dECObj : Obj, +ECKs : List) :
+pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
     JSObjGeneral(dECObj, null, "Object", false) *
     toUtf8PairMap(ECKs, #utf8ECKs) *
     FrozenObjectTable(dECObj, #utf8ECKs);
@@ -174,12 +174,12 @@ pred DecodedEncryptionContext(+dECObj : Obj, +ECKs : List) :
 (***** EDK objects *****)
 
 (* Prototype of EDK objects *)
-pred EDKPrototype () :
+pred EDKPrototype (;) :
     JSObjGeneral($l_edk_proto, null, "Object", false) *
     empty_fields($l_edk_proto: -{ }-);
 
 (* EDK objects *)
-nounfold pred EncryptedDataKey(+EDK, pId:Str, pInfo:Str, encryptedDataKey:List, rawInfo:List) :
+nounfold pred EncryptedDataKey(EDK; pId:Str, pInfo:Str, encryptedDataKey:List, rawInfo:List) :
     JSObjGeneral(EDK, $l_edk_proto, "Object", false) *
     readOnlyProperty(EDK, "providerId", pId) *
     readOnlyProperty(EDK, "providerInfo", pInfo) *
@@ -195,7 +195,7 @@ nounfold pred EncryptedDataKey(+EDK, pId:Str, pInfo:Str, encryptedDataKey:List, 
 (***** Arrays of deserialised EDKs *****)
 
 (* Live array of deserialised EDKs *)
-pred ArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
+pred ArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
@@ -208,7 +208,7 @@ pred ArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
     ArrayOfDEDKsContents(a, #rest_start, #rest);
 
 (* Frozen array of deserialised EDKs *)
-pred FrozenArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
+pred FrozenArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
@@ -223,12 +223,12 @@ pred FrozenArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
 (***** Deserialised EDKs *****)
 
 (* EDKs are first deserialised into a live array *)
-pred LiveDeserialisedEncryptedDataKeys (+a:Obj, EDKs:List) :
+pred LiveDeserialisedEncryptedDataKeys (a:Obj; EDKs:List) :
     ArrayStructure(a, l-len EDKs) *
     ArrayOfDEDKsContents(a, 0, EDKs);
 
 (* Deserialised EDKs are ultimately provided as a frozen array *)
-pred DeserialisedEncryptedDataKeys (+a:Obj, contents:List) :
+pred DeserialisedEncryptedDataKeys (a:Obj; contents:List) :
     FrozenArrayStructure(a, l-len contents) *
     FrozenArrayOfDEDKsContents(a, 0, contents);
 
@@ -242,7 +242,7 @@ pred DeserialisedEncryptedDataKeys (+a:Obj, contents:List) :
  ***************************)
 
 (* Deserialised main part of the message header *)
-nounfold pred MessageHeader(+messageHeader, +ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
+nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
     JSObject(messageHeader) *
     DataProp(messageHeader, "version", version) *
     DataProp(messageHeader, "type", type) *
@@ -259,7 +259,7 @@ nounfold pred MessageHeader(+messageHeader, +ECKs, version, type, suiteId, messa
     DataProp(messageHeader, "frameLength", frameLength);
 
 (* Entire deserialised header *)
-nounfold pred HeaderInfo(+headerInfo, +ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
+nounfold pred HeaderInfo(headerInfo, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
                             frameLength, headerLength, rawHeaderData, headerIv, headerAuthTag) :
     JSObject(headerInfo) *
     DataProp(headerInfo, "messageHeader", #messageHeader) *

--- a/Gillian-JS/Examples/Amazon/EncryptionHeaderLogic.gil
+++ b/Gillian-JS/Examples/Amazon/EncryptionHeaderLogic.gil
@@ -358,8 +358,8 @@ pred IElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
 
 (* A general element sequene is either a complete or an incomplete element sequence *)
 @nopath
-nounfold pred Elements(definition : Str, +buffer : List, +readPos : Num,
-                       +eCount : Num, +fCount : Num, eList : List,
+nounfold pred Elements(+buffer : List, +readPos : Num, +eCount : Num,
+                       +fCount : Num, definition : Str, eList : List,
                        esLength : Num) :
   (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
   (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
@@ -370,17 +370,17 @@ nounfold pred Elements(definition : Str, +buffer : List, +readPos : Num,
 lemma PrependCElementsE(definition, buffer, readPos, eCount1, fCount, fList1, esLength1, eCount2, fList2, esLength2)
 [[
     CElements(#buffer, #readPos, #eCount1, #fCount, #fList1, #esLength1) *
-    Elements(#definition, #buffer, #readPos + #esLength1, #eCount2, #fCount, #fList2, #esLength2)
+    Elements(#buffer, #readPos + #esLength1, #eCount2, #fCount, #definition, #fList2, #esLength2)
 ]]
 [[
-    Elements(#definition, #buffer, #readPos, #eCount1 + #eCount2, #fCount, l+ (#fList1, #fList2), #esLength1 + #esLength2)
+    Elements(#buffer, #readPos, #eCount1 + #eCount2, #fCount, #definition, l+ (#fList1, #fList2), #esLength1 + #esLength2)
 ]]
 [*
     unfold CElements(#buffer, #readPos, #eCount1, #fCount, #fList1, #esLength1)
       [bind: (#fList := #element) and (#eLength := #eLength) and (#restElements := #restElements) and (#restESLength := #restLength)] ;
     if (0 < #eCount1) then {
         apply PrependCElementsE(#definition, #buffer, #readPos + #eLength, #eCount1 - 1, #fCount, #restElements, #restESLength, #eCount2, #fList2, #esLength2);
-        unfold Elements(#definition, #buffer, (#eLength + #readPos), ((-1. + #eCount1) + #eCount2), #fCount, l+ (#restElements, #fList2), (#restESLength + #esLength2));
+        unfold Elements(#buffer, (#eLength + #readPos), ((-1. + #eCount1) + #eCount2), #fCount, #definition, l+ (#restElements, #fList2), (#restESLength + #esLength2));
         if (#definition == "Incomplete") then {
             fold IElements(#buffer, #readPos, #eCount1 + #eCount2, #fCount, l+ (#fList1, #fList2), #esLength1 + #esLength2)
         }
@@ -413,7 +413,7 @@ nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Num,
     (0 <=# readPos) * (readPos <=# as_num (l-len buffer)) *
     (#rawEC == l-sub(buffer, as_int readPos, 2i)) *
     rawToUInt16(#rawEC, false, #keyCount) * (0 <# #keyCount) *
-    Elements("Complete", buffer, (readPos + 2), #keyCount, 3, EDKs, #EDKsLength) *
+    Elements(buffer, (readPos + 2), #keyCount, 3, "Complete", EDKs, #EDKsLength) *
     (EDKsLength == (#EDKsLength + 2));
 
 (* Incomplete serialised EDKs *)
@@ -425,12 +425,12 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num) :
   (* Enough data to read the number of EDKs, but not enough data to read the EDKs *)
   (is_int readPos) * (0 <=# readPos) * ((readPos + 2) <=# as_num (l-len buffer)) * (#rawEC == l-sub(buffer, as_int readPos, 2i)) *
     rawToUInt16(#rawEC, false, #keyCount) * (0 <# #keyCount) *
-    Elements("Incomplete", buffer, (readPos + 2), #keyCount, 3, #eList, #esLength);
+    Elements(buffer, (readPos + 2), #keyCount, 3, "Incomplete", #eList, #esLength);
   facts: (is_int readPos);
 
 (* Broken serialised EDKs *)
 @nopath
-nounfold pred BRawEncryptedDataKeys(errorMessage : Str, +buffer : List, +readPos : Num) :
+nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Num, errorMessage : Str) :
   (* Incorrect starting position *)
   (is_int readPos) * ((readPos <# 0) \/ (as_num (l-len buffer) <# readPos)) *
     (errorMessage == "deserializeMessageHeader: startPos out of bounds."),
@@ -444,10 +444,10 @@ nounfold pred BRawEncryptedDataKeys(errorMessage : Str, +buffer : List, +readPos
 
 (* General serialised EDKs *)
 @nopath
-nounfold pred RawEncryptedDataKeys(definition : Str, +buffer : List, +readPos : Num, EDKs : List, EDKsLength : Num, errorMessage : Str) :
+nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Num, definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
   (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
   (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
-  (definition == "Broken") * BRawEncryptedDataKeys(errorMessage, buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0);
+  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
 
 
 (******************************
@@ -474,19 +474,19 @@ nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
   ((l-len buffer) == 0i) * (ECKs == {{  }}),
   (#rawKC == l-sub(buffer, 0i, 2i)) *
     rawToUInt16(#rawKC, false, #keyCount) * (0 <# #keyCount) *
-    Elements("Complete", buffer, 2, #keyCount, 2, ECKs, #ECKsLength) *
+    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) *
     Unique(#ECKeys) * (as_int (2 + #ECKsLength) == (l-len buffer));
 
 (* Broken serialised encryption context *)
 @nopath
-nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:List) :
+nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (2i i<# (l-len buffer)) *
     (#rawKC == l-sub (buffer, 0i, 2i)) *
     rawToUInt16(#rawKC, false, #keyCount) *
     (0 <# #keyCount) * (ECKs == {{ }}) *
-    Elements("Incomplete", buffer, 2, #keyCount, 2, #eList, #esLength) *
+    Elements(buffer, 2, #keyCount, 2, "Incomplete", #eList, #esLength) *
     (errorMessage == "decodeEncryptionContext: Underflow, not enough data."),
 
     (* Too much data provided *)
@@ -494,7 +494,7 @@ nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:List) :
     (#rawKC == l-sub (buffer, 0i, 2i)) *
     rawToUInt16(#rawKC, false, #keyCount) *
     (0 <# #keyCount) *
-    Elements("Complete", buffer, 2, #keyCount, 2, ECKs, #ECKsLength) *
+    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
     (! (as_int (#ECKsLength + 2) == l-len buffer)) *
     (errorMessage == "decodeEncryptionContext: Overflow, too much data."),
 
@@ -503,16 +503,16 @@ nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:List) :
     (#rawKC == l-sub (buffer, 0i, 2i)) *
     rawToUInt16(#rawKC, false, #keyCount) *
     (0 <# #keyCount) *
-    Elements("Complete", buffer, 2, #keyCount, 2, ECKs, #ECKsLength) *
+    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Duplicated({{ }}, #ECKeys) *
     (as_int (2 + #ECKsLength) == l-len buffer) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
 (* General serialised encryption context *)
 @nopath
-pred RawEncryptionContext(definition:Str, +buffer:List, ECKs:List, errorMessage:Str) :
+pred RawEncryptionContext(+buffer:List, definition:Str, ECKs:List, errorMessage:Str) :
   (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
-  (definition == "Broken")   * BRawEncryptionContext(errorMessage, buffer, ECKs);
+  (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
 
 
 (*****************************
@@ -598,7 +598,7 @@ nounfold pred CHeader(+rawHeaderData, part_one, version, type, suiteId,
     ((l-len #EC) == as_int ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rawFrameLength, headerIv, headerAuthTag)) *
-    RawEncryptedDataKeys("Complete", rawHeaderData, (22 + ECLength), EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, (22 + ECLength), "Complete", EDKs, #EDKsLength, _) *
     (as_int #EDKsLength == (l-len #edks)) * ((l-len #rawFrameLength) == 4i) *
     rawToUInt32(#rawFrameLength, false, frameLength) *
     (headerLength == ((((((22 + ECLength) + #EDKsLength) + 1) + 4) + 1) + 4)) *
@@ -656,7 +656,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
 
-    RawEncryptedDataKeys("Incomplete", rawHeaderData, 22 + ECLength, EDKs, _, errorMessage) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Incomplete", EDKs, _, errorMessage) *
     (contentType == 0) * (frameLength == 0) * (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
 
     (* Not enough data to read the header IV and the authentication tag *)
@@ -678,7 +678,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     CRawEncryptionContext(#EC, ECKs) *
 
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rawFrameLength, #rest)) *
-    RawEncryptedDataKeys("Complete", rawHeaderData, 22 + ECLength, EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (l-len #rawFrameLength == 4) *
     rawToUInt32(#rawFrameLength, false, frameLength) *
@@ -732,7 +732,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == as_int ECLength) *
-    BRawEncryptionContext(errorMessage, #EC, ECKs) *
+    BRawEncryptionContext(#EC, errorMessage, ECKs) *
 
     (EDKs == {{ }}) * (contentType == 0) * (frameLength == 0) *
     (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -754,7 +754,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == as_int ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
-    RawEncryptedDataKeys("Broken", rawHeaderData, 22 + ECLength, _, _, errorMessage) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Broken", _, _, errorMessage) *
 
     (EDKs == {{ }}) * (contentType == 0) * (frameLength == 0) *
     (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -777,7 +777,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (l-len #EC == as_int ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, #rawReservedBytes, #rest)) *
-    RawEncryptedDataKeys("Complete", rawHeaderData, 22 + ECLength, EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == as_num (l-len #edks)) *
     (l-len #rawReservedBytes == 4i) *
     rawToUInt32(#rawReservedBytes, false, #reservedBytes) *
@@ -806,7 +806,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (l-len #EC == as_int ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rest)) *
-    RawEncryptedDataKeys("Complete", rawHeaderData, 22 + ECLength, EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == as_num (l-len #edks)) *
     (headerLength == 22 + ECLength + #EDKsLength + 1 + 4 + 1 + 4) *
     (headerLength + #ivLength + (#tagLength / 8) <=# as_num (l-len rawHeaderData)) *
@@ -817,7 +817,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
 
 (* General serialised header *)
 @nopath
-nounfold pred Header(definition, +rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
+nounfold pred Header(+rawHeaderData, definition, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
     (* Complete header *)
     (definition == "Complete") *
     CHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *

--- a/Gillian-JS/Examples/Amazon/EncryptionHeaderLogic.gil
+++ b/Gillian-JS/Examples/Amazon/EncryptionHeaderLogic.gil
@@ -14,7 +14,7 @@
     ----------------||----|----|---- ... ----||----------------
                 readPos
 *)
-pred Field(+buffer : List, +readPos : Num, field : List, length : Num) :
+pred Field(buffer : List, readPos : Num; field : List, length : Num) :
   (0 <=# readPos) * (is_int readPos) *
     (#rawFL == l-sub(buffer, as_int readPos, 2i)) *
     rawToUInt16(#rawFL, false, #fLength) *
@@ -43,7 +43,7 @@ pred Field(+buffer : List, +readPos : Num, field : List, length : Num) :
                 readPos
 *)
 @nopath
-pred CElement(+buffer : List, +readPos : Num, +fCount : Num, element : List, length : Num) :
+pred CElement(buffer : List, readPos : Num, fCount : Num; element : List, length : Num) :
   (0 <=# readPos) * (readPos <=# as_num (l-len buffer)) *
     (fCount == 0) * (element == {{  }}) * (length == 0),
   (0 <# fCount) * Field(buffer, readPos, #field, #fLength) *
@@ -128,7 +128,7 @@ lemma AppendFieldCC(buffer, readPos, fCount1, fList1, eLength1, fCount2, field, 
     ----------------||-------| ... |-------||----------------
                  readPos
 *)
-pred CElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
+pred CElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
                elements : List, length : Num) :
   (0 <=# readPos) * (readPos <=# as_num (l-len buffer)) * (eCount == 0) *
   (0 <# fCount) * (elements == {{  }}) * (length == 0),
@@ -232,7 +232,7 @@ lemma CElementsElementLength(buffer, readPos, eCount, fCount, eList, prefix, ele
                 readPos
 *)
 @nopath
-pred IElement(+buffer : List, +readPos : Num, +fCount : Num, fList : List, eLength : Num) :
+pred IElement(buffer : List, readPos : Num, fCount : Num; fList : List, eLength : Num) :
   (* Base case: not enough data to read length of next field *)
   (0 <=# readPos) * (0 <# fCount) * (readPos <=# as_num (l-len buffer)) *
     (as_num (l-len buffer) <# (readPos + 2)) * (fList == {{  }}) *
@@ -329,7 +329,7 @@ lemma PrependCElementI(buffer, readPos, fCount1, fList1, eLength1, fCount2, fLis
                 readPos
 *)
 @nopath
-pred IElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
+pred IElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
                eList : List, esLength : Num) :
   (* Base case: single incomplete element *)
   (0 <=# readPos) * (readPos <=# as_num (l-len buffer)) * (0 <# eCount) * (0 <# fCount) *
@@ -358,8 +358,8 @@ pred IElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
 
 (* A general element sequene is either a complete or an incomplete element sequence *)
 @nopath
-nounfold pred Elements(+buffer : List, +readPos : Num, +eCount : Num,
-                       +fCount : Num, definition : Str, eList : List,
+nounfold pred Elements(buffer : List, readPos : Num, eCount : Num,
+                       fCount : Num; definition : Str, eList : List,
                        esLength : Num) :
   (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
   (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
@@ -408,7 +408,7 @@ lemma PrependCElementsE(definition, buffer, readPos, eCount1, fCount, fList1, es
 
 (* Complete serialised EDKs *)
 @nopath
-nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Num,
+nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Num;
                                     EDKs : List, EDKsLength : Num) :
     (0 <=# readPos) * (readPos <=# as_num (l-len buffer)) *
     (#rawEC == l-sub(buffer, as_int readPos, 2i)) *
@@ -418,7 +418,7 @@ nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Num,
 
 (* Incomplete serialised EDKs *)
 @nopath
-nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num) :
+nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num;) :
   (* Not enough data to read the number of EDKs *)
   (is_int readPos) * (0 <=# readPos) * (readPos <=# as_num (l-len buffer)) * (as_num (l-len buffer) <# (readPos + 2)),
 
@@ -430,7 +430,7 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num) :
 
 (* Broken serialised EDKs *)
 @nopath
-nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Num, errorMessage : Str) :
+nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Num; errorMessage : Str) :
   (* Incorrect starting position *)
   (is_int readPos) * ((readPos <# 0) \/ (as_num (l-len buffer) <# readPos)) *
     (errorMessage == "deserializeMessageHeader: startPos out of bounds."),
@@ -444,7 +444,7 @@ nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Num, errorMessage
 
 (* General serialised EDKs *)
 @nopath
-nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Num, definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
+nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Num; definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
   (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
   (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
   (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
@@ -470,7 +470,7 @@ nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Num, definition : 
 
 (* Complete serialised encryption context *)
 @nopath
-nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
+nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
   ((l-len buffer) == 0i) * (ECKs == {{  }}),
   (#rawKC == l-sub(buffer, 0i, 2i)) *
     rawToUInt16(#rawKC, false, #keyCount) * (0 <# #keyCount) *
@@ -480,7 +480,7 @@ nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
 
 (* Broken serialised encryption context *)
 @nopath
-nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:List) :
+nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (2i i<# (l-len buffer)) *
     (#rawKC == l-sub (buffer, 0i, 2i)) *
@@ -510,7 +510,7 @@ nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:List) :
 
 (* General serialised encryption context *)
 @nopath
-pred RawEncryptionContext(+buffer:List, definition:Str, ECKs:List, errorMessage:Str) :
+pred RawEncryptionContext(buffer:List; definition:Str, ECKs:List, errorMessage:Str) :
   (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
   (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
 
@@ -526,7 +526,7 @@ pred RawEncryptionContext(+buffer:List, definition:Str, ECKs:List, errorMessage:
 
 (* Correctly formed algorithm suite *)
 @nopath
-pred CAlgorithmSuite(+numId, stringId, ivLength, tagLength) :
+pred CAlgorithmSuite(numId; stringId, ivLength, tagLength) :
   (numId == 20) * (stringId == "ALG_AES128_GCM_IV12_TAG16") *
     (ivLength == 12) * (tagLength == 128),
   (numId == 70) * (stringId == "ALG_AES192_GCM_IV12_TAG16") * (ivLength == 12) *
@@ -534,13 +534,13 @@ pred CAlgorithmSuite(+numId, stringId, ivLength, tagLength) :
 
 (* Broken algorithm suite *)
 @nopath
-pred BAlgorithmSuite(+numId, errorMessage) :
+pred BAlgorithmSuite(numId; errorMessage) :
   (! (numId == 20)) * (! (numId == 70)) *
   (errorMessage == "Malformed Header: Unsupported algorithm suite.");
 
 (* The object that holds information about allowed algorithm suites *)
 @nopath
-pred AlgorithmSuiteIdentifierObject(o) :
+pred AlgorithmSuiteIdentifierObject(o;) :
     JSObject(o) *
     DataProp(o, "20",  "ALG_AES128_GCM_IV12_TAG16") * DataProp(o, "ALG_AES128_GCM_IV12_TAG16", 20) *
     DataProp(o, "70",  "ALG_AES192_GCM_IV12_TAG16") * DataProp(o, "ALG_AES192_GCM_IV12_TAG16", 70) *
@@ -551,7 +551,7 @@ pred AlgorithmSuiteIdentifierObject(o) :
     TODO: This object is more complex than presented here.
  *)
 @nopath
-pred AlgorithmSuiteObject(+aso: Obj, ivLength: Num, tagLength: Num) :
+pred AlgorithmSuiteObject(aso: Obj; ivLength: Num, tagLength: Num) :
     JSObject(aso) *
     readOnlyProperty(aso, "ivLength",  ivLength) *
     readOnlyProperty(aso, "tagLength", tagLength);
@@ -567,12 +567,12 @@ pred AlgorithmSuiteObject(+aso: Obj, ivLength: Num, tagLength: Num) :
 
 (* The correct version and type *)
 @nopath
-pred CVersionAndType(version, type) :
+pred CVersionAndType(version, type;) :
   (version == 1) * (type == 128);
 
 (* Broken version and type *)
 @nopath
-pred BVersionAndType(+version:Num, +type:Num, errorMessage:Str) :
+pred BVersionAndType(version:Num, type:Num; errorMessage:Str) :
     (version == 65) * (type == 89) * (errorMessage == "Malformed Header: This blob may be base64 encoded."),
     (! (version == 1) \/ ! (type == 128)) * (! (version == 65) \/ ! (type == 89)) * (errorMessage == "Malformed Header: Unsupported version and/or type.");
 
@@ -581,7 +581,7 @@ pred BVersionAndType(+version:Num, +type:Num, errorMessage:Str) :
 
 (* Serialised complete header *)
 @nopath
-nounfold pred CHeader(+rawHeaderData, part_one, version, type, suiteId,
+nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
                       messageId, ECLength, part_two, ECKs, part_three, EDKs,
                       contentType, headerIvLength, frameLength, headerLength,
                       headerIv, headerAuthTag) :
@@ -609,7 +609,7 @@ nounfold pred CHeader(+rawHeaderData, part_one, version, type, suiteId,
 
 (* Serialised incomplete header *)
 @nopath
-nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageId, ECLength,
+nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength,
                                       part_two, ECKs,
                                       part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) :
     (* Not enough data to read first part *)
@@ -689,7 +689,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
 
 (* Broken serialised header *)
 @nopath
-nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageId, ECLength,
+nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength,
                                       part_two, ECKs,
                                       part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
     (* Incorrect version and/or type *)
@@ -817,7 +817,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
 
 (* General serialised header *)
 @nopath
-nounfold pred Header(+rawHeaderData, definition, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
+nounfold pred Header(rawHeaderData; definition, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
     (* Complete header *)
     (definition == "Complete") *
     CHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *

--- a/Gillian-JS/Examples/Amazon/EncryptionHeaderLogic.gil
+++ b/Gillian-JS/Examples/Amazon/EncryptionHeaderLogic.gil
@@ -418,7 +418,7 @@ nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Num;
 
 (* Incomplete serialised EDKs *)
 @nopath
-nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num;) :
+nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num) :
   (* Not enough data to read the number of EDKs *)
   (is_int readPos) * (0 <=# readPos) * (readPos <=# as_num (l-len buffer)) * (as_num (l-len buffer) <# (readPos + 2)),
 
@@ -446,7 +446,7 @@ nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Num; errorMessage :
 @nopath
 nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Num; definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
   (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos; EDKs, EDKsLength),
-  (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos;) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
+  (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
   (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos; errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
 
 
@@ -476,7 +476,7 @@ nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
     rawToUInt16(#rawKC, false; #keyCount) * (0 <# #keyCount) *
     Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) *
-    Unique(#ECKeys;) * (as_int (2 + #ECKsLength) == (l-len buffer));
+    Unique(#ECKeys) * (as_int (2 + #ECKsLength) == (l-len buffer));
 
 (* Broken serialised encryption context *)
 @nopath
@@ -504,7 +504,7 @@ nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
     rawToUInt16(#rawKC, false; #keyCount) *
     (0 <# #keyCount) *
     Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Duplicated({{ }}, #ECKeys;) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Duplicated({{ }}, #ECKeys) *
     (as_int (2 + #ECKsLength) == l-len buffer) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
@@ -540,11 +540,11 @@ pred BAlgorithmSuite(numId; errorMessage) :
 
 (* The object that holds information about allowed algorithm suites *)
 @nopath
-pred AlgorithmSuiteIdentifierObject(o;) :
-    JSObject(o;) *
+pred AlgorithmSuiteIdentifierObject(o) :
+    JSObject(o) *
     DataProp(o, "20";  "ALG_AES128_GCM_IV12_TAG16") * DataProp(o, "ALG_AES128_GCM_IV12_TAG16"; 20) *
     DataProp(o, "70";  "ALG_AES192_GCM_IV12_TAG16") * DataProp(o, "ALG_AES192_GCM_IV12_TAG16"; 70) *
-    <Props>(o, -{ "20", "70", "ALG_AES128_GCM_IV12_TAG16", "ALG_AES192_GCM_IV12_TAG16" }-;);
+    <Props>(o, -{ "20", "70", "ALG_AES128_GCM_IV12_TAG16", "ALG_AES192_GCM_IV12_TAG16" }-);
 
 (*
     The object representing a given algorithm suite.
@@ -552,7 +552,7 @@ pred AlgorithmSuiteIdentifierObject(o;) :
  *)
 @nopath
 pred AlgorithmSuiteObject(aso: Obj; ivLength: Num, tagLength: Num) :
-    JSObject(aso;) *
+    JSObject(aso) *
     readOnlyProperty(aso, "ivLength";  ivLength) *
     readOnlyProperty(aso, "tagLength"; tagLength);
 
@@ -567,7 +567,7 @@ pred AlgorithmSuiteObject(aso: Obj; ivLength: Num, tagLength: Num) :
 
 (* The correct version and type *)
 @nopath
-pred CVersionAndType(version, type;) :
+pred CVersionAndType(version, type) :
   (version == 1) * (type == 128);
 
 (* Broken version and type *)
@@ -590,7 +590,7 @@ nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     ((l-len #rawSuiteId) == 2i) *
     ((l-len messageId) == 16i) *
-    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type;) *
+    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -628,7 +628,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -646,7 +646,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -667,7 +667,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -707,7 +707,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (22 <=# as_num (l-len rawHeaderData)) *
     (rawHeaderData == l+ ({{ version, type }}, #rawSuiteId, #rest)) *
     (l-len #rawSuiteId == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     BAlgorithmSuite(suiteId; errorMessage) *
 
@@ -724,7 +724,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -745,7 +745,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -767,7 +767,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -796,7 +796,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, #ivLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *

--- a/Gillian-JS/Examples/Amazon/EncryptionHeaderLogic.gil
+++ b/Gillian-JS/Examples/Amazon/EncryptionHeaderLogic.gil
@@ -17,7 +17,7 @@
 pred Field(buffer : List, readPos : Num; field : List, length : Num) :
   (0 <=# readPos) * (is_int readPos) *
     (#rawFL == l-sub(buffer, as_int readPos, 2i)) *
-    rawToUInt16(#rawFL, false, #fLength) *
+    rawToUInt16(#rawFL, false; #fLength) *
     (field == l-sub(buffer, as_int (readPos + 2), as_int #fLength)) *
     (length == (2 + #fLength)) * ((readPos + length) <=# as_num (l-len buffer));
   facts: (2 <=# length) and (is_int readPos) and (is_int length);
@@ -46,9 +46,9 @@ pred Field(buffer : List, readPos : Num; field : List, length : Num) :
 pred CElement(buffer : List, readPos : Num, fCount : Num; element : List, length : Num) :
   (0 <=# readPos) * (readPos <=# as_num (l-len buffer)) *
     (fCount == 0) * (element == {{  }}) * (length == 0),
-  (0 <# fCount) * Field(buffer, readPos, #field, #fLength) *
+  (0 <# fCount) * Field(buffer, readPos; #field, #fLength) *
     (#restFCount == (fCount - 1)) *
-    CElement(buffer, (readPos + #fLength), #restFCount, #restFields, #restLength) *
+    CElement(buffer, (readPos + #fLength), #restFCount; #restFields, #restLength) *
     (element == l+ ({{ #field }}, #restFields)) * (length == (#fLength + #restLength));
   (*
       A complete element has a non-negative number of fields
@@ -62,10 +62,10 @@ pred CElement(buffer : List, readPos : Num, fCount : Num; element : List, length
 (* The length of an element is not smaller than the length of its first field *)
 lemma CElementFirstFieldLength(buffer, readPos, fCount, field, restFields, eLength)
 [[
-    CElement(#buffer, #readPos, #fCount, l+({{ #field }}, #restFields), #eLength)
+    CElement(#buffer, #readPos, #fCount; l+({{ #field }}, #restFields), #eLength)
 ]]
 [[
-    CElement(#buffer, #readPos, #fCount, l+({{ #field }}, #restFields), #eLength) *
+    CElement(#buffer, #readPos, #fCount; l+({{ #field }}, #restFields), #eLength) *
     (2 + as_num (l-len #field) <=# #eLength)
 ]]
 [*
@@ -75,35 +75,35 @@ lemma CElementFirstFieldLength(buffer, readPos, fCount, field, restFields, eLeng
 (* The length of a non-empty complete element is strictly positive *)
 lemma CElementNonEmptyPositiveLength(buffer, readPos, fCount, fList, eLength)
 [[
-    CElement(#buffer, #readPos, #fCount, #fList, #eLength) * (0 <# #fCount)
+    CElement(#buffer, #readPos, #fCount; #fList, #eLength) * (0 <# #fCount)
 ]]
 [[
-    CElement(#buffer, #readPos, #fCount, #fList, #eLength) *
+    CElement(#buffer, #readPos, #fCount; #fList, #eLength) *
     (0 <# #eLength)
 ]]
 [*
     unfold CElement(#buffer, #readPos, #fCount, #fList, #eLength);
-    sep_assert (Field(#buffer, #readPos, #field, #fLength)) [bind: #fLength];
-    sep_assert (CElement(#buffer, #readPos + #fLength, #fCount - 1, #restFields, #restELength)) [bind: #restELength]
+    sep_assert (Field(#buffer, #readPos; #field, #fLength)) [bind: #fLength];
+    sep_assert (CElement(#buffer, #readPos + #fLength, #fCount - 1; #restFields, #restELength)) [bind: #restELength]
 *]
 
 (* Appending the first field of a given complete element to a complete element on its left *)
 lemma AppendFieldCC(buffer, readPos, fCount1, fList1, eLength1, fCount2, field, fList2, eLength2)
 [[
-    CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1) *
-    CElement(#buffer, #readPos + #eLength1, #fCount2, l+({{ #field }}, #fList2), #eLength2) *
+    CElement(#buffer, #readPos, #fCount1; #fList1, #eLength1) *
+    CElement(#buffer, #readPos + #eLength1, #fCount2; l+({{ #field }}, #fList2), #eLength2) *
     (#shift == 2 + as_num (l-len #field))
 ]]
 [[
-    CElement(#buffer, #readPos, #fCount1 + 1, l+ (#fList1, {{ #field }}), #eLength1 + #shift) *
-    CElement(#buffer, #readPos + #eLength1 + #shift, #fCount2 - 1, #fList2, #eLength2 - #shift)
+    CElement(#buffer, #readPos, #fCount1 + 1; l+ (#fList1, {{ #field }}), #eLength1 + #shift) *
+    CElement(#buffer, #readPos + #eLength1 + #shift, #fCount2 - 1; #fList2, #eLength2 - #shift)
 ]]
 [*
     apply CElementFirstFieldLength(#buffer, #readPos + #eLength1, #fCount2, #field, #fList2, #eLength2);
     unfold CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1);
     if (0 < #fCount1) then {
         sep_assert ((#fList1 == l+ ({{ #fl1 }}, #rfl1))) [bind: #fl1, #rfl1];
-        sep_assert (CElement(#buffer, 2 + (as_num (l-len #fl1)) + #readPos, #fCount1 - 1, #rfl1, #reL1)) [bind: #reL1];
+        sep_assert (CElement(#buffer, 2 + (as_num (l-len #fl1)) + #readPos, #fCount1 - 1; #rfl1, #reL1)) [bind: #reL1];
         apply AppendFieldCC(#buffer, 2 + (as_num (l-len #fl1)) + #readPos, #fCount1 - 1, #rfl1, #reL1, #fCount2, #field, #fList2, #eLength2)
     };
     fold CElement(#buffer, #readPos, #fCount1 + 1, l+ (#fList1, {{ #field }}), #eLength1 + #shift)
@@ -133,8 +133,8 @@ pred CElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
   (0 <=# readPos) * (readPos <=# as_num (l-len buffer)) * (eCount == 0) *
   (0 <# fCount) * (elements == {{  }}) * (length == 0),
   (0 <=# readPos) * (0 <# eCount) * (0 <# fCount) * (0 <# length) *
-    CElement(buffer, readPos, fCount, #element, #eLength) * (#restECount == (eCount - 1)) *
-    CElements(buffer, (readPos + #eLength), #restECount, fCount, #restElements, #restLength) *
+    CElement(buffer, readPos, fCount; #element, #eLength) * (#restECount == (eCount - 1)) *
+    CElements(buffer, (readPos + #eLength), #restECount, fCount; #restElements, #restLength) *
     (elements == l+ ({{ #element }}, #restElements)) *
     (length == (#eLength + #restLength));
   (*
@@ -153,18 +153,18 @@ pred CElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
 (* Appending a complete element to the given complete elements from the right *)
 lemma CElementsAppend(buffer, readPos, eCount, fCount, eList, esLength, fList, eLength)
 [[
-    CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
-    CElement(#buffer, #readPos + #esLength, #fCount, #fList, #eLength)
+    CElements(#buffer, #readPos, #eCount, #fCount; #eList, #esLength) *
+    CElement(#buffer, #readPos + #esLength, #fCount; #fList, #eLength)
 ]]
 [[
-    CElements(#buffer, #readPos, #eCount + 1, #fCount, l+ (#eList, {{ #fList }}), #esLength + #eLength)
+    CElements(#buffer, #readPos, #eCount + 1, #fCount; l+ (#eList, {{ #fList }}), #esLength + #eLength)
 ]]
 [*
     apply CElementNonEmptyPositiveLength(#buffer, #readPos + #esLength, #fCount, #fList, #eLength);
     unfold CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength);
     if (0 < #eCount) then {
-        sep_assert (CElement(#buffer, #readPos, #fCount, #newElementFieldList, #newElementLength)) [bind: #newElementFieldList, #newElementLength];
-        sep_assert (CElements(#buffer, (#readPos + #newElementLength), (#eCount - 1), #fCount, #remainingElementsList, #remainingElementsLength)) [bind: #remainingElementsList, #remainingElementsLength];
+        sep_assert (CElement(#buffer, #readPos, #fCount; #newElementFieldList, #newElementLength)) [bind: #newElementFieldList, #newElementLength];
+        sep_assert (CElements(#buffer, (#readPos + #newElementLength), (#eCount - 1), #fCount; #remainingElementsList, #remainingElementsLength)) [bind: #remainingElementsList, #remainingElementsLength];
         apply CElementsAppend(#buffer, (#readPos + #newElementLength), (#eCount - 1), #fCount, #remainingElementsList, #remainingElementsLength, #fList, #eLength)
     }
  *]
@@ -172,20 +172,20 @@ lemma CElementsAppend(buffer, readPos, eCount, fCount, eList, esLength, fList, e
 (* Every element of a complete element sequence has the same number of fields *)
 lemma CElementsElementLength(buffer, readPos, eCount, fCount, eList, prefix, element, suffix)
 [[
-    CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
+    CElements(#buffer, #readPos, #eCount, #fCount; #eList, #esLength) *
     (#eList == l+ (#prefix, {{ #element }}, #suffix))
 ]]
 [[
-    CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
+    CElements(#buffer, #readPos, #eCount, #fCount; #eList, #esLength) *
     (l-len #element == as_int #fCount)
 ]]
 [*
     apply DestructList(#prefix);
     unfold CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength);
     if (not (#prefix == {{ }})) then {
-        sep_assert (CElement(#buffer, #readPos, #fCount, #fList, #elementLength)) [bind: #elementLength];
+        sep_assert (CElement(#buffer, #readPos, #fCount; #fList, #elementLength)) [bind: #elementLength];
         sep_assert ((#prefix == l+ ({{ #head }}, #rest))) [bind: #head, #rest];
-        sep_assert (CElements(#buffer, (#readPos + #elementLength), (#eCount - 1), #fCount, l+ (#rest, {{#element}}, #suffix), #restESLength)) [bind: #restESLength];
+        sep_assert (CElements(#buffer, (#readPos + #elementLength), (#eCount - 1), #fCount; l+ (#rest, {{#element}}, #suffix), #restESLength)) [bind: #restESLength];
         apply CElementsElementLength(#buffer, (#readPos + #elementLength), (#eCount - 1), #fCount, l+ (#rest, {{#element}}, #suffix), #rest, #element, #suffix)
     };
     fold CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength)
@@ -240,14 +240,14 @@ pred IElement(buffer : List, readPos : Num, fCount : Num; fList : List, eLength 
 
   (* Base case: enough data to read length of next field, but not enough data to read next field *)
   (0 <=# readPos) * (0 <# fCount) * ((readPos + 2) <=# as_num (l-len buffer)) *
-    (#rawFL == l-sub(buffer, as_int readPos, 2i)) * rawToUInt16(#rawFL, false, #fLength) *
+    (#rawFL == l-sub(buffer, as_int readPos, 2i)) * rawToUInt16(#rawFL, false; #fLength) *
     (as_num (l-len buffer) <# ((readPos + 2) + #fLength)) * (fList == {{  }}) *
     (eLength == ((as_num (l-len buffer)) - (readPos + 2))),
 
   (* Recursive case: enough data to read one field, but not enough data to read the remaining ones *)
-  (0 <=# readPos) * (1 <# fCount) * Field(buffer, readPos, #field, #fLength) *
+  (0 <=# readPos) * (1 <# fCount) * Field(buffer, readPos; #field, #fLength) *
     (#restFCount == (fCount - 1)) * ((readPos + #fLength) <=# as_num (l-len buffer)) *
-    IElement(buffer, (readPos + #fLength), #restFCount, #restFList, #restELength) *
+    IElement(buffer, (readPos + #fLength), #restFCount; #restFList, #restELength) *
     (fList == l+ ({{ #field }}, #restFList)) *
     (eLength == (#fLength + #restELength));
 
@@ -261,19 +261,19 @@ pred IElement(buffer : List, readPos : Num, fCount : Num; fList : List, eLength 
 (* Appending the first field of a given incomplete element to a complete element on its left *)
 lemma AppendFieldCI(buffer, readPos, fCount1, fList1, eLength1, fCount2, field, fList2, eLength2)
 [[
-    CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1) *
-    IElement(#buffer, #readPos + #eLength1, #fCount2, l+({{ #field }}, #fList2), #eLength2) *
+    CElement(#buffer, #readPos, #fCount1; #fList1, #eLength1) *
+    IElement(#buffer, #readPos + #eLength1, #fCount2; l+({{ #field }}, #fList2), #eLength2) *
     (#shift == 2 + as_num (l-len #field))
 ]]
 [[
-    CElement(#buffer, #readPos, #fCount1 + 1, l+ (#fList1, {{ #field }}), #eLength1 + #shift) *
-    IElement(#buffer, #readPos + #eLength1 + #shift, #fCount2 - 1, #fList2, #eLength2 - #shift)
+    CElement(#buffer, #readPos, #fCount1 + 1; l+ (#fList1, {{ #field }}), #eLength1 + #shift) *
+    IElement(#buffer, #readPos + #eLength1 + #shift, #fCount2 - 1; #fList2, #eLength2 - #shift)
 ]]
 [*
     unfold CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1);
     if (0 < #fCount1) then {
         sep_assert ((#fList1 == l+ ({{ #fl1 }}, #rfl1))) [bind: #fl1, #rfl1];
-        sep_assert (CElement(#buffer, 2 + as_num (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1)) [bind: #reL1];
+        sep_assert (CElement(#buffer, 2 + as_num (l-len #fl1) + #readPos, #fCount1 - 1; #rfl1, #reL1)) [bind: #reL1];
         apply AppendFieldCI(#buffer, 2 + as_num (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1, #fCount2, #field, #fList2, #eLength2)
     };
     fold CElement(#buffer, #readPos, #fCount1 + 1, l+ (#fList1, {{ #field }}), #eLength1 + #shift)
@@ -282,17 +282,17 @@ lemma AppendFieldCI(buffer, readPos, fCount1, fList1, eLength1, fCount2, field, 
 (* Prepend an entire complete element to an incomplete element following it *)
 lemma PrependCElementI(buffer, readPos, fCount1, fList1, eLength1, fCount2, fList2, eLength2)
 [[
-    CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1) *
-    IElement(#buffer, #readPos + #eLength1, #fCount2, #fList2, #eLength2)
+    CElement(#buffer, #readPos, #fCount1; #fList1, #eLength1) *
+    IElement(#buffer, #readPos + #eLength1, #fCount2; #fList2, #eLength2)
 ]]
 [[
-    IElement(#buffer, #readPos, #fCount1 + #fCount2, l+ (#fList1, #fList2), #eLength1 + #eLength2)
+    IElement(#buffer, #readPos, #fCount1 + #fCount2; l+ (#fList1, #fList2), #eLength1 + #eLength2)
 ]]
 [*
     unfold CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1);
     if (0 < #fCount1) then {
         sep_assert ((#fList1 == l+ ({{ #fl1 }}, #rfl1))) [bind: #fl1, #rfl1];
-        sep_assert (CElement(#buffer, 2 + as_num (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1)) [bind: #reL1];
+        sep_assert (CElement(#buffer, 2 + as_num (l-len #fl1) + #readPos, #fCount1 - 1; #rfl1, #reL1)) [bind: #reL1];
         apply PrependCElementI(#buffer, 2 + as_num (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1, #fCount2, #fList2, #eLength2)
     }
 *]
@@ -333,13 +333,13 @@ pred IElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
                eList : List, esLength : Num) :
   (* Base case: single incomplete element *)
   (0 <=# readPos) * (readPos <=# as_num (l-len buffer)) * (0 <# eCount) * (0 <# fCount) *
-    IElement(buffer, readPos, fCount, #fList, esLength) * (eList == {{  }}),
+    IElement(buffer, readPos, fCount; #fList, esLength) * (eList == {{  }}),
 
   (* Recursive case: enough data to read first element, but not enough data to read the remaining ones *)
   (0 <=# readPos) * (readPos <=# as_num (l-len buffer)) * (1 <# eCount) * (0 <# fCount) *
-    CElement(buffer, readPos, fCount, #fList, #eLength) *
+    CElement(buffer, readPos, fCount; #fList, #eLength) *
     (#restECount == (eCount - 1)) *
-    IElements(buffer, (readPos + #eLength), #restECount, fCount, #restEList, #restESLength) *
+    IElements(buffer, (readPos + #eLength), #restECount, fCount; #restEList, #restESLength) *
     (eList == l+ ({{ #fList }}, #restEList)) * (esLength == (#eLength + #restESLength));
   facts: (0 <=# readPos) and (readPos <=# as_num (l-len buffer)) and (0 <# eCount) and (0 <# fCount) and (0 <=# esLength) and
          (is_int readPos) and (is_int eCount) and (is_int fCount) and (is_int esLength);
@@ -361,19 +361,19 @@ pred IElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
 nounfold pred Elements(buffer : List, readPos : Num, eCount : Num,
                        fCount : Num; definition : Str, eList : List,
                        esLength : Num) :
-  (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
-  (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
+  (definition == "Complete") * CElements(buffer, readPos, eCount, fCount; eList, esLength),
+  (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount; eList, esLength);
   facts: (0 <=# readPos) and (readPos <=# as_num (l-len buffer)) and (0 <=# eCount) and (0 <# fCount) and (0 <=# esLength) and
          (is_int readPos) and (is_int eCount) and (is_int fCount) and (is_int esLength);
 
  (* An entire complete element sequence can be prepended to a general element sequence *)
 lemma PrependCElementsE(definition, buffer, readPos, eCount1, fCount, fList1, esLength1, eCount2, fList2, esLength2)
 [[
-    CElements(#buffer, #readPos, #eCount1, #fCount, #fList1, #esLength1) *
-    Elements(#buffer, #readPos + #esLength1, #eCount2, #fCount, #definition, #fList2, #esLength2)
+    CElements(#buffer, #readPos, #eCount1, #fCount; #fList1, #esLength1) *
+    Elements(#buffer, #readPos + #esLength1, #eCount2, #fCount; #definition, #fList2, #esLength2)
 ]]
 [[
-    Elements(#buffer, #readPos, #eCount1 + #eCount2, #fCount, #definition, l+ (#fList1, #fList2), #esLength1 + #esLength2)
+    Elements(#buffer, #readPos, #eCount1 + #eCount2, #fCount; #definition, l+ (#fList1, #fList2), #esLength1 + #esLength2)
 ]]
 [*
     unfold CElements(#buffer, #readPos, #eCount1, #fCount, #fList1, #esLength1)
@@ -412,8 +412,8 @@ nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Num;
                                     EDKs : List, EDKsLength : Num) :
     (0 <=# readPos) * (readPos <=# as_num (l-len buffer)) *
     (#rawEC == l-sub(buffer, as_int readPos, 2i)) *
-    rawToUInt16(#rawEC, false, #keyCount) * (0 <# #keyCount) *
-    Elements(buffer, (readPos + 2), #keyCount, 3, "Complete", EDKs, #EDKsLength) *
+    rawToUInt16(#rawEC, false; #keyCount) * (0 <# #keyCount) *
+    Elements(buffer, (readPos + 2), #keyCount, 3; "Complete", EDKs, #EDKsLength) *
     (EDKsLength == (#EDKsLength + 2));
 
 (* Incomplete serialised EDKs *)
@@ -424,8 +424,8 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num;) :
 
   (* Enough data to read the number of EDKs, but not enough data to read the EDKs *)
   (is_int readPos) * (0 <=# readPos) * ((readPos + 2) <=# as_num (l-len buffer)) * (#rawEC == l-sub(buffer, as_int readPos, 2i)) *
-    rawToUInt16(#rawEC, false, #keyCount) * (0 <# #keyCount) *
-    Elements(buffer, (readPos + 2), #keyCount, 3, "Incomplete", #eList, #esLength);
+    rawToUInt16(#rawEC, false; #keyCount) * (0 <# #keyCount) *
+    Elements(buffer, (readPos + 2), #keyCount, 3; "Incomplete", #eList, #esLength);
   facts: (is_int readPos);
 
 (* Broken serialised EDKs *)
@@ -437,7 +437,7 @@ nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Num; errorMessage :
 
   (* Zero EDKs provided *)
   (is_int readPos) * (0 <=# readPos) * ((readPos + 2) <=# as_num (l-len buffer)) *
-    (#rawEC == l-sub(buffer, as_int readPos, 2i)) * rawToUInt16(#rawEC, false, 0.) *
+    (#rawEC == l-sub(buffer, as_int readPos, 2i)) * rawToUInt16(#rawEC, false; 0.) *
     (errorMessage == "Malformed Header: No EncryptedDataKey found.");
 
   facts: (is_int readPos);
@@ -445,9 +445,9 @@ nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Num; errorMessage :
 (* General serialised EDKs *)
 @nopath
 nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Num; definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
-  (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
-  (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
-  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
+  (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos; EDKs, EDKsLength),
+  (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos;) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
+  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos; errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
 
 
 (******************************
@@ -473,10 +473,10 @@ nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Num; definition : St
 nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
   ((l-len buffer) == 0i) * (ECKs == {{  }}),
   (#rawKC == l-sub(buffer, 0i, 2i)) *
-    rawToUInt16(#rawKC, false, #keyCount) * (0 <# #keyCount) *
-    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) *
-    Unique(#ECKeys) * (as_int (2 + #ECKsLength) == (l-len buffer));
+    rawToUInt16(#rawKC, false; #keyCount) * (0 <# #keyCount) *
+    Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) *
+    Unique(#ECKeys;) * (as_int (2 + #ECKsLength) == (l-len buffer));
 
 (* Broken serialised encryption context *)
 @nopath
@@ -484,35 +484,35 @@ nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (2i i<# (l-len buffer)) *
     (#rawKC == l-sub (buffer, 0i, 2i)) *
-    rawToUInt16(#rawKC, false, #keyCount) *
+    rawToUInt16(#rawKC, false; #keyCount) *
     (0 <# #keyCount) * (ECKs == {{ }}) *
-    Elements(buffer, 2, #keyCount, 2, "Incomplete", #eList, #esLength) *
+    Elements(buffer, 2, #keyCount, 2; "Incomplete", #eList, #esLength) *
     (errorMessage == "decodeEncryptionContext: Underflow, not enough data."),
 
     (* Too much data provided *)
     (2i <# (l-len buffer)) *
     (#rawKC == l-sub (buffer, 0i, 2i)) *
-    rawToUInt16(#rawKC, false, #keyCount) *
+    rawToUInt16(#rawKC, false; #keyCount) *
     (0 <# #keyCount) *
-    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
+    Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
     (! (as_int (#ECKsLength + 2) == l-len buffer)) *
     (errorMessage == "decodeEncryptionContext: Overflow, too much data."),
 
     (* Duplicated key in context *)
     (2i <# (l-len buffer)) *
     (#rawKC == l-sub (buffer, 0i, 2i)) *
-    rawToUInt16(#rawKC, false, #keyCount) *
+    rawToUInt16(#rawKC, false; #keyCount) *
     (0 <# #keyCount) *
-    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Duplicated({{ }}, #ECKeys) *
+    Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Duplicated({{ }}, #ECKeys;) *
     (as_int (2 + #ECKsLength) == l-len buffer) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
 (* General serialised encryption context *)
 @nopath
 pred RawEncryptionContext(buffer:List; definition:Str, ECKs:List, errorMessage:Str) :
-  (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
-  (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
+  (definition == "Complete") * CRawEncryptionContext(buffer; ECKs) * (errorMessage == ""),
+  (definition == "Broken")   * BRawEncryptionContext(buffer; errorMessage, ECKs);
 
 
 (*****************************
@@ -541,9 +541,9 @@ pred BAlgorithmSuite(numId; errorMessage) :
 (* The object that holds information about allowed algorithm suites *)
 @nopath
 pred AlgorithmSuiteIdentifierObject(o;) :
-    JSObject(o) *
-    DataProp(o, "20",  "ALG_AES128_GCM_IV12_TAG16") * DataProp(o, "ALG_AES128_GCM_IV12_TAG16", 20) *
-    DataProp(o, "70",  "ALG_AES192_GCM_IV12_TAG16") * DataProp(o, "ALG_AES192_GCM_IV12_TAG16", 70) *
+    JSObject(o;) *
+    DataProp(o, "20";  "ALG_AES128_GCM_IV12_TAG16") * DataProp(o, "ALG_AES128_GCM_IV12_TAG16"; 20) *
+    DataProp(o, "70";  "ALG_AES192_GCM_IV12_TAG16") * DataProp(o, "ALG_AES192_GCM_IV12_TAG16"; 70) *
     <Props>(o, -{ "20", "70", "ALG_AES128_GCM_IV12_TAG16", "ALG_AES192_GCM_IV12_TAG16" }-;);
 
 (*
@@ -552,9 +552,9 @@ pred AlgorithmSuiteIdentifierObject(o;) :
  *)
 @nopath
 pred AlgorithmSuiteObject(aso: Obj; ivLength: Num, tagLength: Num) :
-    JSObject(aso) *
-    readOnlyProperty(aso, "ivLength",  ivLength) *
-    readOnlyProperty(aso, "tagLength", tagLength);
+    JSObject(aso;) *
+    readOnlyProperty(aso, "ivLength";  ivLength) *
+    readOnlyProperty(aso, "tagLength"; tagLength);
 
 (***************************
  ***************************
@@ -590,17 +590,17 @@ nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     ((l-len #rawSuiteId) == 2i) *
     ((l-len messageId) == 16i) *
-    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    ((l-len #rawContextLength) == 2i) * CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (part_two == l+ (#EC, part_three)) *
     ((l-len #EC) == as_int ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rawFrameLength, headerIv, headerAuthTag)) *
-    RawEncryptedDataKeys(rawHeaderData, (22 + ECLength), "Complete", EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, (22 + ECLength); "Complete", EDKs, #EDKsLength, _) *
     (as_int #EDKsLength == (l-len #edks)) * ((l-len #rawFrameLength) == 4i) *
-    rawToUInt32(#rawFrameLength, false, frameLength) *
+    rawToUInt32(#rawFrameLength, false; frameLength) *
     (headerLength == ((((((22 + ECLength) + #EDKsLength) + 1) + 4) + 1) + 4)) *
     ((l-len headerIv) == as_int headerIvLength) *
     ((l-len headerAuthTag) == as_int (#tagLength / 8)) *
@@ -628,10 +628,10 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (l-len rawHeaderData <# 22 + ECLength) *
 
     (ECKs == {{ }}) *
@@ -646,17 +646,17 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
 
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Incomplete", EDKs, _, errorMessage) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Incomplete", EDKs, _, errorMessage) *
     (contentType == 0) * (frameLength == 0) * (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
 
     (* Not enough data to read the header IV and the authentication tag *)
@@ -667,21 +667,21 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
 
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rawFrameLength, #rest)) *
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (l-len #rawFrameLength == 4) *
-    rawToUInt32(#rawFrameLength, false, frameLength) *
+    rawToUInt32(#rawFrameLength, false; frameLength) *
     (headerLength == 22 + ECLength + #EDKsLength + 1 + 4 + 1 + 4) *
     (l-len rawHeaderData <# headerLength + headerIvLength + (#tagLength / 8)) *
 
@@ -695,7 +695,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (* Incorrect version and/or type *)
     (22 <=# as_num (l-len rawHeaderData)) *
     (rawHeaderData == l+ ({{ version, type }}, #rest)) *
-    BVersionAndType(version, type, errorMessage) *
+    BVersionAndType(version, type; errorMessage) *
 
     (part_one == {{ }}) *
     (suiteId == 0) * (messageId == {{ }}) * (ECLength == 0) *
@@ -707,9 +707,9 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (22 <=# as_num (l-len rawHeaderData)) *
     (rawHeaderData == l+ ({{ version, type }}, #rawSuiteId, #rest)) *
     (l-len #rawSuiteId == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    BAlgorithmSuite(suiteId, errorMessage) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    BAlgorithmSuite(suiteId; errorMessage) *
 
     (part_one == {{ }}) * (messageId == {{ }}) * (ECLength == 0) *
     (part_two == {{ }}) * (ECKs == {{ }}) *
@@ -724,15 +724,15 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# as_num (l-len rawHeaderData)) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == as_int ECLength) *
-    BRawEncryptionContext(#EC, errorMessage, ECKs) *
+    BRawEncryptionContext(#EC; errorMessage, ECKs) *
 
     (EDKs == {{ }}) * (contentType == 0) * (frameLength == 0) *
     (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -745,16 +745,16 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# as_num (l-len rawHeaderData)) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == as_int ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Broken", _, _, errorMessage) *
+    CRawEncryptionContext(#EC; ECKs) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Broken", _, _, errorMessage) *
 
     (EDKs == {{ }}) * (contentType == 0) * (frameLength == 0) *
     (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -767,20 +767,20 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# as_num (l-len rawHeaderData)) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == as_int ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, #rawReservedBytes, #rest)) *
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == as_num (l-len #edks)) *
     (l-len #rawReservedBytes == 4i) *
-    rawToUInt32(#rawReservedBytes, false, #reservedBytes) *
+    rawToUInt32(#rawReservedBytes, false; #reservedBytes) *
     (! (#reservedBytes == 0)) *
     (headerLength == 22 + ECLength + #EDKsLength + 1 + 4 + 1 + 4) *
     (headerLength + headerIvLength + (#tagLength / 8) <=# as_num (l-len rawHeaderData)) *
@@ -796,17 +796,17 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2i) *
     (l-len messageId == 16i) *
     (l-len #rawContextLength == 2i) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, #ivLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, #ivLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# as_num (l-len rawHeaderData)) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == as_int ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rest)) *
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == as_num (l-len #edks)) *
     (headerLength == 22 + ECLength + #EDKsLength + 1 + 4 + 1 + 4) *
     (headerLength + #ivLength + (#tagLength / 8) <=# as_num (l-len rawHeaderData)) *
@@ -820,17 +820,17 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
 nounfold pred Header(rawHeaderData; definition, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
     (* Complete header *)
     (definition == "Complete") *
-    CHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
+    CHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
     (errorMessage == ""),
 
     (* Incomplete header *)
     (definition == "Incomplete") *
-    IHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
+    IHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
     (errorMessage == ""),
 
     (* Broken header *)
     (definition == "Broken") *
-    BHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage);
+    BHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage);
 
 (*************************
  *************************

--- a/Gillian-JS/Examples/Amazon/ListLogic.gil
+++ b/Gillian-JS/Examples/Amazon/ListLogic.gil
@@ -29,12 +29,12 @@ lemma DestructList(lst)
 @nopath
 pure pred FirstProj(lst : List; fProj : List) : (lst == {{  }}) *
   (fProj == {{  }}), (lst == l+ ({{ {{ #fst, #lvar_js_7 }} }}, #rest)) *
-  FirstProj(#rest, #fProjRest) * (fProj == l+ ({{ #fst }}, #fProjRest));
+  FirstProj(#rest; #fProjRest) * (fProj == l+ ({{ #fst }}, #fProjRest));
 
 (* FirstProj is a function *)
 lemma FirstProjFunction(lst1, proj1, lst2, proj2)
 [[
-    FirstProj(#lst1, #proj1) * FirstProj(#lst2, #proj2) * (#lst1 == #lst2)
+    FirstProj(#lst1; #proj1) * FirstProj(#lst2; #proj2) * (#lst1 == #lst2)
 ]]
 [[
     (#proj1 == #proj2)
@@ -50,16 +50,16 @@ lemma FirstProjFunction(lst1, proj1, lst2, proj2)
 (* Adding a pair to a first projection *)
 lemma FirstProjAppendPair(lst, fProj, prop, value)
 [[
-    FirstProj(#lst, #fProj)
+    FirstProj(#lst; #fProj)
 ]]
 [[
-    FirstProj(l+ (#lst, {{ {{ #prop, #value }} }}), l+ (#fProj, {{ #prop }}))
+    FirstProj(l+ (#lst, {{ {{ #prop, #value }} }}); l+ (#fProj, {{ #prop }}))
 ]]
 [*
     unfold FirstProj(#lst, #fProj);
     if (!(#lst == {{ }})) then {
         sep_assert ((#lst == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs))) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (FirstProj(#restPVPairs, #restProj)) [bind: #restProj];
+        sep_assert (FirstProj(#restPVPairs; #restProj)) [bind: #restProj];
         apply FirstProjAppendPair(#restPVPairs, #restProj, #prop, #value)
     }
 *]
@@ -67,8 +67,8 @@ lemma FirstProjAppendPair(lst, fProj, prop, value)
 (* First projection goes through concatenation *)
 lemma FirstProjConcatSplit(PVPairs, prefix, suffix)
 [[
-    (#PVPairs == l+ (#prefix, #suffix)) * FirstProj(#PVPairs, #props) *
-    FirstProj(#prefix, #preProps) * FirstProj(#suffix, #sufProps)
+    (#PVPairs == l+ (#prefix, #suffix)) * FirstProj(#PVPairs; #props) *
+    FirstProj(#prefix; #preProps) * FirstProj(#suffix; #sufProps)
 ]]
 [[
     (#props == l+ (#preProps, #sufProps))
@@ -88,12 +88,12 @@ lemma FirstProjConcatSplit(PVPairs, prefix, suffix)
 (* Compatibility of first projection and toUtf8 *)
 lemma FirstProjToUtf8MapPairCompat(PVPairs)
 [[
-    FirstProj(#PVPairs, #props) *
-    toUtf8PairMap(#PVPairs, #utf8PVPairs) *
-    FirstProj(#utf8PVPairs, #utf8Props)
+    FirstProj(#PVPairs; #props) *
+    toUtf8PairMap(#PVPairs; #utf8PVPairs) *
+    FirstProj(#utf8PVPairs; #utf8Props)
 ]]
 [[
-    toUtf8Map(#props, #utf8Props)
+    toUtf8Map(#props; #utf8Props)
 ]]
 [*
     unfold FirstProj(#PVPairs, #props);
@@ -117,12 +117,12 @@ lemma FirstProjToUtf8MapPairCompat(PVPairs)
 pure pred ListToSet(lst : List; set : Set) :
   (lst == {{  }}) * (set == -{  }-),
   (lst == l+ ({{ #e }}, #restLst)) *
-    ListToSet(#restLst, #restSet) * (set == -u- (#restSet, -{ #e }-));
+    ListToSet(#restLst; #restSet) * (set == -u- (#restSet, -{ #e }-));
 
 (* ListToSet is a function *)
 lemma ListToSetFunction(lst1, set1, lst2, set2)
 [[
-    ListToSet(#lst1, #set1) * ListToSet(#lst2, #set2) * (#lst1 == #lst2)
+    ListToSet(#lst1; #set1) * ListToSet(#lst2; #set2) * (#lst1 == #lst2)
 ]]
 [[
     (#set1 == #set2)
@@ -138,7 +138,7 @@ lemma ListToSetFunction(lst1, set1, lst2, set2)
 (* ListToSet concat-union compatibility *)
 lemma ListToSetUnion(lst1, lst2)
 [[
-    ListToSet(#lst1, #set1) * ListToSet(#lst2, #set2) * ListToSet(l+ (#lst1, #lst2), #uset)
+    ListToSet(#lst1; #set1) * ListToSet(#lst2; #set2) * ListToSet(l+ (#lst1, #lst2); #uset)
 ]]
 [[
     (#uset == -u- (#set1, #set2))
@@ -160,7 +160,7 @@ lemma ProduceListToSet(lst)
     types(lst: List)
 ]]
 [[
-    ListToSet(#lst, #set)
+    ListToSet(#lst; #set)
 ]]
 [*
     apply DestructList(#lst);
@@ -173,16 +173,16 @@ lemma ProduceListToSet(lst)
 (* Adding an element in list-to-set conversion *)
 lemma ListToSetAddElement(lst, set, element)
 [[
-    ListToSet(#lst, #set)
+    ListToSet(#lst; #set)
 ]]
 [[
-    ListToSet(l+ (#lst, {{ #element }}), -u- (#set, -{ #element }-))
+    ListToSet(l+ (#lst, {{ #element }}); -u- (#set, -{ #element }-))
 ]]
 [*
     unfold ListToSet(#lst, #set);
     if (!(#lst == {{ }})) then {
         sep_assert ((#lst == l+ ({{ #fProp }}, #restLst))) [bind: #fProp, #restLst];
-        sep_assert (ListToSet(#restLst, #restSet)) [bind: #restSet];
+        sep_assert (ListToSet(#restLst; #restSet)) [bind: #restSet];
         apply ListToSetAddElement(#restLst, #restSet, #element)
     }
 *]
@@ -191,7 +191,7 @@ lemma ListToSetAddElement(lst, set, element)
 lemma HeadInSet(lst)
 [[
     (#lst == l+ ({{ #hd }}, #tl)) *
-    ListToSet(#lst, #set)
+    ListToSet(#lst; #set)
 ]]
 [[
     (#hd --e-- #set)
@@ -201,11 +201,11 @@ lemma HeadInSet(lst)
 (* toUtf8 mapping and list membership, positive *)
 lemma InListToUtf8(prop, props)
 [[
-    ListToSet(#props, #propsSet) *
+    ListToSet(#props; #propsSet) *
     (#prop --e-- #propsSet) *
-    toUtf8(#prop, #utf8Prop) *
-    toUtf8Map(#props, #utf8Props) *
-    ListToSet(#utf8Props, #utf8PropsSet)
+    toUtf8(#prop; #utf8Prop) *
+    toUtf8Map(#props; #utf8Props) *
+    ListToSet(#utf8Props; #utf8PropsSet)
 ]]
 [[
     (#utf8Prop --e-- #utf8PropsSet)
@@ -215,7 +215,7 @@ lemma InListToUtf8(prop, props)
     if (!(#props == {{ }})) then {
         sep_assert ((#props == l+ ({{ #fstProp }}, #rest))) [bind: #rest];
         unfold toUtf8Map(#props, #utf8Props);
-        sep_assert (toUtf8(#fstProp, #utf8FstProp)) [bind: #utf8FstProp];
+        sep_assert (toUtf8(#fstProp; #utf8FstProp)) [bind: #utf8FstProp];
         sep_assert ((#utf8Props == l+ ({{ #utf8FstProp }}, #restUtf8))) [bind: #restUtf8];
         unfold ListToSet(#utf8Props, #utf8PropsSet);
         if (#prop == #fstProp) then {
@@ -230,11 +230,11 @@ lemma InListToUtf8(prop, props)
 (* toUtf8 mapping and list membership, negative *)
 lemma NotInListToUtf8(prop, props)
 [[
-    ListToSet(#props, #propsSet) *
+    ListToSet(#props; #propsSet) *
     (! (#prop --e-- #propsSet)) *
-    toUtf8(#prop, #utf8Prop) *
-    toUtf8Map(#props, #utf8Props) *
-    ListToSet(#utf8Props, #utf8PropsSet)
+    toUtf8(#prop; #utf8Prop) *
+    toUtf8Map(#props; #utf8Props) *
+    ListToSet(#utf8Props; #utf8PropsSet)
 ]]
 [[
     (! (#utf8Prop --e-- #utf8PropsSet))
@@ -246,7 +246,7 @@ lemma NotInListToUtf8(prop, props)
 
     if (!(#props == {{ }})) then {
         sep_assert ((#props == l+ ({{ #fstProp }}, #rest))) [bind: #rest];
-        sep_assert (toUtf8(#fstProp, #utf8FstProp)) [bind: #utf8FstProp];
+        sep_assert (toUtf8(#fstProp; #utf8FstProp)) [bind: #utf8FstProp];
         apply toUtf8Injective(#prop, #utf8Prop, #fstProp, #utf8FstProp);
         apply NotInListToUtf8(#prop, #rest)
     }
@@ -263,15 +263,15 @@ lemma NotInListToUtf8(prop, props)
 @nopath
 pure pred Unique(l : List;) :
   (l == {{  }}),
-  (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest, #setRest) *
-    (! (#fst --e-- #setRest)) * Unique(#rest);
+  (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest; #setRest) *
+    (! (#fst --e-- #setRest)) * Unique(#rest;);
 
 (* In a unique list split into a left and a right sublist,
    no element from the right is on the left *)
 lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
 [[
-    (#props == l+ (#prefix, #suffix)) * Unique(#props) *
-    ListToSet(#prefix, #setPrefix) * ListToSet(#suffix, #setSuffix) *
+    (#props == l+ (#prefix, #suffix)) * Unique(#props;) *
+    ListToSet(#prefix; #setPrefix) * ListToSet(#suffix; #setSuffix) *
     (#prop --e-- #setSuffix)
 ]]
 [[
@@ -295,11 +295,11 @@ lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
 (* Appending an element to a unique list *)
 lemma UniqueAppendElement(lst, element)
 [[
-    Unique(#lst) * ListToSet(#lst, #set) *
+    Unique(#lst;) * ListToSet(#lst; #set) *
     (! (#element --e-- #set))
 ]]
 [[
-    Unique(l+ (#lst, {{ #element }}))
+    Unique(l+ (#lst, {{ #element }});)
 ]]
 [*
     unfold Unique(#lst) [bind: (#fst := #fst) and (#rest := #rest) and (#setRest1 := #setRest)];
@@ -324,11 +324,11 @@ lemma UniqueAppendElement(lst, element)
 pure pred Duplicated(prefix:List, suffix:List;) :
     (* Either the head is duplicated *)
     (suffix == l+ ({{ #fst }}, #rest)) *
-    ListToSet(prefix, #preSet) *
+    ListToSet(prefix; #preSet) *
     (#fst --e-- #preSet),
 
     (* Or the duplication is in the tail *)
     (suffix == l+ ({{ #fst }}, #rest)) *
-    ListToSet(prefix, #preSet) *
+    ListToSet(prefix; #preSet) *
     (! (#fst --e-- #preSet)) *
-    Duplicated(l+ (prefix, {{ #fst }}), #rest);
+    Duplicated(l+ (prefix, {{ #fst }}), #rest;);

--- a/Gillian-JS/Examples/Amazon/ListLogic.gil
+++ b/Gillian-JS/Examples/Amazon/ListLogic.gil
@@ -27,7 +27,7 @@ lemma DestructList(lst)
 
 (* First projection of a list of pairs *)
 @nopath
-pure pred FirstProj(+lst : List, fProj : List) : (lst == {{  }}) *
+pure pred FirstProj(lst : List; fProj : List) : (lst == {{  }}) *
   (fProj == {{  }}), (lst == l+ ({{ {{ #fst, #lvar_js_7 }} }}, #rest)) *
   FirstProj(#rest, #fProjRest) * (fProj == l+ ({{ #fst }}, #fProjRest));
 
@@ -114,7 +114,7 @@ lemma FirstProjToUtf8MapPairCompat(PVPairs)
 ******************************************)
 
 @nopath
-pure pred ListToSet(+lst : List, set : Set) :
+pure pred ListToSet(lst : List; set : Set) :
   (lst == {{  }}) * (set == -{  }-),
   (lst == l+ ({{ #e }}, #restLst)) *
     ListToSet(#restLst, #restSet) * (set == -u- (#restSet, -{ #e }-));
@@ -261,7 +261,7 @@ lemma NotInListToUtf8(prop, props)
  ********************************)
 
 @nopath
-pure pred Unique(l : List) :
+pure pred Unique(l : List;) :
   (l == {{  }}),
   (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest, #setRest) *
     (! (#fst --e-- #setRest)) * Unique(#rest);
@@ -321,7 +321,7 @@ lemma UniqueAppendElement(lst, element)
 
 (* Lists with duplicates *)
 @nopath
-pure pred Duplicated(+prefix:List, +suffix:List) :
+pure pred Duplicated(prefix:List, suffix:List;) :
     (* Either the head is duplicated *)
     (suffix == l+ ({{ #fst }}, #rest)) *
     ListToSet(prefix, #preSet) *

--- a/Gillian-JS/Examples/Amazon/ListLogic.gil
+++ b/Gillian-JS/Examples/Amazon/ListLogic.gil
@@ -261,16 +261,16 @@ lemma NotInListToUtf8(prop, props)
  ********************************)
 
 @nopath
-pure pred Unique(l : List;) :
+pure pred Unique(l : List) :
   (l == {{  }}),
   (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest; #setRest) *
-    (! (#fst --e-- #setRest)) * Unique(#rest;);
+    (! (#fst --e-- #setRest)) * Unique(#rest);
 
 (* In a unique list split into a left and a right sublist,
    no element from the right is on the left *)
 lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
 [[
-    (#props == l+ (#prefix, #suffix)) * Unique(#props;) *
+    (#props == l+ (#prefix, #suffix)) * Unique(#props) *
     ListToSet(#prefix; #setPrefix) * ListToSet(#suffix; #setSuffix) *
     (#prop --e-- #setSuffix)
 ]]
@@ -295,11 +295,11 @@ lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
 (* Appending an element to a unique list *)
 lemma UniqueAppendElement(lst, element)
 [[
-    Unique(#lst;) * ListToSet(#lst; #set) *
+    Unique(#lst) * ListToSet(#lst; #set) *
     (! (#element --e-- #set))
 ]]
 [[
-    Unique(l+ (#lst, {{ #element }});)
+    Unique(l+ (#lst, {{ #element }}))
 ]]
 [*
     unfold Unique(#lst) [bind: (#fst := #fst) and (#rest := #rest) and (#setRest1 := #setRest)];
@@ -321,7 +321,7 @@ lemma UniqueAppendElement(lst, element)
 
 (* Lists with duplicates *)
 @nopath
-pure pred Duplicated(prefix:List, suffix:List;) :
+pure pred Duplicated(prefix:List, suffix:List) :
     (* Either the head is duplicated *)
     (suffix == l+ ({{ #fst }}, #rest)) *
     ListToSet(prefix; #preSet) *
@@ -331,4 +331,4 @@ pure pred Duplicated(prefix:List, suffix:List;) :
     (suffix == l+ ({{ #fst }}, #rest)) *
     ListToSet(prefix; #preSet) *
     (! (#fst --e-- #preSet)) *
-    Duplicated(l+ (prefix, {{ #fst }}), #rest;);
+    Duplicated(l+ (prefix, {{ #fst }}), #rest);

--- a/Gillian-JS/Examples/Amazon/Utf8Logic.gil
+++ b/Gillian-JS/Examples/Amazon/Utf8Logic.gil
@@ -21,14 +21,14 @@ abstract pure nounfold pred toUtf8(rawData : List; utf8Data : Str);
 pure pred toUtf8PairMap(data : List; utf8Data : List) : (data == {{  }}) *
   (utf8Data == {{  }}),
   (data == l+ ({{ {{ #prop, #value }} }}, #rest)) *
-    toUtf8(#prop, #utf8Prop) * toUtf8(#value, #utf8Value) *
-    toUtf8PairMap(#rest, #utf8Rest) *
+    toUtf8(#prop; #utf8Prop) * toUtf8(#value; #utf8Value) *
+    toUtf8PairMap(#rest; #utf8Rest) *
     (utf8Data == l+ ({{ {{ #utf8Prop, #utf8Value }} }}, #utf8Rest));
 
 (* toUtf8 is injective *)
 lemma toUtf8Injective(rawData1, utf8Data1, rawData2, utf8Data2)
 [[
-    toUtf8(#rawData1, #utf8Data1) * toUtf8(#rawData2, #utf8Data2)
+    toUtf8(#rawData1; #utf8Data1) * toUtf8(#rawData2; #utf8Data2)
 ]]
 [[
     (#rawData1 == #rawData2) * (#utf8Data1 == #utf8Data2);
@@ -36,7 +36,7 @@ lemma toUtf8Injective(rawData1, utf8Data1, rawData2, utf8Data2)
 ]]
 
 (*
-    fromUtf8(utf8Data, rawData) is an abstract predicate which
+    fromUtf8(utf8Data; rawData) is an abstract predicate which
     denotes that the raw bytes rawData are obtained by converting
     the string utf8Data into bytes
 *)
@@ -46,7 +46,7 @@ abstract pure pred fromUtf8(utf8Data:Str; rawData:List);
 (* fromUtf8 is injective *)
 lemma fromUtf8Injective(utf8Data1, rawData1, utf8Data2, rawData2)
 [[
-    fromUtf8(#utf8Data1, #rawData1) * fromUtf8(#utf8Data2, #rawData2)
+    fromUtf8(#utf8Data1; #rawData1) * fromUtf8(#utf8Data2; #rawData2)
 ]]
 [[
     (#utf8Data1 == #utf8Data2) * (#rawData1 == #rawData2);
@@ -56,19 +56,19 @@ lemma fromUtf8Injective(utf8Data1, rawData1, utf8Data2, rawData2)
 (* Invertibility of toUtf8 with respect to fromUtf8 *)
 lemma toUtf8fromUtf8(rawData)
 [[
-    toUtf8(#rawData, #utf8Data)
+    toUtf8(#rawData; #utf8Data)
 ]]
 [[
-    fromUtf8(#utf8Data, #rawData)
+    fromUtf8(#utf8Data; #rawData)
 ]]
 
 (* Invertibility of fromUtf8 with respect to toUtf8 *)
 lemma fromUtf8toUtf8(utf8Data)
 [[
-    fromUtf8(#utf8Data, #rawData)
+    fromUtf8(#utf8Data; #rawData)
 ]]
 [[
-    toUtf8(#rawData, #utf8Data)
+    toUtf8(#rawData; #utf8Data)
 ]]
 
 (* UTF-8 Mapping of lists *)
@@ -77,14 +77,14 @@ pure pred toUtf8Map(data : List; utf8Data : List) :
     (data == {{ }}) * (utf8Data == {{ }}),
 
     (data == l+ ({{ #fst }}, #rest)) *
-    toUtf8(#fst, #utf8Fst) *
-    toUtf8Map(#rest, #utf8Rest) *
+    toUtf8(#fst; #utf8Fst) *
+    toUtf8Map(#rest; #utf8Rest) *
     (utf8Data == l+ ({{ #utf8Fst }}, #utf8Rest));
 
 (* toUtf8PairMap is injective *)
 lemma toUtf8MapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
 [[
-    toUtf8Map(#rawData1, #utf8Data1) * toUtf8Map(#rawData2, #utf8Data2)
+    toUtf8Map(#rawData1; #utf8Data1) * toUtf8Map(#rawData2; #utf8Data2)
 ]]
 [[
     (#rawData1 == #rawData2) * (#utf8Data1 == #utf8Data2);
@@ -105,7 +105,7 @@ lemma toUtf8MapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
 (* toUtf8PairMap is injective *)
 lemma toUtf8PairMapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
 [[
-    toUtf8PairMap(#rawData1, #utf8Data1) * toUtf8PairMap(#rawData2, #utf8Data2)
+    toUtf8PairMap(#rawData1; #utf8Data1) * toUtf8PairMap(#rawData2; #utf8Data2)
 ]]
 [[
     (#rawData1 == #rawData2) * (#utf8Data1 == #utf8Data2);
@@ -127,18 +127,18 @@ lemma toUtf8PairMapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
 (* Appending a pair to a mapping of lists of pairs *)
 lemma toUtf8PairMapAppendPair(data, utf8Data, prop, value)
 [[
-    toUtf8PairMap(#data, #utf8Data) *
-    toUtf8(#prop, #utf8Prop) *
-    toUtf8(#value, #utf8Value)
+    toUtf8PairMap(#data; #utf8Data) *
+    toUtf8(#prop; #utf8Prop) *
+    toUtf8(#value; #utf8Value)
 ]]
 [[
-    toUtf8PairMap(l+ (#data, {{ {{ #prop, #value }} }}), l+ (#utf8Data, {{ {{ #utf8Prop, #utf8Value }} }}))
+    toUtf8PairMap(l+ (#data, {{ {{ #prop, #value }} }}); l+ (#utf8Data, {{ {{ #utf8Prop, #utf8Value }} }}))
 ]]
 [*
     unfold toUtf8PairMap(#data, #utf8Data);
     if (!(#data == {{ }})) then {
         sep_assert ((#data == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs))) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (toUtf8PairMap(#restPVPairs, #restUtf8Data)) [bind: #restUtf8Data];
+        sep_assert (toUtf8PairMap(#restPVPairs; #restUtf8Data)) [bind: #restUtf8Data];
         apply toUtf8PairMapAppendPair(#restPVPairs, #restUtf8Data, #prop, #value)
     }
 *]

--- a/Gillian-JS/Examples/Amazon/Utf8Logic.gil
+++ b/Gillian-JS/Examples/Amazon/Utf8Logic.gil
@@ -14,11 +14,11 @@
     the raw bytes rawData to UTF-8 format
 *)
 @nopath
-abstract pure nounfold pred toUtf8(+rawData : List, utf8Data : Str);
+abstract pure nounfold pred toUtf8(rawData : List; utf8Data : Str);
 
 (* UTF-8 Mapping of lists of pairs *)
 @nopath
-pure pred toUtf8PairMap(+data : List, utf8Data : List) : (data == {{  }}) *
+pure pred toUtf8PairMap(data : List; utf8Data : List) : (data == {{  }}) *
   (utf8Data == {{  }}),
   (data == l+ ({{ {{ #prop, #value }} }}, #rest)) *
     toUtf8(#prop, #utf8Prop) * toUtf8(#value, #utf8Value) *
@@ -41,7 +41,7 @@ lemma toUtf8Injective(rawData1, utf8Data1, rawData2, utf8Data2)
     the string utf8Data into bytes
 *)
 @nopath
-abstract pure pred fromUtf8(+utf8Data:Str, rawData:List);
+abstract pure pred fromUtf8(utf8Data:Str; rawData:List);
 
 (* fromUtf8 is injective *)
 lemma fromUtf8Injective(utf8Data1, rawData1, utf8Data2, rawData2)
@@ -73,7 +73,7 @@ lemma fromUtf8toUtf8(utf8Data)
 
 (* UTF-8 Mapping of lists *)
 @nopath
-pure pred toUtf8Map(+data : List, utf8Data : List) :
+pure pred toUtf8Map(data : List; utf8Data : List) :
     (data == {{ }}) * (utf8Data == {{ }}),
 
     (data == l+ ({{ #fst }}, #rest)) *

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/AmazonLogic.jsil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/AmazonLogic.jsil
@@ -110,17 +110,17 @@ lemma PrependCElementI(buffer, readPos, fCount1, fList1, eLength1, fCount2, fLis
 lemma PrependCElementsE(definition, buffer, readPos, eCount1, fCount, fList1, esLength1, eCount2, fList2, esLength2)
 [[
     CElements(#buffer, #readPos, #eCount1, #fCount, #fList1, #esLength1) *
-    Elements(#definition, #buffer, #readPos + #esLength1, #eCount2, #fCount, #fList2, #esLength2)
+    Elements(#buffer, #readPos + #esLength1, #eCount2, #fCount, #definition, #fList2, #esLength2)
 ]]
 [[
-    Elements(#definition, #buffer, #readPos, #eCount1 + #eCount2, #fCount, l+ (#fList1, #fList2), #esLength1 + #esLength2)
+    Elements(#buffer, #readPos, #eCount1 + #eCount2, #fCount, #definition, l+ (#fList1, #fList2), #esLength1 + #esLength2)
 ]]
 [*
     unfold CElements(#buffer, #readPos, #eCount1, #fCount, #fList1, #esLength1)
       [bind: (#fList := #element) and (#eLength := #eLength) and (#restElements := #restElements) and (#restESLength := #restLength)] ;
     if (0 < #eCount1) then {
         apply PrependCElementsE(#definition, #buffer, #readPos + #eLength, #eCount1 - 1, #fCount, #restElements, #restESLength, #eCount2, #fList2, #esLength2);
-        unfold Elements(#definition, #buffer, (#eLength + #readPos), ((-1. + #eCount1) + #eCount2), #fCount, l+ (#restElements, #fList2), (#restESLength + #esLength2));
+        unfold Elements(#buffer, (#eLength + #readPos), ((-1. + #eCount1) + #eCount2), #fCount, #definition, l+ (#restElements, #fList2), (#restESLength + #esLength2));
         if (definition = "Incomplete") then {
             fold IElements(#buffer, #readPos, #eCount1 + #eCount2, #fCount, l+ (#fList1, #fList2), #esLength1 + #esLength2)
         }
@@ -167,13 +167,13 @@ lemma CElementsElementLength(buffer, readPos, eCount, fCount, eList, prefix, ele
 *)
 
 (* Broken serialised encryption context *)
-nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:List) :
+nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (2 <# l-len buffer) *
     (#rawKC == l-sub (buffer, 0, 2)) *
     rawToUInt16(#rawKC, false, #keyCount) *
     (0 <# #keyCount) * (ECKs == {{ }}) *
-    Elements("Incomplete", buffer, 2, #keyCount, 2, #eList, #esLength) *
+    Elements(buffer, 2, #keyCount, 2, "Incomplete", #eList, #esLength) *
     (errorMessage == "decodeEncryptionContext: Underflow, not enough data."),
 
     (* Too much data provided *)
@@ -181,7 +181,7 @@ nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:List) :
     (#rawKC == l-sub (buffer, 0, 2)) *
     rawToUInt16(#rawKC, false, #keyCount) *
     (0 <# #keyCount) *
-    Elements("Complete", buffer, 2, #keyCount, 2, ECKs, #ECKsLength) *
+    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
     (! (#ECKsLength + 2 == l-len buffer)) *
     (errorMessage == "decodeEncryptionContext: Overflow, too much data."),
 
@@ -190,15 +190,15 @@ nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:List) :
     (#rawKC == l-sub (buffer, 0, 2)) *
     rawToUInt16(#rawKC, false, #keyCount) *
     (0 <# #keyCount) *
-    Elements("Complete", buffer, 2, #keyCount, 2, ECKs, #ECKsLength) *
+    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Duplicated({{ }}, #ECKeys) *
     (2 + #ECKsLength == l-len buffer) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
 (* General serialised encryption context *)
-pred RawEncryptionContext(definition:Str, +buffer:List, ECKs:List, errorMessage:Str) :
+pred RawEncryptionContext(+buffer:List, definition:Str, ECKs:List, errorMessage:Str) :
   (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
-  (definition == "Broken")   * BRawEncryptionContext(errorMessage, buffer, ECKs);
+  (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
 
 (* Live decoded encryption context *)
 pred LiveDecodedEncryptionContext(+dECObj : Obj, +ECKs : List) :
@@ -247,7 +247,7 @@ nounfold pred EncryptedDataKey(+EDK, pId:Str, pInfo:Str, encryptedDataKey:List, 
 (***** Arrays of deserialised EDKs *****)
 
 (* Live array of deserialised EDKs *)
-pred ArrayOfDEDKsContents(+a:Obj, contents:List, +start:Num) :
+pred ArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
@@ -257,10 +257,10 @@ pred ArrayOfDEDKsContents(+a:Obj, contents:List, +start:Num) :
     (#element == {{ #rawId, #rawInfo, #encryptedDataKey }}) *
     (contents == #element :: #rest) *
     (#rest_start == start + 1) *
-    ArrayOfDEDKsContents(a, #rest, #rest_start);
+    ArrayOfDEDKsContents(a, #rest_start, #rest);
 
 (* Frozen array of deserialised EDKs *)
-pred FrozenArrayOfDEDKsContents(+a:Obj, contents:List, +start:Num) :
+pred FrozenArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
@@ -270,19 +270,19 @@ pred FrozenArrayOfDEDKsContents(+a:Obj, contents:List, +start:Num) :
     (#edk == {{ #rawId, #rawInfo, #encryptedDataKey }}) *
     (contents == #edk :: #rest_contents) *
     (#rest_start == start + 1) *
-    FrozenArrayOfDEDKsContents(a, #rest_contents, #rest_start);
+    FrozenArrayOfDEDKsContents(a, #rest_start, #rest_contents);
 
 (***** Deserialised EDKs *****)
 
 (* EDKs are first deserialised into a live array *)
 pred LiveDeserialisedEncryptedDataKeys (+a:Obj, EDKs:List) :
     ArrayStructure(a, l-len EDKs) *
-    ArrayOfDEDKsContents(a, EDKs, 0);
+    ArrayOfDEDKsContents(a, 0, EDKs);
 
 (* Deserialised EDKs are ultimately provided as a frozen array *)
 pred DeserialisedEncryptedDataKeys (+a:Obj, contents:List) :
     FrozenArrayStructure(a, l-len contents) *
-    FrozenArrayOfDEDKsContents(a, contents, 0);
+    FrozenArrayOfDEDKsContents(a, 0, contents);
 
 (************************************
  ************************************
@@ -500,7 +500,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
 
-    RawEncryptedDataKeys("Incomplete", rawHeaderData, 22 + ECLength, EDKs, _, errorMessage) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Incomplete", EDKs, _, errorMessage) *
     (contentType == 0) * (frameLength == 0) * (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
 
     (* Not enough data to read the header IV and the authentication tag *)
@@ -522,7 +522,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     CRawEncryptionContext(#EC, ECKs) *
 
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rawFrameLength, #rest)) *
-    RawEncryptedDataKeys("Complete", rawHeaderData, 22 + ECLength, EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (l-len #rawFrameLength == 4) *
     rawToUInt32(#rawFrameLength, false, frameLength) *
@@ -575,7 +575,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    BRawEncryptionContext(errorMessage, #EC, ECKs) *
+    BRawEncryptionContext(#EC, errorMessage, ECKs) *
 
     (EDKs == {{ }}) * (contentType == 0) * (frameLength == 0) *
     (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -597,7 +597,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
-    RawEncryptedDataKeys("Broken", rawHeaderData, 22 + ECLength, _, _, errorMessage) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Broken", _, _, errorMessage) *
 
     (EDKs == {{ }}) * (contentType == 0) * (frameLength == 0) *
     (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -620,7 +620,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, #rawReservedBytes, #rest)) *
-    RawEncryptedDataKeys("Complete", rawHeaderData, 22 + ECLength, EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (l-len #rawReservedBytes == 4) *
     rawToUInt32(#rawReservedBytes, false, #reservedBytes) *
@@ -649,7 +649,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rest)) *
-    RawEncryptedDataKeys("Complete", rawHeaderData, 22 + ECLength, EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (headerLength == 22 + ECLength + #EDKsLength + 1 + 4 + 1 + 4) *
     (headerLength + #ivLength + (#tagLength / 8) <=# l-len rawHeaderData) *
@@ -659,7 +659,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (frameLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }});
 
 (* General serialised header *)
-nounfold pred Header(definition, +rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
+nounfold pred Header(+rawHeaderData, definition, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
     (* Complete header *)
     (definition == "Complete") *
     CHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
@@ -678,7 +678,7 @@ nounfold pred Header(definition, +rawHeaderData, part_one, version, type, suiteI
   ********   Header         *******)
 
 (* Deserialised main part of the message header *)
-nounfold pred MessageHeader(+messageHeader, version, type, suiteId, messageId, +ECKs, EDKs, contentType, headerIvLength, frameLength) :
+nounfold pred MessageHeader(+messageHeader, +ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
     JSObject(messageHeader) *
     DataProp(messageHeader, "version", version) *
     DataProp(messageHeader, "type", type) *
@@ -695,11 +695,11 @@ nounfold pred MessageHeader(+messageHeader, version, type, suiteId, messageId, +
     DataProp(messageHeader, "frameLength", frameLength);
 
 (* Entire deserialised header *)
-nounfold pred HeaderInfo(+headerInfo, version, type, suiteId, messageId, +ECKs, EDKs, contentType, headerIvLength,
+nounfold pred HeaderInfo(+headerInfo, +ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
                             frameLength, headerLength, rawHeaderData, headerIv, headerAuthTag) :
     JSObject(headerInfo) *
     DataProp(headerInfo, "messageHeader", #messageHeader) *
-        MessageHeader(#messageHeader, version, type, suiteId, messageId, ECKs, EDKs, contentType, headerIvLength, frameLength) *
+        MessageHeader(#messageHeader, ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) *
     DataProp(headerInfo, "headerLength", headerLength) *
     DataProp(headerInfo, "algorithmSuite", #algoSuiteObject) *
         AlgorithmSuiteObject(#algoSuiteObject, headerIvLength, #tagLength) *

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/AmazonLogic.jsil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/AmazonLogic.jsil
@@ -167,7 +167,7 @@ lemma CElementsElementLength(buffer, readPos, eCount, fCount, eList, prefix, ele
 *)
 
 (* Broken serialised encryption context *)
-nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:List) :
+nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (2 <# l-len buffer) *
     (#rawKC == l-sub (buffer, 0, 2)) *
@@ -196,18 +196,18 @@ nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:List) :
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
 (* General serialised encryption context *)
-pred RawEncryptionContext(+buffer:List, definition:Str, ECKs:List, errorMessage:Str) :
+pred RawEncryptionContext(buffer:List; definition:Str, ECKs:List, errorMessage:Str) :
   (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
   (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
 
 (* Live decoded encryption context *)
-pred LiveDecodedEncryptionContext(+dECObj : Obj, +ECKs : List) :
+pred LiveDecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
     JSObjWithProto(dECObj, null) *
     toUtf8PairMap(ECKs, #utf8ECKs) *
     ObjectTable(dECObj, #utf8ECKs);
 
 (* Decoded encryption context *)
-pred DecodedEncryptionContext(+dECObj : Obj, +ECKs : List) :
+pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
     JSObjGeneral(dECObj, null, "Object", false) *
     toUtf8PairMap(ECKs, #utf8ECKs) *
     FrozenObjectTable(dECObj, #utf8ECKs);
@@ -226,12 +226,12 @@ pred DecodedEncryptionContext(+dECObj : Obj, +ECKs : List) :
 (***** EDK objects *****)
 
 (* Prototype of EDK objects *)
-pred EDKPrototype () :
+pred EDKPrototype (;) :
     JSObjGeneral($l_edk_proto, null, "Object", false) *
     empty_fields($l_edk_proto : -{ }-);
 
 (* EDK objects *)
-nounfold pred EncryptedDataKey(+EDK, pId:Str, pInfo:Str, encryptedDataKey:List, rawInfo:List) :
+nounfold pred EncryptedDataKey(EDK; pId:Str, pInfo:Str, encryptedDataKey:List, rawInfo:List) :
     JSObjGeneral(EDK, $l_edk_proto, "Object", false) *
     readOnlyProperty(EDK, "providerId", pId) *
     readOnlyProperty(EDK, "providerInfo", pInfo) *
@@ -247,7 +247,7 @@ nounfold pred EncryptedDataKey(+EDK, pId:Str, pInfo:Str, encryptedDataKey:List, 
 (***** Arrays of deserialised EDKs *****)
 
 (* Live array of deserialised EDKs *)
-pred ArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
+pred ArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
@@ -260,7 +260,7 @@ pred ArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
     ArrayOfDEDKsContents(a, #rest_start, #rest);
 
 (* Frozen array of deserialised EDKs *)
-pred FrozenArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
+pred FrozenArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
@@ -275,12 +275,12 @@ pred FrozenArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
 (***** Deserialised EDKs *****)
 
 (* EDKs are first deserialised into a live array *)
-pred LiveDeserialisedEncryptedDataKeys (+a:Obj, EDKs:List) :
+pred LiveDeserialisedEncryptedDataKeys (a:Obj; EDKs:List) :
     ArrayStructure(a, l-len EDKs) *
     ArrayOfDEDKsContents(a, 0, EDKs);
 
 (* Deserialised EDKs are ultimately provided as a frozen array *)
-pred DeserialisedEncryptedDataKeys (+a:Obj, contents:List) :
+pred DeserialisedEncryptedDataKeys (a:Obj; contents:List) :
     FrozenArrayStructure(a, l-len contents) *
     FrozenArrayOfDEDKsContents(a, 0, contents);
 
@@ -309,7 +309,7 @@ lemma toUtf8Injective(rawData1, utf8Data1, rawData2, utf8Data2)
     denotes that the raw bytes rawData are obtained by converting
     the string utf8Data into bytes
 *)
-abstract pure pred fromUtf8(+utf8Data:Str, rawData:List);
+abstract pure pred fromUtf8(utf8Data:Str; rawData:List);
 
 (* fromUtf8 is injective *)
 lemma fromUtf8Injective(utf8Data1, rawData1, utf8Data2, rawData2)
@@ -340,7 +340,7 @@ lemma fromUtf8toUtf8(utf8Data)
 ]]
 
 (* UTF-8 Mapping of lists *)
-pure pred toUtf8Map(+data : List, utf8Data : List) :
+pure pred toUtf8Map(data : List; utf8Data : List) :
     (data == {{ }}) * (utf8Data == {{ }}),
 
     (data == #fst :: #rest) *
@@ -420,7 +420,7 @@ lemma toUtf8PairMapAppendPair(data, utf8Data, prop, value)
  *****************************)
 
 (* The object that holds information about allowed algorithm suites *)
-pred AlgorithmSuiteIdentifierObject(o) :
+pred AlgorithmSuiteIdentifierObject(o;) :
     JSObject(o) *
     DataProp(o, "20",  "ALG_AES128_GCM_IV12_TAG16") * DataProp(o, "ALG_AES128_GCM_IV12_TAG16", 20) *
     DataProp(o, "70",  "ALG_AES192_GCM_IV12_TAG16") * DataProp(o, "ALG_AES192_GCM_IV12_TAG16", 70) *
@@ -430,7 +430,7 @@ pred AlgorithmSuiteIdentifierObject(o) :
     The object representing a given algorithm suite.
     TODO: This object is more complex than presented here.
  *)
-pred AlgorithmSuiteObject(+aso: Obj, ivLength: Num, tagLength: Num) :
+pred AlgorithmSuiteObject(aso: Obj; ivLength: Num, tagLength: Num) :
     JSObject(aso) *
     readOnlyProperty(aso, "ivLength",  ivLength) *
     readOnlyProperty(aso, "tagLength", tagLength);
@@ -445,7 +445,7 @@ pred AlgorithmSuiteObject(+aso: Obj, ivLength: Num, tagLength: Num) :
  ***************************)
 
 (* Broken version and type *)
-pred BVersionAndType(+version:Num, +type:Num, errorMessage:Str) :
+pred BVersionAndType(version:Num, type:Num; errorMessage:Str) :
     (version == 65) * (type == 89) * (errorMessage == "Malformed Header: This blob may be base64 encoded."),
     (! (version == 1) \/ ! (type == 128)) * (! (version == 65) \/ ! (type == 89)) * (errorMessage == "Malformed Header: Unsupported version and/or type.");
 
@@ -453,7 +453,7 @@ pred BVersionAndType(+version:Num, +type:Num, errorMessage:Str) :
   ********   Header       *******)
 
 (* Serialised incomplete header *)
-nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageId, ECLength,
+nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength,
                                       part_two, ECKs,
                                       part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) :
     (* Not enough data to read first part *)
@@ -532,7 +532,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (headerIv == {{ }}) * (headerAuthTag == {{ }});
 
 (* Broken serialised header *)
-nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageId, ECLength,
+nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength,
                                       part_two, ECKs,
                                       part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
     (* Incorrect version and/or type *)
@@ -659,7 +659,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (frameLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }});
 
 (* General serialised header *)
-nounfold pred Header(+rawHeaderData, definition, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
+nounfold pred Header(rawHeaderData; definition, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
     (* Complete header *)
     (definition == "Complete") *
     CHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
@@ -678,7 +678,7 @@ nounfold pred Header(+rawHeaderData, definition, part_one, version, type, suiteI
   ********   Header         *******)
 
 (* Deserialised main part of the message header *)
-nounfold pred MessageHeader(+messageHeader, +ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
+nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
     JSObject(messageHeader) *
     DataProp(messageHeader, "version", version) *
     DataProp(messageHeader, "type", type) *
@@ -695,7 +695,7 @@ nounfold pred MessageHeader(+messageHeader, +ECKs, version, type, suiteId, messa
     DataProp(messageHeader, "frameLength", frameLength);
 
 (* Entire deserialised header *)
-nounfold pred HeaderInfo(+headerInfo, +ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
+nounfold pred HeaderInfo(headerInfo, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
                             frameLength, headerLength, rawHeaderData, headerIv, headerAuthTag) :
     JSObject(headerInfo) *
     DataProp(headerInfo, "messageHeader", #messageHeader) *
@@ -1037,7 +1037,7 @@ lemma UniqueAppendElement(lst, element)
  ************************************)
 
 (* Lists with duplicates *)
-pure pred Duplicated(+prefix:List, +suffix:List) :
+pure pred Duplicated(prefix:List, suffix:List;) :
     (* Either the head is duplicated *)
     (suffix == #fst :: #rest) *
     ListToSet(prefix, #preSet) *
@@ -1058,7 +1058,7 @@ pure pred Duplicated(+prefix:List, +suffix:List) :
  *************************************)
 
 (* Object properties as a table *)
-pred ObjectTableStructure(+l:Obj, +PVPairs:List) :
+pred ObjectTableStructure(l:Obj, PVPairs:List;) :
     (* Base case - no properties left *)
     (PVPairs == {{ }}),
 
@@ -1068,7 +1068,7 @@ pred ObjectTableStructure(+l:Obj, +PVPairs:List) :
     ObjectTableStructure(l, #restPVPairs);
 
 (* Complete Object-as-Table predicate *)
-nounfold pred ObjectTable(+l:Obj, +PVPairs:List) :
+nounfold pred ObjectTable(l:Obj, PVPairs:List;) :
     ObjectTableStructure(l, PVPairs) *
     FirstProj(PVPairs, #pList) *
     ListToSet(#pList, #pSet) *
@@ -1091,7 +1091,7 @@ lemma ObjectTableAbsentProperty(l, PVPairs, prop)
 [*  *]
 
 (* Removing a property from a list of prop-value pairs *)
-pred RemoveProp(+PVPairs : List, +prop : Str, found : Bool, value : Str, newPairs : List) :
+pred RemoveProp(PVPairs : List, prop : Str; found : Bool, value : Str, newPairs : List) :
     (PVPairs == {{ }}) * (found == false) * (value == "") * (newPairs == {{ }}),
 
     (PVPairs == {{ prop, value }} :: newPairs) * (found == true),
@@ -1177,7 +1177,7 @@ lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
  *]
 
 (* Frozen object properties *)
-pred FrozenObjectTableStructure(+l:Obj, +PVPairs:List) :
+pred FrozenObjectTableStructure(l:Obj, PVPairs:List;) :
     (* Base case - no properties left *)
     (PVPairs == {{ }}),
 
@@ -1187,7 +1187,7 @@ pred FrozenObjectTableStructure(+l:Obj, +PVPairs:List) :
     FrozenObjectTableStructure(l, #restPVPairs);
 
 (* Frozen Object-as-Table predicate *)
-nounfold pred FrozenObjectTable(+l:Obj, +PVPairs:List) :
+nounfold pred FrozenObjectTable(l:Obj, PVPairs:List;) :
     FrozenObjectTableStructure(l, PVPairs) *
     FirstProj(PVPairs, #pList) *
     ListToSet(#pList, #pSet) *

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/AmazonLogic.jsil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/AmazonLogic.jsil
@@ -191,7 +191,7 @@ nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
     rawToUInt16(#rawKC, false; #keyCount) *
     (0 <# #keyCount) *
     Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Duplicated({{ }}, #ECKeys;) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Duplicated({{ }}, #ECKeys) *
     (2 + #ECKsLength == l-len buffer) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
@@ -201,16 +201,16 @@ pred RawEncryptionContext(buffer:List; definition:Str, ECKs:List, errorMessage:S
   (definition == "Broken")   * BRawEncryptionContext(buffer; errorMessage, ECKs);
 
 (* Live decoded encryption context *)
-pred LiveDecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
+pred LiveDecodedEncryptionContext(dECObj : Obj, ECKs : List) :
     JSObjWithProto(dECObj; null) *
     toUtf8PairMap(ECKs; #utf8ECKs) *
-    ObjectTable(dECObj, #utf8ECKs;);
+    ObjectTable(dECObj, #utf8ECKs);
 
 (* Decoded encryption context *)
-pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
+pred DecodedEncryptionContext(dECObj : Obj, ECKs : List) :
     JSObjGeneral(dECObj; null, "Object", false) *
     toUtf8PairMap(ECKs; #utf8ECKs) *
-    FrozenObjectTable(dECObj, #utf8ECKs;);
+    FrozenObjectTable(dECObj, #utf8ECKs);
 
 
 (*****************************
@@ -226,7 +226,7 @@ pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
 (***** EDK objects *****)
 
 (* Prototype of EDK objects *)
-pred EDKPrototype (;) :
+pred EDKPrototype () :
     JSObjGeneral($l_edk_proto; null, "Object", false) *
     empty_fields($l_edk_proto : -{ }-);
 
@@ -276,12 +276,12 @@ pred FrozenArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
 
 (* EDKs are first deserialised into a live array *)
 pred LiveDeserialisedEncryptedDataKeys (a:Obj; EDKs:List) :
-    ArrayStructure(a, l-len EDKs;) *
+    ArrayStructure(a, l-len EDKs) *
     ArrayOfDEDKsContents(a, 0; EDKs);
 
 (* Deserialised EDKs are ultimately provided as a frozen array *)
 pred DeserialisedEncryptedDataKeys (a:Obj; contents:List) :
-    FrozenArrayStructure(a, l-len contents;) *
+    FrozenArrayStructure(a, l-len contents) *
     FrozenArrayOfDEDKsContents(a, 0; contents);
 
 (************************************
@@ -420,8 +420,8 @@ lemma toUtf8PairMapAppendPair(data, utf8Data, prop, value)
  *****************************)
 
 (* The object that holds information about allowed algorithm suites *)
-pred AlgorithmSuiteIdentifierObject(o;) :
-    JSObject(o;) *
+pred AlgorithmSuiteIdentifierObject(o) :
+    JSObject(o) *
     DataProp(o, "20";  "ALG_AES128_GCM_IV12_TAG16") * DataProp(o, "ALG_AES128_GCM_IV12_TAG16"; 20) *
     DataProp(o, "70";  "ALG_AES192_GCM_IV12_TAG16") * DataProp(o, "ALG_AES192_GCM_IV12_TAG16"; 70) *
     empty_fields(o : -{ "20", "70", "ALG_AES128_GCM_IV12_TAG16", "ALG_AES192_GCM_IV12_TAG16" }-);
@@ -431,7 +431,7 @@ pred AlgorithmSuiteIdentifierObject(o;) :
     TODO: This object is more complex than presented here.
  *)
 pred AlgorithmSuiteObject(aso: Obj; ivLength: Num, tagLength: Num) :
-    JSObject(aso;) *
+    JSObject(aso) *
     readOnlyProperty(aso, "ivLength";  ivLength) *
     readOnlyProperty(aso, "tagLength"; tagLength);
 
@@ -472,7 +472,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -490,7 +490,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -511,7 +511,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -550,7 +550,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (22 <=# l-len rawHeaderData) *
     (rawHeaderData == l+ ({{ version, type }}, #rawSuiteId, #rest)) *
     (l-len #rawSuiteId == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     BAlgorithmSuite(suiteId; errorMessage) *
 
@@ -567,7 +567,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -588,7 +588,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -610,7 +610,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -639,7 +639,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, #ivLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -679,7 +679,7 @@ nounfold pred Header(rawHeaderData; definition, part_one, version, type, suiteId
 
 (* Deserialised main part of the message header *)
 nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
-    JSObject(messageHeader;) *
+    JSObject(messageHeader) *
     DataProp(messageHeader, "version"; version) *
     DataProp(messageHeader, "type"; type) *
     DataProp(messageHeader, "suiteId"; suiteId) *
@@ -687,7 +687,7 @@ nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, message
         Uint8Array(#ui8aMessageId; #abMessageId, 0, 16) *
         ArrayBuffer(#abMessageId; messageId) *
     DataProp(messageHeader, "encryptionContext"; #dECObj) *
-        DecodedEncryptionContext(#dECObj, ECKs;) *
+        DecodedEncryptionContext(#dECObj, ECKs) *
     DataProp(messageHeader, "encryptedDataKeys"; #dEDKs) *
         DeserialisedEncryptedDataKeys(#dEDKs; EDKs) *
     DataProp(messageHeader, "contentType"; contentType) *
@@ -697,7 +697,7 @@ nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, message
 (* Entire deserialised header *)
 nounfold pred HeaderInfo(headerInfo, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
                             frameLength, headerLength, rawHeaderData, headerIv, headerAuthTag) :
-    JSObject(headerInfo;) *
+    JSObject(headerInfo) *
     DataProp(headerInfo, "messageHeader"; #messageHeader) *
         MessageHeader(#messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) *
     DataProp(headerInfo, "headerLength"; headerLength) *
@@ -987,7 +987,7 @@ lemma NotInListToUtf8(prop, props)
    no element from the right is on the left *)
 lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
 [[
-    (#props == l+ (#prefix, #suffix)) * Unique(#props;) *
+    (#props == l+ (#prefix, #suffix)) * Unique(#props) *
     ListToSet(#prefix; #setPrefix) * ListToSet(#suffix; #setSuffix) *
     (#prop --e-- #setSuffix)
 ]]
@@ -1012,11 +1012,11 @@ lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
 (* Appending an element to a unique list *)
 lemma UniqueAppendElement(lst, element)
 [[
-    Unique(#lst;) * ListToSet(#lst; #set) *
+    Unique(#lst) * ListToSet(#lst; #set) *
     (! (#element --e-- #set))
 ]]
 [[
-    Unique(l+ (#lst, {{ #element }});)
+    Unique(l+ (#lst, {{ #element }}))
 ]]
 [*
     unfold Unique(#lst) [bind: (#fst := #fst) and (#rest := #rest) and (#setRest1 := #setRest)];
@@ -1037,7 +1037,7 @@ lemma UniqueAppendElement(lst, element)
  ************************************)
 
 (* Lists with duplicates *)
-pure pred Duplicated(prefix:List, suffix:List;) :
+pure pred Duplicated(prefix:List, suffix:List) :
     (* Either the head is duplicated *)
     (suffix == #fst :: #rest) *
     ListToSet(prefix; #preSet) *
@@ -1047,7 +1047,7 @@ pure pred Duplicated(prefix:List, suffix:List;) :
     (suffix == #fst :: #rest) *
     ListToSet(prefix; #preSet) *
     (! (#fst --e-- #preSet)) *
-    Duplicated(l+ (prefix, {{ #fst }}), #rest;);
+    Duplicated(l+ (prefix, {{ #fst }}), #rest);
 
 (*************************************
  *************************************
@@ -1058,18 +1058,18 @@ pure pred Duplicated(prefix:List, suffix:List;) :
  *************************************)
 
 (* Object properties as a table *)
-pred ObjectTableStructure(l:Obj, PVPairs:List;) :
+pred ObjectTableStructure(l:Obj, PVPairs:List) :
     (* Base case - no properties left *)
     (PVPairs == {{ }}),
 
     (* Recursive case - one property and the rest *)
     (PVPairs == {{ #prop, #value }} :: #restPVPairs) *
     DataProp(l, #prop; #value) * types(#value : Str) *
-    ObjectTableStructure(l, #restPVPairs;);
+    ObjectTableStructure(l, #restPVPairs);
 
 (* Complete Object-as-Table predicate *)
-nounfold pred ObjectTable(l:Obj, PVPairs:List;) :
-    ObjectTableStructure(l, PVPairs;) *
+nounfold pred ObjectTable(l:Obj, PVPairs:List) :
+    ObjectTableStructure(l, PVPairs) *
     FirstProj(PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet);
@@ -1077,14 +1077,14 @@ nounfold pred ObjectTable(l:Obj, PVPairs:List;) :
 (* Object-as-Table absent property *)
 lemma ObjectTableAbsentProperty(l, PVPairs, prop)
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     FirstProj(#PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet) *
     (! (#prop --e-- #pSet))
 ]]
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     ((#l, #prop) -> none) *
     empty_fields(#l : -u- (#pSet, -{ #prop }-))
 ]]
@@ -1107,14 +1107,14 @@ pred RemoveProp(PVPairs : List, prop : Str; found : Bool, value : Str, newPairs 
 (* Object-as-Table present property *)
 lemma ObjectTablePresentProperty(l, PVPairs, prop)
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     FirstProj(#PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     (#prop --e-- #pSet)
 ]]
 [[
     RemoveProp(#PVPairs, #prop; true, #value, #newPairs) *
-    ObjectTableStructure(#l, #newPairs;) *
+    ObjectTableStructure(#l, #newPairs) *
     DataProp(#l, #prop; #value) * types(#value : Str)
 ]]
 [*
@@ -1124,7 +1124,7 @@ lemma ObjectTablePresentProperty(l, PVPairs, prop)
         unfold ListToSet(#pList, #pSet)
     } else {
         sep_assert (#PVPairs == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (ObjectTableStructure(#l, #restPVPairs;));
+        sep_assert (ObjectTableStructure(#l, #restPVPairs));
         if (not (#fProp = #prop)) then {
             unfold FirstProj(#PVPairs, #pList);
             unfold ListToSet(#pList, #pSet);
@@ -1136,20 +1136,20 @@ lemma ObjectTablePresentProperty(l, PVPairs, prop)
 (* Appending property to Object-as-Table structure from the right *)
 lemma ObjectTableStructureAppendPVPair(l, PVPairs, prop, value)
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     FirstProj(#PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     (! (#prop --e-- #pSet)) *
     DataProp(#l, #prop; #value) * types(#value : Str)
 ]]
 [[
-    ObjectTableStructure(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }});)
+    ObjectTableStructure(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }}))
 ]]
 [*
     unfold ObjectTableStructure(#l, #PVPairs);
     if (not (#PVPairs = {{ }})) then {
         sep_assert (#PVPairs == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (ObjectTableStructure(#l, #restPVPairs;));
+        sep_assert (ObjectTableStructure(#l, #restPVPairs));
         unfold FirstProj(#PVPairs, #pList);
         unfold ListToSet(#pList, #pSet);
         apply ObjectTableStructureAppendPVPair(#l, #restPVPairs, #prop, #value);
@@ -1160,7 +1160,7 @@ lemma ObjectTableStructureAppendPVPair(l, PVPairs, prop, value)
 (* Appending property to Object-as-Table from the right *)
 lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     FirstProj(#PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     (! (#prop --e-- #pSet)) *
@@ -1168,7 +1168,7 @@ lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
     empty_fields(l : -u- (#pSet, -{ #prop }-))
 ]]
 [[
-    ObjectTable(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }});)
+    ObjectTable(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }}))
 ]]
 [*
     apply FirstProjAppendPair(#PVPairs, #pList, #prop, #value);
@@ -1177,18 +1177,18 @@ lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
  *]
 
 (* Frozen object properties *)
-pred FrozenObjectTableStructure(l:Obj, PVPairs:List;) :
+pred FrozenObjectTableStructure(l:Obj, PVPairs:List) :
     (* Base case - no properties left *)
     (PVPairs == {{ }}),
 
     (* Recursive case - one property and the rest *)
     (PVPairs == {{ #prop, #value }} :: #restPVPairs) *
     DataPropConst(l, #prop; #value, true) *
-    FrozenObjectTableStructure(l, #restPVPairs;);
+    FrozenObjectTableStructure(l, #restPVPairs);
 
 (* Frozen Object-as-Table predicate *)
-nounfold pred FrozenObjectTable(l:Obj, PVPairs:List;) :
-    FrozenObjectTableStructure(l, PVPairs;) *
+nounfold pred FrozenObjectTable(l:Obj, PVPairs:List) :
+    FrozenObjectTableStructure(l, PVPairs) *
     FirstProj(PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet);
@@ -1236,11 +1236,11 @@ normal;
 [[
     (l == #l) *
     JSObjGeneral(#l; #proto, #class, #ext) *
-    ObjectTable(#l, #PVPairs;)
+    ObjectTable(#l, #PVPairs)
 ]]
 [[
     JSObjGeneral(#l; #proto, #class, false) *
-    FrozenObjectTable(#l, #PVPairs;)
+    FrozenObjectTable(#l, #PVPairs)
 ]]
 normal
 

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/AmazonLogic.jsil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/AmazonLogic.jsil
@@ -1,10 +1,10 @@
 (* The length of an element is not smaller than the length of its first field *)
 lemma CElementFirstFieldLength(buffer, readPos, fCount, field, restFields, eLength)
 [[
-    CElement(#buffer, #readPos, #fCount, l+({{ #field }}, #restFields), #eLength)
+    CElement(#buffer, #readPos, #fCount; l+({{ #field }}, #restFields), #eLength)
 ]]
 [[
-    CElement(#buffer, #readPos, #fCount, l+({{ #field }}, #restFields), #eLength) *
+    CElement(#buffer, #readPos, #fCount; l+({{ #field }}, #restFields), #eLength) *
     (2 + l-len #field <=# #eLength)
 ]]
 [*
@@ -14,35 +14,35 @@ lemma CElementFirstFieldLength(buffer, readPos, fCount, field, restFields, eLeng
 (* The length of a non-empty complete element is strictly positive *)
 lemma CElementNonEmptyPositiveLength(buffer, readPos, fCount, fList, eLength)
 [[
-    CElement(#buffer, #readPos, #fCount, #fList, #eLength) * (0 <# #fCount)
+    CElement(#buffer, #readPos, #fCount; #fList, #eLength) * (0 <# #fCount)
 ]]
 [[
-    CElement(#buffer, #readPos, #fCount, #fList, #eLength) *
+    CElement(#buffer, #readPos, #fCount; #fList, #eLength) *
     (0 <# #eLength)
 ]]
 [*
     unfold CElement(#buffer, #readPos, #fCount, #fList, #eLength);
-    sep_assert (Field(#buffer, #readPos, #field, #fLength)) [bind: #fLength];
-    sep_assert (CElement(#buffer, #readPos + #fLength, #fCount - 1, #restFields, #restELength)) [bind: #restELength]
+    sep_assert (Field(#buffer, #readPos; #field, #fLength)) [bind: #fLength];
+    sep_assert (CElement(#buffer, #readPos + #fLength, #fCount - 1; #restFields, #restELength)) [bind: #restELength]
 *]
 
 (* Appending the first field of a given complete element to a complete element on its left *)
 lemma AppendFieldCC(buffer, readPos, fCount1, fList1, eLength1, fCount2, field, fList2, eLength2)
 [[
-    CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1) *
-    CElement(#buffer, #readPos + #eLength1, #fCount2, l+({{ #field }}, #fList2), #eLength2) *
+    CElement(#buffer, #readPos, #fCount1; #fList1, #eLength1) *
+    CElement(#buffer, #readPos + #eLength1, #fCount2; l+({{ #field }}, #fList2), #eLength2) *
     (#shift == 2 + l-len #field)
 ]]
 [[
-    CElement(#buffer, #readPos, #fCount1 + 1, l+ (#fList1, {{ #field }}), #eLength1 + #shift) *
-    CElement(#buffer, #readPos + #eLength1 + #shift, #fCount2 - 1, #fList2, #eLength2 - #shift)
+    CElement(#buffer, #readPos, #fCount1 + 1; l+ (#fList1, {{ #field }}), #eLength1 + #shift) *
+    CElement(#buffer, #readPos + #eLength1 + #shift, #fCount2 - 1; #fList2, #eLength2 - #shift)
 ]]
 [*
     apply CElementFirstFieldLength(#buffer, #readPos + #eLength1, #fCount2, #field, #fList2, #eLength2);
     unfold CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1);
     if (0 < #fCount1) then {
         sep_assert (#fList1 == l+ ({{ #fl1 }}, #rfl1)) [bind: #fl1, #rfl1];
-        sep_assert (CElement(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1)) [bind: #reL1];
+        sep_assert (CElement(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1; #rfl1, #reL1)) [bind: #reL1];
         apply AppendFieldCC(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1, #fCount2, #field, #fList2, #eLength2)
     }
 *]
@@ -52,18 +52,18 @@ lemma AppendFieldCC(buffer, readPos, fCount1, fList1, eLength1, fCount2, field, 
 (* Appending a complete element to the given complete elements from the right *)
 lemma CElementsAppend(buffer, readPos, eCount, fCount, eList, esLength, fList, eLength)
 [[
-    CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
-    CElement(#buffer, #readPos + #esLength, #fCount, #fList, #eLength)
+    CElements(#buffer, #readPos, #eCount, #fCount; #eList, #esLength) *
+    CElement(#buffer, #readPos + #esLength, #fCount; #fList, #eLength)
 ]]
 [[
-    CElements(#buffer, #readPos, #eCount + 1, #fCount, l+ (#eList, {{ #fList }}), #esLength + #eLength)
+    CElements(#buffer, #readPos, #eCount + 1, #fCount; l+ (#eList, {{ #fList }}), #esLength + #eLength)
 ]]
 [*
     apply CElementNonEmptyPositiveLength(#buffer, #readPos + #esLength, #fCount, #fList, #eLength);
     unfold CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength);
     if (0 < #eCount) then {
-        sep_assert (CElement(#buffer, #readPos, #fCount, #newElementFieldList, #newElementLength)) [bind: #newElementFieldList, #newElementLength];
-        sep_assert (CElements(#buffer, (#readPos + #newElementLength), (#eCount - 1), #fCount, #remainingElementsList, #remainingElementsLength)) [bind: #remainingElementsList, #remainingElementsLength];
+        sep_assert (CElement(#buffer, #readPos, #fCount; #newElementFieldList, #newElementLength)) [bind: #newElementFieldList, #newElementLength];
+        sep_assert (CElements(#buffer, (#readPos + #newElementLength), (#eCount - 1), #fCount; #remainingElementsList, #remainingElementsLength)) [bind: #remainingElementsList, #remainingElementsLength];
         apply CElementsAppend(#buffer, (#readPos + #newElementLength), (#eCount - 1), #fCount, #remainingElementsList, #remainingElementsLength, #fList, #eLength)
     }
  *]
@@ -71,19 +71,19 @@ lemma CElementsAppend(buffer, readPos, eCount, fCount, eList, esLength, fList, e
 (* Appending the first field of a given incomplete element to a complete element on its left *)
 lemma AppendFieldCI(buffer, readPos, fCount1, fList1, eLength1, fCount2, field, fList2, eLength2)
 [[
-    CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1) *
-    IElement(#buffer, #readPos + #eLength1, #fCount2, l+({{ #field }}, #fList2), #eLength2) *
+    CElement(#buffer, #readPos, #fCount1; #fList1, #eLength1) *
+    IElement(#buffer, #readPos + #eLength1, #fCount2; l+({{ #field }}, #fList2), #eLength2) *
     (#shift == 2 + l-len #field)
 ]]
 [[
-    CElement(#buffer, #readPos, #fCount1 + 1, l+ (#fList1, {{ #field }}), #eLength1 + #shift) *
-    IElement(#buffer, #readPos + #eLength1 + #shift, #fCount2 - 1, #fList2, #eLength2 - #shift)
+    CElement(#buffer, #readPos, #fCount1 + 1; l+ (#fList1, {{ #field }}), #eLength1 + #shift) *
+    IElement(#buffer, #readPos + #eLength1 + #shift, #fCount2 - 1; #fList2, #eLength2 - #shift)
 ]]
 [*
     unfold CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1);
     if (0 < #fCount1) then {
         sep_assert (#fList1 == l+ ({{ #fl1 }}, #rfl1)) [bind: #fl1, #rfl1];
-        sep_assert (CElement(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1)) [bind: #reL1];
+        sep_assert (CElement(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1; #rfl1, #reL1)) [bind: #reL1];
         apply AppendFieldCI(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1, #fCount2, #field, #fList2, #eLength2)
     }
 *]
@@ -91,17 +91,17 @@ lemma AppendFieldCI(buffer, readPos, fCount1, fList1, eLength1, fCount2, field, 
 (* Prepend an entire complete element to an incomplete element following it *)
 lemma PrependCElementI(buffer, readPos, fCount1, fList1, eLength1, fCount2, fList2, eLength2)
 [[
-    CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1) *
-    IElement(#buffer, #readPos + #eLength1, #fCount2, #fList2, #eLength2)
+    CElement(#buffer, #readPos, #fCount1; #fList1, #eLength1) *
+    IElement(#buffer, #readPos + #eLength1, #fCount2; #fList2, #eLength2)
 ]]
 [[
-    IElement(#buffer, #readPos, #fCount1 + #fCount2, l+ (#fList1, #fList2), #eLength1 + #eLength2)
+    IElement(#buffer, #readPos, #fCount1 + #fCount2; l+ (#fList1, #fList2), #eLength1 + #eLength2)
 ]]
 [*
     unfold CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1);
     if (0 < #fCount1) then {
         sep_assert (#fList1 == l+ ({{ #fl1 }}, #rfl1)) [bind: #fl1, #rfl1];
-        sep_assert (CElement(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1)) [bind: #reL1];
+        sep_assert (CElement(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1; #rfl1, #reL1)) [bind: #reL1];
         apply PrependCElementI(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1, #fCount2, #fList2, #eLength2)
     }
 *]
@@ -109,11 +109,11 @@ lemma PrependCElementI(buffer, readPos, fCount1, fList1, eLength1, fCount2, fLis
 (* An entire complete element sequence can be prepended to a general element sequence *)
 lemma PrependCElementsE(definition, buffer, readPos, eCount1, fCount, fList1, esLength1, eCount2, fList2, esLength2)
 [[
-    CElements(#buffer, #readPos, #eCount1, #fCount, #fList1, #esLength1) *
-    Elements(#buffer, #readPos + #esLength1, #eCount2, #fCount, #definition, #fList2, #esLength2)
+    CElements(#buffer, #readPos, #eCount1, #fCount; #fList1, #esLength1) *
+    Elements(#buffer, #readPos + #esLength1, #eCount2, #fCount; #definition, #fList2, #esLength2)
 ]]
 [[
-    Elements(#buffer, #readPos, #eCount1 + #eCount2, #fCount, #definition, l+ (#fList1, #fList2), #esLength1 + #esLength2)
+    Elements(#buffer, #readPos, #eCount1 + #eCount2, #fCount; #definition, l+ (#fList1, #fList2), #esLength1 + #esLength2)
 ]]
 [*
     unfold CElements(#buffer, #readPos, #eCount1, #fCount, #fList1, #esLength1)
@@ -130,20 +130,20 @@ lemma PrependCElementsE(definition, buffer, readPos, eCount1, fCount, fList1, es
 (* Every element of an element sequence has the same number of fields *)
 lemma CElementsElementLength(buffer, readPos, eCount, fCount, eList, prefix, element, suffix)
 [[
-    CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
+    CElements(#buffer, #readPos, #eCount, #fCount; #eList, #esLength) *
     (#eList == l+ (#prefix, {{ #element }}, #suffix))
 ]]
 [[
-    CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
+    CElements(#buffer, #readPos, #eCount, #fCount; #eList, #esLength) *
     (l-len #element == #fCount)
 ]]
 [*
     apply DestructList(#prefix);
     unfold CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength);
     if (not (#prefix = {{ }})) then {
-        sep_assert (CElement(#buffer, #readPos, #fCount, #fList, #elementLength)) [bind: #elementLength];
+        sep_assert (CElement(#buffer, #readPos, #fCount; #fList, #elementLength)) [bind: #elementLength];
         sep_assert (#prefix == #head :: #rest) [bind: #head, #rest];
-        sep_assert (CElements(#buffer, (#readPos + #elementLength), (#eCount - 1), #fCount, l+ (#rest, {{#element}}, #suffix), #restESLength)) [bind: #restESLength];
+        sep_assert (CElements(#buffer, (#readPos + #elementLength), (#eCount - 1), #fCount; l+ (#rest, {{#element}}, #suffix), #restESLength)) [bind: #restESLength];
         apply CElementsElementLength(#buffer, (#readPos + #elementLength), (#eCount - 1), #fCount, l+ (#rest, {{#element}}, #suffix), #rest, #element, #suffix)
     }
  *]
@@ -171,46 +171,46 @@ nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (2 <# l-len buffer) *
     (#rawKC == l-sub (buffer, 0, 2)) *
-    rawToUInt16(#rawKC, false, #keyCount) *
+    rawToUInt16(#rawKC, false; #keyCount) *
     (0 <# #keyCount) * (ECKs == {{ }}) *
-    Elements(buffer, 2, #keyCount, 2, "Incomplete", #eList, #esLength) *
+    Elements(buffer, 2, #keyCount, 2; "Incomplete", #eList, #esLength) *
     (errorMessage == "decodeEncryptionContext: Underflow, not enough data."),
 
     (* Too much data provided *)
     (2 <# l-len buffer) *
     (#rawKC == l-sub (buffer, 0, 2)) *
-    rawToUInt16(#rawKC, false, #keyCount) *
+    rawToUInt16(#rawKC, false; #keyCount) *
     (0 <# #keyCount) *
-    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
+    Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
     (! (#ECKsLength + 2 == l-len buffer)) *
     (errorMessage == "decodeEncryptionContext: Overflow, too much data."),
 
     (* Duplicated key in context *)
     (2 <# l-len buffer) *
     (#rawKC == l-sub (buffer, 0, 2)) *
-    rawToUInt16(#rawKC, false, #keyCount) *
+    rawToUInt16(#rawKC, false; #keyCount) *
     (0 <# #keyCount) *
-    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Duplicated({{ }}, #ECKeys) *
+    Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Duplicated({{ }}, #ECKeys;) *
     (2 + #ECKsLength == l-len buffer) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
 (* General serialised encryption context *)
 pred RawEncryptionContext(buffer:List; definition:Str, ECKs:List, errorMessage:Str) :
-  (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
-  (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
+  (definition == "Complete") * CRawEncryptionContext(buffer; ECKs) * (errorMessage == ""),
+  (definition == "Broken")   * BRawEncryptionContext(buffer; errorMessage, ECKs);
 
 (* Live decoded encryption context *)
 pred LiveDecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
-    JSObjWithProto(dECObj, null) *
-    toUtf8PairMap(ECKs, #utf8ECKs) *
-    ObjectTable(dECObj, #utf8ECKs);
+    JSObjWithProto(dECObj; null) *
+    toUtf8PairMap(ECKs; #utf8ECKs) *
+    ObjectTable(dECObj, #utf8ECKs;);
 
 (* Decoded encryption context *)
 pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
-    JSObjGeneral(dECObj, null, "Object", false) *
-    toUtf8PairMap(ECKs, #utf8ECKs) *
-    FrozenObjectTable(dECObj, #utf8ECKs);
+    JSObjGeneral(dECObj; null, "Object", false) *
+    toUtf8PairMap(ECKs; #utf8ECKs) *
+    FrozenObjectTable(dECObj, #utf8ECKs;);
 
 
 (*****************************
@@ -227,21 +227,21 @@ pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
 
 (* Prototype of EDK objects *)
 pred EDKPrototype (;) :
-    JSObjGeneral($l_edk_proto, null, "Object", false) *
+    JSObjGeneral($l_edk_proto; null, "Object", false) *
     empty_fields($l_edk_proto : -{ }-);
 
 (* EDK objects *)
 nounfold pred EncryptedDataKey(EDK; pId:Str, pInfo:Str, encryptedDataKey:List, rawInfo:List) :
-    JSObjGeneral(EDK, $l_edk_proto, "Object", false) *
-    readOnlyProperty(EDK, "providerId", pId) *
-    readOnlyProperty(EDK, "providerInfo", pInfo) *
-    readOnlyProperty(EDK, "encryptedDataKey", #aEDK) *
-        Uint8Array(#aEDK, #abEDK, 0, #viewSizeEDK) *
-        ArrayBuffer(#abEDK, encryptedDataKey) *
+    JSObjGeneral(EDK; $l_edk_proto, "Object", false) *
+    readOnlyProperty(EDK, "providerId"; pId) *
+    readOnlyProperty(EDK, "providerInfo"; pInfo) *
+    readOnlyProperty(EDK, "encryptedDataKey"; #aEDK) *
+        Uint8Array(#aEDK; #abEDK, 0, #viewSizeEDK) *
+        ArrayBuffer(#abEDK; encryptedDataKey) *
         (#viewSizeEDK == l-len encryptedDataKey) *
-    readOnlyProperty(EDK, "rawInfo", #aRInfo) *
-        Uint8Array(#aRInfo, #abRInfo, 0, #viewSizeRInfo) *
-        ArrayBuffer(#abRInfo, rawInfo) *
+    readOnlyProperty(EDK, "rawInfo"; #aRInfo) *
+        Uint8Array(#aRInfo; #abRInfo, 0, #viewSizeRInfo) *
+        ArrayBuffer(#abRInfo; rawInfo) *
         (#viewSizeRInfo == l-len rawInfo);
 
 (***** Arrays of deserialised EDKs *****)
@@ -251,38 +251,38 @@ pred ArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
-    DataProp(a, #index, #edk) *
-    EncryptedDataKey(#edk, #pId, #pInfo, #encryptedDataKey, #rawInfo) *
-    fromUtf8(#rawId, #pId) * fromUtf8(#pInfo, #rawInfo) *
+    DataProp(a, #index; #edk) *
+    EncryptedDataKey(#edk; #pId, #pInfo, #encryptedDataKey, #rawInfo) *
+    fromUtf8(#rawId; #pId) * fromUtf8(#pInfo; #rawInfo) *
     (#element == {{ #rawId, #rawInfo, #encryptedDataKey }}) *
     (contents == #element :: #rest) *
     (#rest_start == start + 1) *
-    ArrayOfDEDKsContents(a, #rest_start, #rest);
+    ArrayOfDEDKsContents(a, #rest_start; #rest);
 
 (* Frozen array of deserialised EDKs *)
 pred FrozenArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
-    readOnlyProperty(a, #index, #edk) *
-    EncryptedDataKey(#edk, #pId, #pInfo, #encryptedDataKey, #rawInfo) *
-    fromUtf8(#rawId, #pId) * fromUtf8(#pInfo, #rawInfo) *
+    readOnlyProperty(a, #index; #edk) *
+    EncryptedDataKey(#edk; #pId, #pInfo, #encryptedDataKey, #rawInfo) *
+    fromUtf8(#rawId; #pId) * fromUtf8(#pInfo; #rawInfo) *
     (#edk == {{ #rawId, #rawInfo, #encryptedDataKey }}) *
     (contents == #edk :: #rest_contents) *
     (#rest_start == start + 1) *
-    FrozenArrayOfDEDKsContents(a, #rest_start, #rest_contents);
+    FrozenArrayOfDEDKsContents(a, #rest_start; #rest_contents);
 
 (***** Deserialised EDKs *****)
 
 (* EDKs are first deserialised into a live array *)
 pred LiveDeserialisedEncryptedDataKeys (a:Obj; EDKs:List) :
-    ArrayStructure(a, l-len EDKs) *
-    ArrayOfDEDKsContents(a, 0, EDKs);
+    ArrayStructure(a, l-len EDKs;) *
+    ArrayOfDEDKsContents(a, 0; EDKs);
 
 (* Deserialised EDKs are ultimately provided as a frozen array *)
 pred DeserialisedEncryptedDataKeys (a:Obj; contents:List) :
-    FrozenArrayStructure(a, l-len contents) *
-    FrozenArrayOfDEDKsContents(a, 0, contents);
+    FrozenArrayStructure(a, l-len contents;) *
+    FrozenArrayOfDEDKsContents(a, 0; contents);
 
 (************************************
  ************************************
@@ -297,7 +297,7 @@ pred DeserialisedEncryptedDataKeys (a:Obj; contents:List) :
 (* toUtf8 is injective *)
 lemma toUtf8Injective(rawData1, utf8Data1, rawData2, utf8Data2)
 [[
-    toUtf8(#rawData1, #utf8Data1) * toUtf8(#rawData2, #utf8Data2)
+    toUtf8(#rawData1; #utf8Data1) * toUtf8(#rawData2; #utf8Data2)
 ]]
 [[
     (#rawData1 == #rawData2) * (#utf8Data1 == #utf8Data2);
@@ -305,7 +305,7 @@ lemma toUtf8Injective(rawData1, utf8Data1, rawData2, utf8Data2)
 ]]
 
 (*
-    fromUtf8(utf8Data, rawData) is an abstract predicate which
+    fromUtf8(utf8Data; rawData) is an abstract predicate which
     denotes that the raw bytes rawData are obtained by converting
     the string utf8Data into bytes
 *)
@@ -314,7 +314,7 @@ abstract pure pred fromUtf8(utf8Data:Str; rawData:List);
 (* fromUtf8 is injective *)
 lemma fromUtf8Injective(utf8Data1, rawData1, utf8Data2, rawData2)
 [[
-    fromUtf8(#utf8Data1, #rawData1) * fromUtf8(#utf8Data2, #rawData2)
+    fromUtf8(#utf8Data1; #rawData1) * fromUtf8(#utf8Data2; #rawData2)
 ]]
 [[
     (#utf8Data1 == #utf8Data2) * (#rawData1 == #rawData2);
@@ -324,19 +324,19 @@ lemma fromUtf8Injective(utf8Data1, rawData1, utf8Data2, rawData2)
 (* Invertibility of toUtf8 with respect to fromUtf8 *)
 lemma toUtf8fromUtf8(rawData)
 [[
-    toUtf8(#rawData, #utf8Data)
+    toUtf8(#rawData; #utf8Data)
 ]]
 [[
-    fromUtf8(#utf8Data, #rawData)
+    fromUtf8(#utf8Data; #rawData)
 ]]
 
 (* Invertibility of fromUtf8 with respect to toUtf8 *)
 lemma fromUtf8toUtf8(utf8Data)
 [[
-    fromUtf8(#utf8Data, #rawData)
+    fromUtf8(#utf8Data; #rawData)
 ]]
 [[
-    toUtf8(#rawData, #utf8Data)
+    toUtf8(#rawData; #utf8Data)
 ]]
 
 (* UTF-8 Mapping of lists *)
@@ -344,14 +344,14 @@ pure pred toUtf8Map(data : List; utf8Data : List) :
     (data == {{ }}) * (utf8Data == {{ }}),
 
     (data == #fst :: #rest) *
-    (toUtf8(#fst, #utf8Fst)) *
-    toUtf8Map(#rest, #utf8Rest) *
+    (toUtf8(#fst; #utf8Fst)) *
+    toUtf8Map(#rest; #utf8Rest) *
     (utf8Data == #utf8Fst :: #utf8Rest);
 
 (* toUtf8PairMap is injective *)
 lemma toUtf8MapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
 [[
-    toUtf8Map(#rawData1, #utf8Data1) * toUtf8Map(#rawData2, #utf8Data2)
+    toUtf8Map(#rawData1; #utf8Data1) * toUtf8Map(#rawData2; #utf8Data2)
 ]]
 [[
     (#rawData1 == #rawData2) * (#utf8Data1 == #utf8Data2);
@@ -372,7 +372,7 @@ lemma toUtf8MapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
 (* toUtf8PairMap is injective *)
 lemma toUtf8PairMapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
 [[
-    toUtf8PairMap(#rawData1, #utf8Data1) * toUtf8PairMap(#rawData2, #utf8Data2)
+    toUtf8PairMap(#rawData1; #utf8Data1) * toUtf8PairMap(#rawData2; #utf8Data2)
 ]]
 [[
     (#rawData1 == #rawData2) * (#utf8Data1 == #utf8Data2);
@@ -394,18 +394,18 @@ lemma toUtf8PairMapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
 (* Appending a pair to a mapping of lists of pairs *)
 lemma toUtf8PairMapAppendPair(data, utf8Data, prop, value)
 [[
-    toUtf8PairMap(#data, #utf8Data) *
-    toUtf8(#prop, #utf8Prop) *
-    toUtf8(#value, #utf8Value)
+    toUtf8PairMap(#data; #utf8Data) *
+    toUtf8(#prop; #utf8Prop) *
+    toUtf8(#value; #utf8Value)
 ]]
 [[
-    toUtf8PairMap(l+ (#data, {{ {{ #prop, #value }} }}), l+ (#utf8Data, {{ {{ #utf8Prop, #utf8Value }} }}))
+    toUtf8PairMap(l+ (#data, {{ {{ #prop, #value }} }}); l+ (#utf8Data, {{ {{ #utf8Prop, #utf8Value }} }}))
 ]]
 [*
     unfold toUtf8PairMap(#data, #utf8Data);
     if (not (#data = {{ }})) then {
         sep_assert (#data == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (toUtf8PairMap(#restPVPairs, #restUtf8Data)) [bind: #restUtf8Data];
+        sep_assert (toUtf8PairMap(#restPVPairs; #restUtf8Data)) [bind: #restUtf8Data];
         apply toUtf8PairMapAppendPair(#restPVPairs, #restUtf8Data, #prop, #value)
     }
 *]
@@ -421,9 +421,9 @@ lemma toUtf8PairMapAppendPair(data, utf8Data, prop, value)
 
 (* The object that holds information about allowed algorithm suites *)
 pred AlgorithmSuiteIdentifierObject(o;) :
-    JSObject(o) *
-    DataProp(o, "20",  "ALG_AES128_GCM_IV12_TAG16") * DataProp(o, "ALG_AES128_GCM_IV12_TAG16", 20) *
-    DataProp(o, "70",  "ALG_AES192_GCM_IV12_TAG16") * DataProp(o, "ALG_AES192_GCM_IV12_TAG16", 70) *
+    JSObject(o;) *
+    DataProp(o, "20";  "ALG_AES128_GCM_IV12_TAG16") * DataProp(o, "ALG_AES128_GCM_IV12_TAG16"; 20) *
+    DataProp(o, "70";  "ALG_AES192_GCM_IV12_TAG16") * DataProp(o, "ALG_AES192_GCM_IV12_TAG16"; 70) *
     empty_fields(o : -{ "20", "70", "ALG_AES128_GCM_IV12_TAG16", "ALG_AES192_GCM_IV12_TAG16" }-);
 
 (*
@@ -431,9 +431,9 @@ pred AlgorithmSuiteIdentifierObject(o;) :
     TODO: This object is more complex than presented here.
  *)
 pred AlgorithmSuiteObject(aso: Obj; ivLength: Num, tagLength: Num) :
-    JSObject(aso) *
-    readOnlyProperty(aso, "ivLength",  ivLength) *
-    readOnlyProperty(aso, "tagLength", tagLength);
+    JSObject(aso;) *
+    readOnlyProperty(aso, "ivLength";  ivLength) *
+    readOnlyProperty(aso, "tagLength"; tagLength);
 
 (***************************
  ***************************
@@ -472,10 +472,10 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (l-len rawHeaderData <# 22 + ECLength) *
 
     (ECKs == {{ }}) *
@@ -490,17 +490,17 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
 
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Incomplete", EDKs, _, errorMessage) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Incomplete", EDKs, _, errorMessage) *
     (contentType == 0) * (frameLength == 0) * (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
 
     (* Not enough data to read the header IV and the authentication tag *)
@@ -511,21 +511,21 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
 
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rawFrameLength, #rest)) *
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (l-len #rawFrameLength == 4) *
-    rawToUInt32(#rawFrameLength, false, frameLength) *
+    rawToUInt32(#rawFrameLength, false; frameLength) *
     (headerLength == 22 + ECLength + #EDKsLength + 1 + 4 + 1 + 4) *
     (l-len rawHeaderData <# headerLength + headerIvLength + (#tagLength / 8)) *
 
@@ -538,7 +538,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (* Incorrect version and/or type *)
     (22 <=# l-len rawHeaderData) *
     (rawHeaderData == l+ ({{ version, type }}, #rest)) *
-    BVersionAndType(version, type, errorMessage) *
+    BVersionAndType(version, type; errorMessage) *
 
     (part_one == {{ }}) *
     (suiteId == 0) * (messageId == {{ }}) * (ECLength == 0) *
@@ -550,9 +550,9 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (22 <=# l-len rawHeaderData) *
     (rawHeaderData == l+ ({{ version, type }}, #rawSuiteId, #rest)) *
     (l-len #rawSuiteId == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    BAlgorithmSuite(suiteId, errorMessage) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    BAlgorithmSuite(suiteId; errorMessage) *
 
     (part_one == {{ }}) * (messageId == {{ }}) * (ECLength == 0) *
     (part_two == {{ }}) * (ECKs == {{ }}) *
@@ -567,15 +567,15 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    BRawEncryptionContext(#EC, errorMessage, ECKs) *
+    BRawEncryptionContext(#EC; errorMessage, ECKs) *
 
     (EDKs == {{ }}) * (contentType == 0) * (frameLength == 0) *
     (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -588,16 +588,16 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Broken", _, _, errorMessage) *
+    CRawEncryptionContext(#EC; ECKs) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Broken", _, _, errorMessage) *
 
     (EDKs == {{ }}) * (contentType == 0) * (frameLength == 0) *
     (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -610,20 +610,20 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, #rawReservedBytes, #rest)) *
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (l-len #rawReservedBytes == 4) *
-    rawToUInt32(#rawReservedBytes, false, #reservedBytes) *
+    rawToUInt32(#rawReservedBytes, false; #reservedBytes) *
     (! (#reservedBytes == 0)) *
     (headerLength == 22 + ECLength + #EDKsLength + 1 + 4 + 1 + 4) *
     (headerLength + headerIvLength + (#tagLength / 8) <=# l-len rawHeaderData) *
@@ -639,17 +639,17 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, #ivLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, #ivLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rest)) *
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (headerLength == 22 + ECLength + #EDKsLength + 1 + 4 + 1 + 4) *
     (headerLength + #ivLength + (#tagLength / 8) <=# l-len rawHeaderData) *
@@ -662,56 +662,56 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
 nounfold pred Header(rawHeaderData; definition, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
     (* Complete header *)
     (definition == "Complete") *
-    CHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
+    CHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
     (errorMessage == ""),
 
     (* Incomplete header *)
     (definition == "Incomplete") *
-    IHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
+    IHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
     (errorMessage == ""),
 
     (* Broken header *)
     (definition == "Broken") *
-    BHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage);
+    BHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage);
 
  (********   Deserialised   *******
   ********   Header         *******)
 
 (* Deserialised main part of the message header *)
 nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
-    JSObject(messageHeader) *
-    DataProp(messageHeader, "version", version) *
-    DataProp(messageHeader, "type", type) *
-    DataProp(messageHeader, "suiteId", suiteId) *
-    DataProp(messageHeader, "messageId", #ui8aMessageId) *
-        Uint8Array(#ui8aMessageId, #abMessageId, 0, 16) *
-        ArrayBuffer(#abMessageId, messageId) *
-    DataProp(messageHeader, "encryptionContext", #dECObj) *
-        DecodedEncryptionContext(#dECObj, ECKs) *
-    DataProp(messageHeader, "encryptedDataKeys", #dEDKs) *
-        DeserialisedEncryptedDataKeys(#dEDKs, EDKs) *
-    DataProp(messageHeader, "contentType", contentType) *
-    DataProp(messageHeader, "headerIvLength", headerIvLength) *
-    DataProp(messageHeader, "frameLength", frameLength);
+    JSObject(messageHeader;) *
+    DataProp(messageHeader, "version"; version) *
+    DataProp(messageHeader, "type"; type) *
+    DataProp(messageHeader, "suiteId"; suiteId) *
+    DataProp(messageHeader, "messageId"; #ui8aMessageId) *
+        Uint8Array(#ui8aMessageId; #abMessageId, 0, 16) *
+        ArrayBuffer(#abMessageId; messageId) *
+    DataProp(messageHeader, "encryptionContext"; #dECObj) *
+        DecodedEncryptionContext(#dECObj, ECKs;) *
+    DataProp(messageHeader, "encryptedDataKeys"; #dEDKs) *
+        DeserialisedEncryptedDataKeys(#dEDKs; EDKs) *
+    DataProp(messageHeader, "contentType"; contentType) *
+    DataProp(messageHeader, "headerIvLength"; headerIvLength) *
+    DataProp(messageHeader, "frameLength"; frameLength);
 
 (* Entire deserialised header *)
 nounfold pred HeaderInfo(headerInfo, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
                             frameLength, headerLength, rawHeaderData, headerIv, headerAuthTag) :
-    JSObject(headerInfo) *
-    DataProp(headerInfo, "messageHeader", #messageHeader) *
-        MessageHeader(#messageHeader, ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) *
-    DataProp(headerInfo, "headerLength", headerLength) *
-    DataProp(headerInfo, "algorithmSuite", #algoSuiteObject) *
-        AlgorithmSuiteObject(#algoSuiteObject, headerIvLength, #tagLength) *
-    DataProp(headerInfo, "rawHeader", #rawHeader) *
-        Uint8Array(#rawHeader, #rawBuffer, 0, headerLength) *
-        ArrayBuffer(#rawBuffer, rawHeaderData) *
-    DataProp(headerInfo, "headerIv", #ui8aHeaderIv) *
-        Uint8Array(#ui8aHeaderIv, #abHeaderIv, 0, headerIvLength) *
-        ArrayBuffer(#abHeaderIv, headerIv) *
-    DataProp(headerInfo, "headerAuthTag", #ui8aHeaderAuthTag) *
-        Uint8Array(#ui8aHeaderAuthTag, #abHeaderAuthTag, 0, #tagLength / 8) *
-        ArrayBuffer(#abHeaderAuthTag, headerAuthTag);
+    JSObject(headerInfo;) *
+    DataProp(headerInfo, "messageHeader"; #messageHeader) *
+        MessageHeader(#messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) *
+    DataProp(headerInfo, "headerLength"; headerLength) *
+    DataProp(headerInfo, "algorithmSuite"; #algoSuiteObject) *
+        AlgorithmSuiteObject(#algoSuiteObject; headerIvLength, #tagLength) *
+    DataProp(headerInfo, "rawHeader"; #rawHeader) *
+        Uint8Array(#rawHeader; #rawBuffer, 0, headerLength) *
+        ArrayBuffer(#rawBuffer; rawHeaderData) *
+    DataProp(headerInfo, "headerIv"; #ui8aHeaderIv) *
+        Uint8Array(#ui8aHeaderIv; #abHeaderIv, 0, headerIvLength) *
+        ArrayBuffer(#abHeaderIv; headerIv) *
+    DataProp(headerInfo, "headerAuthTag"; #ui8aHeaderAuthTag) *
+        Uint8Array(#ui8aHeaderAuthTag; #abHeaderAuthTag, 0, #tagLength / 8) *
+        ArrayBuffer(#abHeaderAuthTag; headerAuthTag);
 
 (*****************************
  *****************************
@@ -762,7 +762,7 @@ lemma DestructList(lst)
 (* FirstProj is a function *)
 lemma FirstProjFunction(lst1, proj1, lst2, proj2)
 [[
-    FirstProj(#lst1, #proj1) * FirstProj(#lst2, #proj2) * (#lst1 == #lst2)
+    FirstProj(#lst1; #proj1) * FirstProj(#lst2; #proj2) * (#lst1 == #lst2)
 ]]
 [[
     (#proj1 == #proj2)
@@ -778,16 +778,16 @@ lemma FirstProjFunction(lst1, proj1, lst2, proj2)
 (* Adding a pair to a first projection *)
 lemma FirstProjAppendPair(lst, fProj, prop, value)
 [[
-    FirstProj(#lst, #fProj)
+    FirstProj(#lst; #fProj)
 ]]
 [[
-    FirstProj(l+ (#lst, {{ {{ #prop, #value }} }}), l+ (#fProj, {{ #prop }}))
+    FirstProj(l+ (#lst, {{ {{ #prop, #value }} }}); l+ (#fProj, {{ #prop }}))
 ]]
 [*
     unfold FirstProj(#lst, #fProj);
     if (not (#lst = {{ }})) then {
         sep_assert (#lst == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (FirstProj(#restPVPairs, #restProj)) [bind: #restProj];
+        sep_assert (FirstProj(#restPVPairs; #restProj)) [bind: #restProj];
         apply FirstProjAppendPair(#restPVPairs, #restProj, #prop, #value)
     }
 *]
@@ -795,8 +795,8 @@ lemma FirstProjAppendPair(lst, fProj, prop, value)
 (* First projection goes through concatenation *)
 lemma FirstProjConcatSplit(PVPairs, prefix, suffix)
 [[
-    (#PVPairs == l+ (#prefix, #suffix)) * FirstProj(#PVPairs, #props) *
-    FirstProj(#prefix, #preProps) * FirstProj(#suffix, #sufProps)
+    (#PVPairs == l+ (#prefix, #suffix)) * FirstProj(#PVPairs; #props) *
+    FirstProj(#prefix; #preProps) * FirstProj(#suffix; #sufProps)
 ]]
 [[
     (#props == l+ (#preProps, #sufProps))
@@ -816,12 +816,12 @@ lemma FirstProjConcatSplit(PVPairs, prefix, suffix)
 (* Compatibility of first projection and toUtf8 *)
 lemma FirstProjToUtf8MapPairCompat(PVPairs)
 [[
-    FirstProj(#PVPairs, #props) *
-    toUtf8PairMap(#PVPairs, #utf8PVPairs) *
-    FirstProj(#utf8PVPairs, #utf8Props)
+    FirstProj(#PVPairs; #props) *
+    toUtf8PairMap(#PVPairs; #utf8PVPairs) *
+    FirstProj(#utf8PVPairs; #utf8Props)
 ]]
 [[
-    toUtf8Map(#props, #utf8Props)
+    toUtf8Map(#props; #utf8Props)
 ]]
 [*
     unfold FirstProj(#PVPairs, #props);
@@ -844,7 +844,7 @@ lemma FirstProjToUtf8MapPairCompat(PVPairs)
 (* ListToSet is a function *)
 lemma ListToSetFunction(lst1, set1, lst2, set2)
 [[
-    ListToSet(#lst1, #set1) * ListToSet(#lst2, #set2) * (#lst1 == #lst2)
+    ListToSet(#lst1; #set1) * ListToSet(#lst2; #set2) * (#lst1 == #lst2)
 ]]
 [[
     (#set1 == #set2)
@@ -860,7 +860,7 @@ lemma ListToSetFunction(lst1, set1, lst2, set2)
 (* ListToSet concat-union compatibility *)
 lemma ListToSetUnion(lst1, lst2)
 [[
-    ListToSet(#lst1, #set1) * ListToSet(#lst2, #set2) * ListToSet(l+ (#lst1, #lst2), #uset)
+    ListToSet(#lst1; #set1) * ListToSet(#lst2; #set2) * ListToSet(l+ (#lst1, #lst2); #uset)
 ]]
 [[
     (#uset == -u- (#set1, #set2))
@@ -882,7 +882,7 @@ lemma ProduceListToSet(lst)
     types(lst: List)
 ]]
 [[
-    ListToSet(#lst, #set)
+    ListToSet(#lst; #set)
 ]]
 [*
     apply DestructList(#lst);
@@ -895,16 +895,16 @@ lemma ProduceListToSet(lst)
 (* Adding an element in list-to-set conversion *)
 lemma ListToSetAddElement(lst, set, element)
 [[
-    ListToSet(#lst, #set)
+    ListToSet(#lst; #set)
 ]]
 [[
-    ListToSet(l+ (#lst, {{ #element }}), -u- (#set, -{ #element }-))
+    ListToSet(l+ (#lst, {{ #element }}); -u- (#set, -{ #element }-))
 ]]
 [*
     unfold ListToSet(#lst, #element);
     if (not (#lst = {{ }})) then {
         sep_assert (#lst == l+ ({{ #fProp }}, #restLst)) [bind: #fProp, #restLst];
-        sep_assert (ListToSet(#restLst, #restSet)) [bind: #restSet];
+        sep_assert (ListToSet(#restLst; #restSet)) [bind: #restSet];
         apply ListToSetAddElement(#restLst, #restSet, #element)
     }
 *]
@@ -913,7 +913,7 @@ lemma ListToSetAddElement(lst, set, element)
 lemma HeadInSet(lst)
 [[
     (#lst == #hd :: #tl) *
-    ListToSet(#lst, #set)
+    ListToSet(#lst; #set)
 ]]
 [[
     (#hd --e-- #set)
@@ -923,11 +923,11 @@ lemma HeadInSet(lst)
 (* toUtf8 mapping and list membership, positive *)
 lemma InListToUtf8(prop, props)
 [[
-    ListToSet(#props, #propsSet) *
+    ListToSet(#props; #propsSet) *
     (#prop --e-- #propsSet) *
-    toUtf8(#prop, #utf8Prop) *
-    toUtf8Map(#props, #utf8Props) *
-    ListToSet(#utf8Props, #utf8PropsSet)
+    toUtf8(#prop; #utf8Prop) *
+    toUtf8Map(#props; #utf8Props) *
+    ListToSet(#utf8Props; #utf8PropsSet)
 ]]
 [[
     (#utf8Prop --e-- #utf8PropsSet)
@@ -937,7 +937,7 @@ lemma InListToUtf8(prop, props)
     if (not (#props = {{ }})) then {
         sep_assert (#props == #fstProp :: #rest) [bind: #rest];
         unfold toUtf8Map(#props, #utf8Props);
-        sep_assert (toUtf8(#fstProp, #utf8FstProp)) [bind: #utf8FstProp];
+        sep_assert (toUtf8(#fstProp; #utf8FstProp)) [bind: #utf8FstProp];
         sep_assert (#utf8Props == #utf8FstProp :: #restUtf8) [bind: #restUtf8];
         unfold ListToSet(#utf8Props, #utf8PropsSet);
         if (#prop = #fstProp) then {
@@ -952,11 +952,11 @@ lemma InListToUtf8(prop, props)
 (* toUtf8 mapping and list membership, negative *)
 lemma NotInListToUtf8(prop, props)
 [[
-    ListToSet(#props, #propsSet) *
+    ListToSet(#props; #propsSet) *
     (! (#prop --e-- #propsSet)) *
-    toUtf8(#prop, #utf8Prop) *
-    toUtf8Map(#props, #utf8Props) *
-    ListToSet(#utf8Props, #utf8PropsSet)
+    toUtf8(#prop; #utf8Prop) *
+    toUtf8Map(#props; #utf8Props) *
+    ListToSet(#utf8Props; #utf8PropsSet)
 ]]
 [[
     (! (#utf8Prop --e-- #utf8PropsSet))
@@ -968,7 +968,7 @@ lemma NotInListToUtf8(prop, props)
 
     if (not (#props = {{ }})) then {
         sep_assert (#props == #fstProp :: #rest) [bind: #rest];
-        sep_assert (toUtf8(#fstProp, #utf8FstProp)) [bind: #utf8FstProp];
+        sep_assert (toUtf8(#fstProp; #utf8FstProp)) [bind: #utf8FstProp];
         apply toUtf8Injective(#prop, #utf8Prop, #fstProp, #utf8FstProp);
         apply NotInListToUtf8(#prop, #rest)
     }
@@ -987,8 +987,8 @@ lemma NotInListToUtf8(prop, props)
    no element from the right is on the left *)
 lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
 [[
-    (#props == l+ (#prefix, #suffix)) * Unique(#props) *
-    ListToSet(#prefix, #setPrefix) * ListToSet(#suffix, #setSuffix) *
+    (#props == l+ (#prefix, #suffix)) * Unique(#props;) *
+    ListToSet(#prefix; #setPrefix) * ListToSet(#suffix; #setSuffix) *
     (#prop --e-- #setSuffix)
 ]]
 [[
@@ -1012,11 +1012,11 @@ lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
 (* Appending an element to a unique list *)
 lemma UniqueAppendElement(lst, element)
 [[
-    Unique(#lst) * ListToSet(#lst, #set) *
+    Unique(#lst;) * ListToSet(#lst; #set) *
     (! (#element --e-- #set))
 ]]
 [[
-    Unique(l+ (#lst, {{ #element }}))
+    Unique(l+ (#lst, {{ #element }});)
 ]]
 [*
     unfold Unique(#lst) [bind: (#fst := #fst) and (#rest := #rest) and (#setRest1 := #setRest)];
@@ -1040,14 +1040,14 @@ lemma UniqueAppendElement(lst, element)
 pure pred Duplicated(prefix:List, suffix:List;) :
     (* Either the head is duplicated *)
     (suffix == #fst :: #rest) *
-    ListToSet(prefix, #preSet) *
+    ListToSet(prefix; #preSet) *
     (#fst --e-- #preSet),
 
     (* Or the duplication is in the tail *)
     (suffix == #fst :: #rest) *
-    ListToSet(prefix, #preSet) *
+    ListToSet(prefix; #preSet) *
     (! (#fst --e-- #preSet)) *
-    Duplicated(l+ (prefix, {{ #fst }}), #rest);
+    Duplicated(l+ (prefix, {{ #fst }}), #rest;);
 
 (*************************************
  *************************************
@@ -1064,27 +1064,27 @@ pred ObjectTableStructure(l:Obj, PVPairs:List;) :
 
     (* Recursive case - one property and the rest *)
     (PVPairs == {{ #prop, #value }} :: #restPVPairs) *
-    DataProp(l, #prop, #value) * types(#value : Str) *
-    ObjectTableStructure(l, #restPVPairs);
+    DataProp(l, #prop; #value) * types(#value : Str) *
+    ObjectTableStructure(l, #restPVPairs;);
 
 (* Complete Object-as-Table predicate *)
 nounfold pred ObjectTable(l:Obj, PVPairs:List;) :
-    ObjectTableStructure(l, PVPairs) *
-    FirstProj(PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(l, PVPairs;) *
+    FirstProj(PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet);
 
 (* Object-as-Table absent property *)
 lemma ObjectTableAbsentProperty(l, PVPairs, prop)
 [[
-    ObjectTableStructure(#l, #PVPairs) *
-    FirstProj(#PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(#l, #PVPairs;) *
+    FirstProj(#PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet) *
     (! (#prop --e-- #pSet))
 ]]
 [[
-    ObjectTableStructure(#l, #PVPairs) *
+    ObjectTableStructure(#l, #PVPairs;) *
     ((#l, #prop) -> none) *
     empty_fields(#l : -u- (#pSet, -{ #prop }-))
 ]]
@@ -1097,25 +1097,25 @@ pred RemoveProp(PVPairs : List, prop : Str; found : Bool, value : Str, newPairs 
     (PVPairs == {{ prop, value }} :: newPairs) * (found == true),
 
     (PVPairs == {{ #fstProp, #fstValue }} :: #restPVPairs) *
-    (! (#fstProp == prop)) * RemoveProp(#restPVPairs, prop, false, value, newPairs) *
+    (! (#fstProp == prop)) * RemoveProp(#restPVPairs, prop; false, value, newPairs) *
     (found == false),
 
     (PVPairs == {{ #fstProp, #fstValue }} :: #restPVPairs) *
-    (! (#fstProp == prop)) * RemoveProp(#restPVPairs, prop, true, value, #restNewPairs) *
+    (! (#fstProp == prop)) * RemoveProp(#restPVPairs, prop; true, value, #restNewPairs) *
     (found == true) * (newPairs == {{ #fstProp, #fstValue }} :: #restNewPairs);
 
 (* Object-as-Table present property *)
 lemma ObjectTablePresentProperty(l, PVPairs, prop)
 [[
-    ObjectTableStructure(#l, #PVPairs) *
-    FirstProj(#PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(#l, #PVPairs;) *
+    FirstProj(#PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     (#prop --e-- #pSet)
 ]]
 [[
-    RemoveProp(#PVPairs, #prop, true, #value, #newPairs) *
-    ObjectTableStructure(#l, #newPairs) *
-    DataProp(#l, #prop, #value) * types(#value : Str)
+    RemoveProp(#PVPairs, #prop; true, #value, #newPairs) *
+    ObjectTableStructure(#l, #newPairs;) *
+    DataProp(#l, #prop; #value) * types(#value : Str)
 ]]
 [*
     unfold ObjectTableStructure(#l, #PVPairs);
@@ -1124,7 +1124,7 @@ lemma ObjectTablePresentProperty(l, PVPairs, prop)
         unfold ListToSet(#pList, #pSet)
     } else {
         sep_assert (#PVPairs == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (ObjectTableStructure(#l, #restPVPairs));
+        sep_assert (ObjectTableStructure(#l, #restPVPairs;));
         if (not (#fProp = #prop)) then {
             unfold FirstProj(#PVPairs, #pList);
             unfold ListToSet(#pList, #pSet);
@@ -1136,20 +1136,20 @@ lemma ObjectTablePresentProperty(l, PVPairs, prop)
 (* Appending property to Object-as-Table structure from the right *)
 lemma ObjectTableStructureAppendPVPair(l, PVPairs, prop, value)
 [[
-    ObjectTableStructure(#l, #PVPairs) *
-    FirstProj(#PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(#l, #PVPairs;) *
+    FirstProj(#PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     (! (#prop --e-- #pSet)) *
-    DataProp(#l, #prop, #value) * types(#value : Str)
+    DataProp(#l, #prop; #value) * types(#value : Str)
 ]]
 [[
-    ObjectTableStructure(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }}))
+    ObjectTableStructure(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }});)
 ]]
 [*
     unfold ObjectTableStructure(#l, #PVPairs);
     if (not (#PVPairs = {{ }})) then {
         sep_assert (#PVPairs == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (ObjectTableStructure(#l, #restPVPairs));
+        sep_assert (ObjectTableStructure(#l, #restPVPairs;));
         unfold FirstProj(#PVPairs, #pList);
         unfold ListToSet(#pList, #pSet);
         apply ObjectTableStructureAppendPVPair(#l, #restPVPairs, #prop, #value);
@@ -1160,15 +1160,15 @@ lemma ObjectTableStructureAppendPVPair(l, PVPairs, prop, value)
 (* Appending property to Object-as-Table from the right *)
 lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
 [[
-    ObjectTableStructure(#l, #PVPairs) *
-    FirstProj(#PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(#l, #PVPairs;) *
+    FirstProj(#PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     (! (#prop --e-- #pSet)) *
-    DataProp(#l, #prop, #value) * types(#value : Str) *
+    DataProp(#l, #prop; #value) * types(#value : Str) *
     empty_fields(l : -u- (#pSet, -{ #prop }-))
 ]]
 [[
-    ObjectTable(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }}))
+    ObjectTable(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }});)
 ]]
 [*
     apply FirstProjAppendPair(#PVPairs, #pList, #prop, #value);
@@ -1183,14 +1183,14 @@ pred FrozenObjectTableStructure(l:Obj, PVPairs:List;) :
 
     (* Recursive case - one property and the rest *)
     (PVPairs == {{ #prop, #value }} :: #restPVPairs) *
-    DataPropConst(l, #prop, #value, true) *
-    FrozenObjectTableStructure(l, #restPVPairs);
+    DataPropConst(l, #prop; #value, true) *
+    FrozenObjectTableStructure(l, #restPVPairs;);
 
 (* Frozen Object-as-Table predicate *)
 nounfold pred FrozenObjectTable(l:Obj, PVPairs:List;) :
-    FrozenObjectTableStructure(l, PVPairs) *
-    FirstProj(PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    FrozenObjectTableStructure(l, PVPairs;) *
+    FirstProj(PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet);
 
 (******************************
@@ -1209,13 +1209,13 @@ axiomatic incomplete spec AP_map (xsc, vthis, cfun)
 (* Mapping EDKs into the resulting decoded EDK array *)
 [[
     (vthis == #vthis) * (cfun == #cfun) *
-    JSFunctionObject(#cfun, "aux_deserializeEncryptedDataKey", #a_sc, #a_len, #a_proto) *
-    ArrayOfArraysOfUInt8Arrays(#vthis, #EDKs)
+    JSFunctionObject(#cfun; "aux_deserializeEncryptedDataKey", #a_sc, #a_len, #a_proto) *
+    ArrayOfArraysOfUInt8Arrays(#vthis; #EDKs)
 ]]
 [[
-    JSFunctionObject(#cfun, "aux_deserializeEncryptedDataKey", #a_sc, #a_len, #a_proto) *
-    ArrayOfArraysOfUInt8Arrays(#vthis, #EDKs) *
-    types(ret : Obj) * LiveDeserialisedEncryptedDataKeys(ret, #EDKs)
+    JSFunctionObject(#cfun; "aux_deserializeEncryptedDataKey", #a_sc, #a_len, #a_proto) *
+    ArrayOfArraysOfUInt8Arrays(#vthis; #EDKs) *
+    types(ret : Obj) * LiveDeserialisedEncryptedDataKeys(ret; #EDKs)
 ]]
 normal
 
@@ -1224,10 +1224,10 @@ axiomatic spec Object_freeze(xsc, vthis, l)
 (* Freezing an array of deserialised EDKs *)
 <deserialised_EDKS>
 [[
-    (l == #l) * LiveDeserialisedEncryptedDataKeys(#l, #EDKs)
+    (l == #l) * LiveDeserialisedEncryptedDataKeys(#l; #EDKs)
 ]]
 [[
-    DeserialisedEncryptedDataKeys(#l, #EDKs) * (ret == #l)
+    DeserialisedEncryptedDataKeys(#l; #EDKs) * (ret == #l)
 ]]
 normal;
 
@@ -1235,12 +1235,12 @@ normal;
 <object_table : #PVPairs>
 [[
     (l == #l) *
-    JSObjGeneral(#l, #proto, #class, #ext) *
-    ObjectTable(#l, #PVPairs)
+    JSObjGeneral(#l; #proto, #class, #ext) *
+    ObjectTable(#l, #PVPairs;)
 ]]
 [[
-    JSObjGeneral(#l, #proto, #class, false) *
-    FrozenObjectTable(#l, #PVPairs)
+    JSObjGeneral(#l; #proto, #class, false) *
+    FrozenObjectTable(#l, #PVPairs;)
 ]]
 normal
 

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/ByteLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/ByteLogic.gil
@@ -7,13 +7,13 @@
  ****************************************)
 
 (* Interpretation: one byte as an unsigned 8-bit integer *)
-pure pred rawToUInt8(+bytes:List, num:Num) :
+pure pred rawToUInt8(bytes:List; num:Num) :
     (bytes == {{ #b0 }}) * (num == #b0) *
     (0 <=# #b0) * (#b0 <# 256);
 
 (* Interpretation: two bytes as an unsigned 16-bit integer *)
 @nopath
-pure pred rawToUInt16(+bytes:List, +littleEndian:Bool, num:Num) :
+pure pred rawToUInt16(bytes:List, littleEndian:Bool; num:Num) :
     (littleEndian == false) *
       (bytes == {{ #b0, #b1 }}) *
       (0 <=# #b0) * (#b0 <# 256) *
@@ -28,7 +28,7 @@ pure pred rawToUInt16(+bytes:List, +littleEndian:Bool, num:Num) :
 
 (* Interpretation: four bytes as an unsigned 32-bit integer *)
 @nopath
-pure pred rawToUInt32(+bytes:List, +littleEndian:Bool, num:Num) :
+pure pred rawToUInt32(bytes:List, littleEndian:Bool; num:Num) :
     (littleEndian == false) *
       (bytes == {{ #b0, #b1, #b2, #b3 }}) *
       (0 <=# #b0) * (#b0 <# 256) *

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/EncryptionHeaderLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/EncryptionHeaderLogic.gil
@@ -16,7 +16,7 @@
 *)
 pred Field(buffer : List, readPos : Num; field : List, length : Num) :
   (0 <=# readPos) * (#rawFL == l-sub(buffer, readPos, 2)) *
-    rawToUInt16(#rawFL, false, #fLength) *
+    rawToUInt16(#rawFL, false; #fLength) *
     (field == l-sub(buffer, (readPos + 2), #fLength)) *
     (length == (2 + #fLength)) * ((readPos + length) <=# (l-len buffer));
   facts: (2 <=# length);
@@ -71,14 +71,14 @@ pred IElement(buffer : List, readPos : Num, fCount : Num; fList : List, eLength 
 
   (* Base case: enough data to read length of next field, but not enough data to read next field *)
   (0 <=# readPos) * (0 <# fCount) * ((readPos + 2) <=# (l-len buffer)) *
-    (#rawFL == l-sub(buffer, readPos, 2)) * rawToUInt16(#rawFL, false, #fLength) *
+    (#rawFL == l-sub(buffer, readPos, 2)) * rawToUInt16(#rawFL, false; #fLength) *
     ((l-len buffer) <# ((readPos + 2) + #fLength)) * (fList == {{  }}) *
     (eLength == ((l-len buffer) - (readPos + 2))),
 
   (* Recursive case: enough data to read one field, but not enough data to read the remaining ones *)
-  (0 <=# readPos) * (1 <# fCount) * Field(buffer, readPos, #field, #fLength) *
+  (0 <=# readPos) * (1 <# fCount) * Field(buffer, readPos; #field, #fLength) *
     (#restFCount == (fCount - 1)) * ((readPos + #fLength) <=# (l-len buffer)) *
-    IElement(buffer, (readPos + #fLength), #restFCount, #restFList, #restELength) *
+    IElement(buffer, (readPos + #fLength), #restFCount; #restFList, #restELength) *
     (fList == l+ ({{ #field }}, #restFList)) *
     (eLength == (#fLength + #restELength));
 
@@ -125,13 +125,13 @@ pred IElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
                eList : List, esLength : Num) :
   (* Base case: single incomplete element *)
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * (0 <# eCount) * (0 <# fCount) *
-    IElement(buffer, readPos, fCount, #fList, esLength) * (eList == {{  }}),
+    IElement(buffer, readPos, fCount; #fList, esLength) * (eList == {{  }}),
 
   (* Recursive case: enough data to read first element, but not enough data to read the remaining ones *)
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * (1 <# eCount) * (0 <# fCount) *
-    CElement(buffer, readPos, fCount, #fList, #eLength) *
+    CElement(buffer, readPos, fCount; #fList, #eLength) *
     (#restECount == (eCount - 1)) *
-    IElements(buffer, (readPos + #eLength), #restECount, fCount, #restEList, #restESLength) *
+    IElements(buffer, (readPos + #eLength), #restECount, fCount; #restEList, #restESLength) *
     (eList == l+ ({{ #fList }}, #restEList)) * (esLength == (#eLength + #restESLength));
   facts: (0 <=# readPos) and (readPos <=# (l-len buffer)) and (0 <# eCount) and (0 <# fCount) and (0 <=# esLength);
 
@@ -160,9 +160,9 @@ pred IElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
 pred CElement(buffer : List, readPos : Num, fCount : Num; element : List, length : Num) :
   (0 <=# readPos) * (readPos <=# (l-len buffer)) *
     (fCount == 0) * (element == {{  }}) * (length == 0),
-  (0 <# fCount) * Field(buffer, readPos, #field, #fLength) *
+  (0 <# fCount) * Field(buffer, readPos; #field, #fLength) *
     (#restFCount == (fCount - 1)) *
-    CElement(buffer, (readPos + #fLength), #restFCount, #restFields, #restLength) *
+    CElement(buffer, (readPos + #fLength), #restFCount; #restFields, #restLength) *
     (element == l+ ({{ #field }}, #restFields)) * (length == (#fLength + #restLength));
   (*
       A complete element has a non-negative number of fields
@@ -195,8 +195,8 @@ pred CElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * (eCount == 0) *
   (0 <# fCount) * (elements == {{  }}) * (length == 0),
   (0 <=# readPos) * (0 <# eCount) * (0 <# fCount) * (0 <# length) *
-    CElement(buffer, readPos, fCount, #element, #eLength) * (#restECount == (eCount - 1)) *
-    CElements(buffer, (readPos + #eLength), #restECount, fCount, #restElements, #restLength) *
+    CElement(buffer, readPos, fCount; #element, #eLength) * (#restECount == (eCount - 1)) *
+    CElements(buffer, (readPos + #eLength), #restECount, fCount; #restElements, #restLength) *
     (elements == l+ ({{ #element }}, #restElements)) *
     (length == (#eLength + #restLength));
   (*
@@ -224,8 +224,8 @@ pred CElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
 nounfold pred Elements(buffer : List, readPos : Num, eCount : Num,
                        fCount : Num; definition : Str, eList : List,
                        esLength : Num) :
-  (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
-  (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
+  (definition == "Complete") * CElements(buffer, readPos, eCount, fCount; eList, esLength),
+  (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount; eList, esLength);
   facts: (0 <=# readPos) and (readPos <=# (l-len buffer)) and (0 <=# eCount) and (0 <# fCount) and (0 <=# esLength);
 
 (*****************************
@@ -253,8 +253,8 @@ nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Num;
                                     EDKs : List, EDKsLength : Num) :
     (0 <=# readPos) * (readPos <=# (l-len buffer)) *
     (#rawEC == l-sub(buffer, readPos, 2)) *
-    rawToUInt16(#rawEC, false, #keyCount) * (0 <# #keyCount) *
-    Elements(buffer, (readPos + 2), #keyCount, 3, "Complete", EDKs, #EDKsLength) *
+    rawToUInt16(#rawEC, false; #keyCount) * (0 <# #keyCount) *
+    Elements(buffer, (readPos + 2), #keyCount, 3; "Complete", EDKs, #EDKsLength) *
     (EDKsLength == (#EDKsLength + 2));
 
 (* Incomplete serialised EDKs *)
@@ -265,8 +265,8 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num;) :
 
     (* Enough data to read the number of EDKs, but not enough data to read the EDKs *)
   (0 <=# readPos) * ((readPos + 2) <=# (l-len buffer)) * (#rawEC == l-sub(buffer, readPos, 2)) *
-    rawToUInt16(#rawEC, false, #keyCount) * (0 <# #keyCount) *
-    Elements(buffer, (readPos + 2), #keyCount, 3, "Incomplete", #eList, #esLength);
+    rawToUInt16(#rawEC, false; #keyCount) * (0 <# #keyCount) *
+    Elements(buffer, (readPos + 2), #keyCount, 3; "Incomplete", #eList, #esLength);
 
 (* Broken serialised EDKs *)
 @nopath
@@ -277,15 +277,15 @@ nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Num; errorMessage :
 
   (* Zero EDKs provided *)
   (0 <=# readPos) * ((readPos + 2) <=# (l-len buffer)) *
-    (#rawEC == l-sub(buffer, readPos, 2)) * rawToUInt16(#rawEC, false, 0) *
+    (#rawEC == l-sub(buffer, readPos, 2)) * rawToUInt16(#rawEC, false; 0) *
     (errorMessage == "Malformed Header: No EncryptedDataKey found.");
 
 (* General serialised EDKs *)
 @nopath
 nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Num; definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
-  (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
-  (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
-  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
+  (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos; EDKs, EDKsLength),
+  (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos;) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
+  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos; errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
 
 
 (******************************
@@ -311,10 +311,10 @@ nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Num; definition : St
 nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
   ((l-len buffer) == 0) * (ECKs == {{  }}),
   (#rawKC == l-sub(buffer, 0, 2)) *
-    rawToUInt16(#rawKC, false, #keyCount) * (0 <# #keyCount) *
-    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) *
-    Unique(#ECKeys) * ((2 + #ECKsLength) == (l-len buffer));
+    rawToUInt16(#rawKC, false; #keyCount) * (0 <# #keyCount) *
+    Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) *
+    Unique(#ECKeys;) * ((2 + #ECKsLength) == (l-len buffer));
 
 
 (****************************
@@ -366,17 +366,17 @@ nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     ((l-len #rawSuiteId) == 2) *
     ((l-len messageId) == 16) *
-    ((l-len #rawContextLength) == 2) * CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    ((l-len #rawContextLength) == 2) * CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (part_two == l+ (#EC, part_three)) *
     ((l-len #EC) == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rawFrameLength, headerIv, headerAuthTag)) *
-    RawEncryptedDataKeys(rawHeaderData, (22 + ECLength), "Complete", EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, (22 + ECLength); "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == (l-len #edks)) * ((l-len #rawFrameLength) == 4) *
-    rawToUInt32(#rawFrameLength, false, frameLength) *
+    rawToUInt32(#rawFrameLength, false; frameLength) *
     (headerLength == ((((((22 + ECLength) + #EDKsLength) + 1) + 4) + 1) + 4)) *
     ((l-len headerIv) == headerIvLength) *
     ((l-len headerAuthTag) == (#tagLength / 8)) *

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/EncryptionHeaderLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/EncryptionHeaderLogic.gil
@@ -221,8 +221,8 @@ pred CElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
 
 (* A general element sequene is either a complete or an incomplete element sequence *)
 @nopath
-nounfold pred Elements(definition : Str, +buffer : List, +readPos : Num,
-                       +eCount : Num, +fCount : Num, eList : List,
+nounfold pred Elements(+buffer : List, +readPos : Num, +eCount : Num,
+                       +fCount : Num, definition : Str, eList : List,
                        esLength : Num) :
   (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
   (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
@@ -254,7 +254,7 @@ nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Num,
     (0 <=# readPos) * (readPos <=# (l-len buffer)) *
     (#rawEC == l-sub(buffer, readPos, 2)) *
     rawToUInt16(#rawEC, false, #keyCount) * (0 <# #keyCount) *
-    Elements("Complete", buffer, (readPos + 2), #keyCount, 3, EDKs, #EDKsLength) *
+    Elements(buffer, (readPos + 2), #keyCount, 3, "Complete", EDKs, #EDKsLength) *
     (EDKsLength == (#EDKsLength + 2));
 
 (* Incomplete serialised EDKs *)
@@ -266,11 +266,11 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num) :
     (* Enough data to read the number of EDKs, but not enough data to read the EDKs *)
   (0 <=# readPos) * ((readPos + 2) <=# (l-len buffer)) * (#rawEC == l-sub(buffer, readPos, 2)) *
     rawToUInt16(#rawEC, false, #keyCount) * (0 <# #keyCount) *
-    Elements("Incomplete", buffer, (readPos + 2), #keyCount, 3, #eList, #esLength);
+    Elements(buffer, (readPos + 2), #keyCount, 3, "Incomplete", #eList, #esLength);
 
 (* Broken serialised EDKs *)
 @nopath
-nounfold pred BRawEncryptedDataKeys(errorMessage : Str, +buffer : List, +readPos : Num) :
+nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Num, errorMessage : Str) :
   (* Incorrect starting position *)
   ((readPos <# 0) \/ ((l-len buffer) <# readPos)) *
     (errorMessage == "deserializeMessageHeader: startPos out of bounds."),
@@ -282,10 +282,10 @@ nounfold pred BRawEncryptedDataKeys(errorMessage : Str, +buffer : List, +readPos
 
 (* General serialised EDKs *)
 @nopath
-nounfold pred RawEncryptedDataKeys(definition : Str, +buffer : List, +readPos : Num, EDKs : List, EDKsLength : Num, errorMessage : Str) :
+nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Num, definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
   (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
   (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
-  (definition == "Broken") * BRawEncryptedDataKeys(errorMessage, buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0);
+  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
 
 
 (******************************
@@ -312,7 +312,7 @@ nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
   ((l-len buffer) == 0) * (ECKs == {{  }}),
   (#rawKC == l-sub(buffer, 0, 2)) *
     rawToUInt16(#rawKC, false, #keyCount) * (0 <# #keyCount) *
-    Elements("Complete", buffer, 2, #keyCount, 2, ECKs, #ECKsLength) *
+    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) *
     Unique(#ECKeys) * ((2 + #ECKsLength) == (l-len buffer));
 
@@ -374,7 +374,7 @@ nounfold pred CHeader(+rawHeaderData, part_one, version, type, suiteId,
     ((l-len #EC) == ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rawFrameLength, headerIv, headerAuthTag)) *
-    RawEncryptedDataKeys("Complete", rawHeaderData, (22 + ECLength), EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, (22 + ECLength), "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == (l-len #edks)) * ((l-len #rawFrameLength) == 4) *
     rawToUInt32(#rawFrameLength, false, frameLength) *
     (headerLength == ((((((22 + ECLength) + #EDKsLength) + 1) + 4) + 1) + 4)) *

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/EncryptionHeaderLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/EncryptionHeaderLogic.gil
@@ -14,7 +14,7 @@
     ----------------||----|----|---- ... ----||----------------
                 readPos
 *)
-pred Field(+buffer : List, +readPos : Num, field : List, length : Num) :
+pred Field(buffer : List, readPos : Num; field : List, length : Num) :
   (0 <=# readPos) * (#rawFL == l-sub(buffer, readPos, 2)) *
     rawToUInt16(#rawFL, false, #fLength) *
     (field == l-sub(buffer, (readPos + 2), #fLength)) *
@@ -63,7 +63,7 @@ pred Field(+buffer : List, +readPos : Num, field : List, length : Num) :
                 readPos
 *)
 @nopath
-pred IElement(+buffer : List, +readPos : Num, +fCount : Num, fList : List, eLength : Num) :
+pred IElement(buffer : List, readPos : Num, fCount : Num; fList : List, eLength : Num) :
   (* Base case: not enough data to read length of next field *)
   (0 <=# readPos) * (0 <# fCount) * (readPos <=# (l-len buffer)) *
     ((l-len buffer) <# (readPos + 2)) * (fList == {{  }}) *
@@ -121,7 +121,7 @@ pred IElement(+buffer : List, +readPos : Num, +fCount : Num, fList : List, eLeng
                 readPos
 *)
 @nopath
-pred IElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
+pred IElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
                eList : List, esLength : Num) :
   (* Base case: single incomplete element *)
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * (0 <# eCount) * (0 <# fCount) *
@@ -157,7 +157,7 @@ pred IElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
                 readPos
 *)
 @nopath
-pred CElement(+buffer : List, +readPos : Num, +fCount : Num, element : List, length : Num) :
+pred CElement(buffer : List, readPos : Num, fCount : Num; element : List, length : Num) :
   (0 <=# readPos) * (readPos <=# (l-len buffer)) *
     (fCount == 0) * (element == {{  }}) * (length == 0),
   (0 <# fCount) * Field(buffer, readPos, #field, #fLength) *
@@ -190,7 +190,7 @@ pred CElement(+buffer : List, +readPos : Num, +fCount : Num, element : List, len
     ----------------||-------| ... |-------||----------------
                  readPos
 *)
-pred CElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
+pred CElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
                elements : List, length : Num) :
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * (eCount == 0) *
   (0 <# fCount) * (elements == {{  }}) * (length == 0),
@@ -221,8 +221,8 @@ pred CElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
 
 (* A general element sequene is either a complete or an incomplete element sequence *)
 @nopath
-nounfold pred Elements(+buffer : List, +readPos : Num, +eCount : Num,
-                       +fCount : Num, definition : Str, eList : List,
+nounfold pred Elements(buffer : List, readPos : Num, eCount : Num,
+                       fCount : Num; definition : Str, eList : List,
                        esLength : Num) :
   (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
   (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
@@ -249,7 +249,7 @@ nounfold pred Elements(+buffer : List, +readPos : Num, +eCount : Num,
 
 (* Complete serialised EDKs *)
 @nopath
-nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Num,
+nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Num;
                                     EDKs : List, EDKsLength : Num) :
     (0 <=# readPos) * (readPos <=# (l-len buffer)) *
     (#rawEC == l-sub(buffer, readPos, 2)) *
@@ -259,7 +259,7 @@ nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Num,
 
 (* Incomplete serialised EDKs *)
 @nopath
-nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num) :
+nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num;) :
   (* Not enough data to read the number of EDKs *)
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * ((l-len buffer) <# (readPos + 2)),
 
@@ -270,7 +270,7 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num) :
 
 (* Broken serialised EDKs *)
 @nopath
-nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Num, errorMessage : Str) :
+nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Num; errorMessage : Str) :
   (* Incorrect starting position *)
   ((readPos <# 0) \/ ((l-len buffer) <# readPos)) *
     (errorMessage == "deserializeMessageHeader: startPos out of bounds."),
@@ -282,7 +282,7 @@ nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Num, errorMessage
 
 (* General serialised EDKs *)
 @nopath
-nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Num, definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
+nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Num; definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
   (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
   (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
   (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
@@ -308,7 +308,7 @@ nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Num, definition : 
 
 (* Complete serialised encryption context *)
 @nopath
-nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
+nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
   ((l-len buffer) == 0) * (ECKs == {{  }}),
   (#rawKC == l-sub(buffer, 0, 2)) *
     rawToUInt16(#rawKC, false, #keyCount) * (0 <# #keyCount) *
@@ -328,7 +328,7 @@ nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
 
 (* Correctly formed algorithm suite *)
 @nopath
-pred CAlgorithmSuite(+numId, stringId, ivLength, tagLength) :
+pred CAlgorithmSuite(numId; stringId, ivLength, tagLength) :
   (numId == 20) * (stringId == "ALG_AES128_GCM_IV12_TAG16") *
     (ivLength == 12) * (tagLength == 128),
   (numId == 70) * (stringId == "ALG_AES192_GCM_IV12_TAG16") * (ivLength == 12) *
@@ -336,7 +336,7 @@ pred CAlgorithmSuite(+numId, stringId, ivLength, tagLength) :
 
 (* Broken algorithm suite *)
 @nopath
-pred BAlgorithmSuite(+numId, errorMessage) :
+pred BAlgorithmSuite(numId; errorMessage) :
   (! (numId == 20)) * (! (numId == 70)) *
   (errorMessage == "Malformed Header: Unsupported algorithm suite.");
 
@@ -351,13 +351,13 @@ pred BAlgorithmSuite(+numId, errorMessage) :
 
 (* The correct version and type *)
 @nopath
-pred CVersionAndType(version, type) :
+pred CVersionAndType(version, type;) :
   (version == 1) * (type == 128);
 
 
 (* Serialised complete header *)
 @nopath
-nounfold pred CHeader(+rawHeaderData, part_one, version, type, suiteId,
+nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
                       messageId, ECLength, part_two, ECKs, part_three, EDKs,
                       contentType, headerIvLength, frameLength, headerLength,
                       headerIv, headerAuthTag) :

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/EncryptionHeaderLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/EncryptionHeaderLogic.gil
@@ -259,7 +259,7 @@ nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Num;
 
 (* Incomplete serialised EDKs *)
 @nopath
-nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num;) :
+nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num) :
   (* Not enough data to read the number of EDKs *)
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * ((l-len buffer) <# (readPos + 2)),
 
@@ -284,7 +284,7 @@ nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Num; errorMessage :
 @nopath
 nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Num; definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
   (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos; EDKs, EDKsLength),
-  (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos;) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
+  (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
   (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos; errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
 
 
@@ -314,7 +314,7 @@ nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
     rawToUInt16(#rawKC, false; #keyCount) * (0 <# #keyCount) *
     Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) *
-    Unique(#ECKeys;) * ((2 + #ECKsLength) == (l-len buffer));
+    Unique(#ECKeys) * ((2 + #ECKsLength) == (l-len buffer));
 
 
 (****************************
@@ -351,7 +351,7 @@ pred BAlgorithmSuite(numId; errorMessage) :
 
 (* The correct version and type *)
 @nopath
-pred CVersionAndType(version, type;) :
+pred CVersionAndType(version, type) :
   (version == 1) * (type == 128);
 
 
@@ -366,7 +366,7 @@ nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     ((l-len #rawSuiteId) == 2) *
     ((l-len messageId) == 16) *
-    ((l-len #rawContextLength) == 2) * CVersionAndType(version, type;) *
+    ((l-len #rawContextLength) == 2) * CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/ListLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/ListLogic.gil
@@ -10,12 +10,12 @@
 @nopath
 pure pred FirstProj(lst : List; fProj : List) : (lst == {{  }}) *
   (fProj == {{  }}), (lst == l+ ({{ {{ #fst, #lvar_js_7 }} }}, #rest)) *
-  FirstProj(#rest, #fProjRest) * (fProj == l+ ({{ #fst }}, #fProjRest));
+  FirstProj(#rest; #fProjRest) * (fProj == l+ ({{ #fst }}, #fProjRest));
   
   
 (*
 lemma FirstProjFunction(lst1, proj1, lst2, proj2)
-  [[  FirstProj(#lst1, #proj1) * FirstProj(#lst2, #proj2) * (#lst1 == #lst2) ]]
+  [[  FirstProj(#lst1; #proj1) * FirstProj(#lst2; #proj2) * (#lst1 == #lst2) ]]
   [[  (#proj1 == #proj2) ]]
   [*  unfold FirstProj(#lst1, #proj1)  [bind: (#fst1 := #fst) and (#rest1 := #rest) and (#fProjRest1 := #fProjRest)];
       if ((not (#lst1 = {{  }}))) then {
@@ -25,13 +25,13 @@ lemma FirstProjFunction(lst1, proj1, lst2, proj2)
   *]
   
 lemma FirstProjAppendPair(lst, fProj, prop, value)
-  [[  FirstProj(#lst, #fProj) ]]
-  [[  FirstProj(l+ (#lst, {{ {{ #prop, #value }} }}), l+ (#fProj, {{ #prop }})) ]]
+  [[  FirstProj(#lst; #fProj) ]]
+  [[  FirstProj(l+ (#lst, {{ {{ #prop, #value }} }}); l+ (#fProj, {{ #prop }})) ]]
   [*  unfold FirstProj(#lst, #fProj) ;
       if ((not (#lst = {{  }}))) then {
         sep_assert ((#lst == l+ ({{ {{ #fProp, #fValue }} }}, #restPVPairs)))
           [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (FirstProj(#restPVPairs, #restProj)) [bind: #restProj];
+        sep_assert (FirstProj(#restPVPairs; #restProj)) [bind: #restProj];
         apply FirstProjAppendPair(#restPVPairs, #restProj, #prop, #value) 
       }  *]
 *)
@@ -48,8 +48,8 @@ lemma FirstProjAppendPair(lst, fProj, prop, value)
 @nopath
 pure pred Unique(l : List;) :
   (l == {{  }}),
-  (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest, #setRest) *
-    (! (#fst --e-- #setRest)) * Unique(#rest);
+  (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest; #setRest) *
+    (! (#fst --e-- #setRest)) * Unique(#rest;);
     
     
 (*****************************************
@@ -64,4 +64,4 @@ pure pred Unique(l : List;) :
 pure pred ListToSet(lst : List; set : Set) :
   (lst == {{  }}) * (set == -{  }-),
   (lst == l+ ({{ #e }}, #restLst)) *
-    ListToSet(#restLst, #restSet) * (set == -u- (#restSet, -{ #e }-));
+    ListToSet(#restLst; #restSet) * (set == -u- (#restSet, -{ #e }-));

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/ListLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/ListLogic.gil
@@ -8,7 +8,7 @@
 
 (* First projection of a list of pairs *)
 @nopath
-pure pred FirstProj(+lst : List, fProj : List) : (lst == {{  }}) *
+pure pred FirstProj(lst : List; fProj : List) : (lst == {{  }}) *
   (fProj == {{  }}), (lst == l+ ({{ {{ #fst, #lvar_js_7 }} }}, #rest)) *
   FirstProj(#rest, #fProjRest) * (fProj == l+ ({{ #fst }}, #fProjRest));
   
@@ -46,7 +46,7 @@ lemma FirstProjAppendPair(lst, fProj, prop, value)
  ********************************)
   
 @nopath
-pure pred Unique(l : List) :
+pure pred Unique(l : List;) :
   (l == {{  }}),
   (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest, #setRest) *
     (! (#fst --e-- #setRest)) * Unique(#rest);
@@ -61,7 +61,7 @@ pure pred Unique(l : List) :
 ******************************************)
 
 @nopath
-pure pred ListToSet(+lst : List, set : Set) :
+pure pred ListToSet(lst : List; set : Set) :
   (lst == {{  }}) * (set == -{  }-),
   (lst == l+ ({{ #e }}, #restLst)) *
     ListToSet(#restLst, #restSet) * (set == -u- (#restSet, -{ #e }-));

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/ListLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/ListLogic.gil
@@ -46,10 +46,10 @@ lemma FirstProjAppendPair(lst, fProj, prop, value)
  ********************************)
   
 @nopath
-pure pred Unique(l : List;) :
+pure pred Unique(l : List) :
   (l == {{  }}),
   (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest; #setRest) *
-    (! (#fst --e-- #setRest)) * Unique(#rest;);
+    (! (#fst --e-- #setRest)) * Unique(#rest);
     
     
 (*****************************************

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/Utf8Logic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/Utf8Logic.gil
@@ -14,11 +14,11 @@
     the raw bytes rawData to UTF-8 format
 *)
 @nopath
-abstract pure nounfold pred toUtf8(+rawData : List, utf8Data : Str);    
+abstract pure nounfold pred toUtf8(rawData : List; utf8Data : Str);    
     
 (* UTF-8 Mapping of lists of pairs *)
 @nopath
-pure pred toUtf8PairMap(+data : List, utf8Data : List) : (data == {{  }}) *
+pure pred toUtf8PairMap(data : List; utf8Data : List) : (data == {{  }}) *
   (utf8Data == {{  }}),
   (data == l+ ({{ {{ #prop, #value }} }}, #rest)) *
     toUtf8(#prop, #utf8Prop) * toUtf8(#value, #utf8Value) *

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/Utf8Logic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/Utf8Logic.gil
@@ -21,6 +21,6 @@ abstract pure nounfold pred toUtf8(rawData : List; utf8Data : Str);
 pure pred toUtf8PairMap(data : List; utf8Data : List) : (data == {{  }}) *
   (utf8Data == {{  }}),
   (data == l+ ({{ {{ #prop, #value }} }}, #rest)) *
-    toUtf8(#prop, #utf8Prop) * toUtf8(#value, #utf8Value) *
-    toUtf8PairMap(#rest, #utf8Rest) *
+    toUtf8(#prop; #utf8Prop) * toUtf8(#value; #utf8Value) *
+    toUtf8PairMap(#rest; #utf8Rest) *
     (utf8Data == l+ ({{ {{ #utf8Prop, #utf8Value }} }}, #utf8Rest));

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/deserialize_factory.js
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/deserialize_factory.js
@@ -48,7 +48,7 @@ function needs(condition, errorMessage) {
       Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
 
       scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals (;)
+      JSInternals ()
 
     @post
       (#definition == "Complete") *
@@ -56,9 +56,9 @@ function needs(condition, errorMessage) {
       ArrayBuffer(#ab; #data) *
       Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
       scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals (;) *
+      JSInternals () *
 
-      JSObject(ret;) *
+      JSObject(ret) *
         DataProp(ret, "elements"; #elements) *
             ArrayOfArraysOfUInt8Arrays(#elements; #eList) *
         DataProp(ret, "readPos"; #ret_readPos) *
@@ -70,7 +70,7 @@ function needs(condition, errorMessage) {
       Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
 
       scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals (;) *
+      JSInternals () *
 
       (ret == false)
 */
@@ -93,7 +93,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
       scope(elements : #doneEls) * scope(readPos : #outerLoopReadPos) *
       scope(elementCount : #eLeft) * scope(fieldsPerElement: #fCount) *
       scope(element: _) * scope(fieldCount: _) * scope(fieldBinary: _) * scope(length: _) *
-      JSInternals(;) *
+      JSInternals() *
 
       CElements(#view, #readPos, #eCount - #eLeft, #fCount; #doneElsList, #doneElsLength) *
       Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength) *
@@ -118,7 +118,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
         scope(dataView: #dataView) * DataView(#dataView; #ab, #viewOffset, #viewSize) *
         scope(element : #doneEl) * scope(readPos : #innerLoopReadPos) * scope(fieldCount : #fLeft) *
         scope(fieldBinary: _) * scope(length: _) *
-        JSInternals(;) *
+        JSInternals() *
 
         CElement(#view, #outerLoopReadPos, #fCount - #fLeft; #doneElList, #doneElLength) *
         (#fList == l+ (#doneElList, #remElList)) *
@@ -201,7 +201,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
     @onlyspec EncryptedDataKey (edk)
     [[
         (edk == #edk) *
-        JSObject(#edk;) *
+        JSObject(#edk) *
         DataProp(#edk, "providerId"; #pId) * types(#pId : Str) *
         DataProp(#edk, "providerInfo"; #pInfo) * types(#pInfo : Str) *
         DataProp(#edk, "encryptedDataKey"; #aEDK) *
@@ -215,7 +215,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
         JSObjWithProto (this; $l_edk_proto)
     ]]
     [[
-        JSObject(#edk;) *
+        JSObject(#edk) *
         DataProp(#edk, "providerId"; #pId) *
         DataProp(#edk, "providerInfo"; #pInfo) *
         DataProp(#edk, "encryptedDataKey"; #aEDK) *
@@ -268,9 +268,9 @@ var toUtf8 = function (buffer) { };
 
 /**
 
-    @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List;) :
-        (definition == "Complete") * Unique(lst1;),
-        (definition == "Broken") * Duplicated(lst2, lst3;);
+    @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List) :
+        (definition == "Complete") * Unique(lst1),
+        (definition == "Broken") * Duplicated(lst2, lst3);
 
     @id decodeEncryptionContext
 
@@ -283,17 +283,17 @@ var toUtf8 = function (buffer) { };
          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
-         JSInternals(;)
+         JSInternals()
 
     @post Uint8Array(#eEC; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
           RawEncryptionContext(#EC; #definition, #ECKs, #errorMessage) *
 
-          DecodedEncryptionContext(ret, #ECKs;) *
+          DecodedEncryptionContext(ret, #ECKs) *
 
           scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
           scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
           scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
-          JSInternals (;)
+          JSInternals ()
 */
 function decodeEncryptionContext(encodedEncryptionContext) {
   /* @tactic
@@ -347,7 +347,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
             scope(pairsCount: #pairsCount) * (#pairsCount == l-len #ECKs) *
             scope(elements: #elements) * ArrayOfArraysOfUInt8Arrays(#elements; #ECKs) *
             scope(encryptionContext: #dECObj) * JSObjWithProto(#dECObj; null) * empty_fields(#dECObj : -{ }-) *
-            toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) * UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;)
+            toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) * UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps)
         ) [bind: #pairsCount, #elements, #dECObj, #utf8ECKs, #rProps]
 
     @invariant
@@ -357,25 +357,25 @@ function decodeEncryptionContext(encodedEncryptionContext) {
         scope(key: _) * scope(value: _) *
         toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) *
         CElements(#EC, 2., ((256. * #b0) + #b1), 2.; #ECKs, (l-len #rest)) *
-        UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;) *
-        JSInternals(;) *
+        UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps) *
+        JSInternals() *
 
         scope(count: #count) * (#count <=# #pairsCount) *
-        ArrayStructure(#elements, #pairsCount;) *
+        ArrayStructure(#elements, #pairsCount) *
         ArrayOfArraysOfUInt8ArraysContents(#elements, 0, #count; #done) *
         ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left) *
         (#ECKs == l+ (#done, #left)) *
-        FirstProj(#done; #doneRProps) * Unique(#doneRProps;) *
-        FirstProj(#left; #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;) *
+        FirstProj(#done; #doneRProps) * Unique(#doneRProps) *
+        FirstProj(#left; #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps) *
         toUtf8PairMap(#done; #utf8Done) *
-        JSObjWithProto(#dECObj; null) * ObjectTable(#dECObj, #utf8Done;)
+        JSObjWithProto(#dECObj; null) * ObjectTable(#dECObj, #utf8Done)
         [bind: #count, #done, #left, #doneRProps, #leftRProps, #utf8Done] */
   for (var count = 0; count < pairsCount; count++) {
     /*
         @tactic
-            unfold ArrayStructure(#elements, #pairsCount;);
-            unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;);
-            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;);
+            unfold ArrayStructure(#elements, #pairsCount);
+            unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps);
+            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
             unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
             apply CElementsElementLength(#EC, 2., ((256. * #b0) + #b1), 2., #ECKs, #done, #ECK, #rest_left);
             assert (#ECK == {{ #new_prop, #new_value }})
@@ -391,7 +391,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
         @tactic
             assert (toUtf8(#new_prop; #utf8NProp)) [bind: #utf8NProp];
             assert (toUtf8(#new_value; #utf8NVal)) [bind: #utf8NVal];
-            unfold ObjectTable(#dECObj, #utf8Done;) [bind: (#doneProps := #pList) and (#donePropsSet := #pSet)];
+            unfold ObjectTable(#dECObj, #utf8Done) [bind: (#doneProps := #pList) and (#donePropsSet := #pSet)];
             apply FirstProjConcatSplit(#ECKs, #done, #left);
             apply ProduceListToSet(#doneRProps); apply ProduceListToSet(#leftRProps);
             assert (ListToSet(#doneRProps; #doneRPropsSet)) [bind: #doneRPropsSet];
@@ -404,7 +404,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
                 apply ObjectTableAbsentProperty(#dECObj, #utf8Done, #utf8NProp)
             } else {
                 apply FirstProjToUtf8MapPairCompat(#done);
-                unfold Duplicated(#doneRProps, #leftRProps;) [bind: (#doneRPropsSet2 := #preSet)];
+                unfold Duplicated(#doneRProps, #leftRProps) [bind: (#doneRPropsSet2 := #preSet)];
                 apply ListToSetFunction(#doneRProps, #doneRPropsSet, #doneRProps, #doneRPropsSet2);
                 if (#new_prop -e- #doneRPropsSet) then {
                     apply InListToUtf8(#new_prop, #doneRProps);
@@ -431,7 +431,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
             apply ListToSetAddElement(#doneProps, #donePropsSet, #utf8NProp);
             apply UniqueAppendElement(#doneRProps, #new_prop);
             if (#definition = "Complete") then {
-                unfold Unique(#leftRProps;)
+                unfold Unique(#leftRProps)
             }
     */
     0 === 0;
@@ -443,8 +443,8 @@ function decodeEncryptionContext(encodedEncryptionContext) {
         apply toUtf8PairMapInjective(#ECKs, #utf8ECKs, #done, #utf8Done);
         if (#definition = "Broken") then {
             unfold FirstProj(#left; #leftRProps);
-            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;);
-            unfold Duplicated(#doneRProps, #leftRProps;)
+            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
+            unfold Duplicated(#doneRProps, #leftRProps)
         };
         use_subst [object_table : (#PVPairs: #utf8ECKs) ]
   */

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/deserialize_factory.js
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/deserialize_factory.js
@@ -45,7 +45,7 @@ function needs(condition, errorMessage) {
       Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
       ArrayBuffer(#ab, #data) *
       (#view == l-sub(#data, #viewOffset, #viewSize)) *
-      Elements(#definition, #view, #readPos, #eCount, #fCount, #eList, #esLength) *
+      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
 
       scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
       JSInternals ()
@@ -54,7 +54,7 @@ function needs(condition, errorMessage) {
       (#definition == "Complete") *
       Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
       ArrayBuffer(#ab, #data) *
-      Elements(#definition, #view, #readPos, #eCount, #fCount, #eList, #esLength) *
+      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
       scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
       JSInternals () *
 
@@ -67,7 +67,7 @@ function needs(condition, errorMessage) {
       (#definition == "Incomplete") *
       Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
       ArrayBuffer(#ab, #data) *
-      Elements(#definition, #view, #readPos, #eCount, #fCount, #eList, #esLength) *
+      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
 
       scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
       JSInternals () *
@@ -96,7 +96,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
       JSInternals() *
 
       CElements(#view, #readPos, #eCount - #eLeft, #fCount, #doneElsList, #doneElsLength) *
-      Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength) *
+      Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength) *
       (#eList == l+ (#doneElsList, #remElsList)) *
       (#esLength == #doneElsLength + #remElsLength) *
       (#readPos + #doneElsLength == #outerLoopReadPos) *
@@ -104,7 +104,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
       [bind : #doneEls, #outerLoopReadPos, #eLeft, #remElsList, #remElsLength, #doneElsList, #doneElsLength] */
   while (elementCount--) {
     /* @tactic
-        unfold Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength);
+        unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
         if (#definition = "Complete") then {
             unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength) [bind: (#fList := #element) and (#eLength := #eLength)]
         } else {
@@ -142,7 +142,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
         /* @tactic
             apply PrependCElementI(#view, #outerLoopReadPos, (#fCount - #fLeft), #doneElList, #doneElLength, #fLeft, #remElList, #remElLength);
             assert IElement(#view, #outerLoopReadPos, #fCount, #fList, #remElsLength);
-            assert Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength);
+            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
             apply PrependCElementsE(#definition, #view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #eLeft, #remElsList, #remElsLength)
         */
         return false
@@ -154,7 +154,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
         /* @tactic
             apply PrependCElementI(#view, #outerLoopReadPos, (#fCount - #fLeft), #doneElList, #doneElLength, #fLeft, #remElList, #remElLength);
             assert IElement(#view, #outerLoopReadPos, #fCount, #fList, #remElsLength);
-            assert Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength);
+            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
             apply PrependCElementsE(#definition, #view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #eLeft, #remElsList, #remElsLength)
         */
         return false
@@ -178,7 +178,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
   }
 
   /* @tactic
-      unfold Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength);
+      unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
       if (#definition = "Complete") then {
           unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength)
       } else {
@@ -278,7 +278,7 @@ var toUtf8 = function (buffer) { };
          Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
          (#EC == l-sub(#data, #byteOffset, #byteLength)) *
          (#definition == "Complete") *
-         RawEncryptionContext(#definition, #EC, #ECKs, #errorMessage) *
+         RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
 
          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
          scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
@@ -286,7 +286,7 @@ var toUtf8 = function (buffer) { };
          JSInternals()
 
     @post Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
-          RawEncryptionContext(#definition, #EC, #ECKs, #errorMessage) *
+          RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
 
           DecodedEncryptionContext(ret, #ECKs) *
 
@@ -300,7 +300,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
       if (#definition = "Complete") then {
         unfold CRawEncryptionContext(#EC, #ECKs)
       } else {
-        unfold BRawEncryptionContext(#errorMessage, #EC, #ECKs)
+        unfold BRawEncryptionContext(#EC, #errorMessage, #ECKs)
       }
    */
 
@@ -340,9 +340,9 @@ function decodeEncryptionContext(encodedEncryptionContext) {
     @tactic
         assert (
             (#EC == l+ ({{ #b0, #b1 }}, #rest)) *
-            Elements("Complete", #EC, 2, ((256 * #b0) + #b1), 2, #ECKs, l-len #rest)
+            Elements(#EC, 2, ((256 * #b0) + #b1), 2, "Complete", #ECKs, l-len #rest)
         ) [bind: #b0, #b1, #rest];
-        unfold Elements("Complete", #EC, 2, ((256 * #b0) + #b1), 2, #ECKs, l-len #rest);
+        unfold Elements(#EC, 2, ((256 * #b0) + #b1), 2, "Complete", #ECKs, l-len #rest);
         assert (
             scope(pairsCount: #pairsCount) * (#pairsCount == l-len #ECKs) *
             scope(elements: #elements) * ArrayOfArraysOfUInt8Arrays(#elements, #ECKs) *
@@ -362,8 +362,8 @@ function decodeEncryptionContext(encodedEncryptionContext) {
 
         scope(count: #count) * (#count <=# #pairsCount) *
         ArrayStructure(#elements, #pairsCount) *
-        ArrayOfArraysOfUInt8ArraysContents(#elements, #done, 0, #count) *
-        ArrayOfArraysOfUInt8ArraysContents(#elements, #left, #count, #pairsCount - #count) *
+        ArrayOfArraysOfUInt8ArraysContents(#elements, 0, #count, #done) *
+        ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left) *
         (#ECKs == l+ (#done, #left)) *
         FirstProj(#done, #doneRProps) * Unique(#doneRProps) *
         FirstProj(#left, #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps) *
@@ -376,7 +376,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
             unfold ArrayStructure(#elements, #pairsCount);
             unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps);
             unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
-            unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #left, #count, #pairsCount - #count) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
+            unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
             apply CElementsElementLength(#EC, 2., ((256. * #b0) + #b1), 2., #ECKs, #done, #ECK, #rest_left);
             assert (#ECK == {{ #new_prop, #new_value }})
     */
@@ -439,7 +439,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
 
   /*
     @tactic
-        unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #left, #count, #pairsCount - #count);
+        unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left);
         apply toUtf8PairMapInjective(#ECKs, #utf8ECKs, #done, #utf8Done);
         if (#definition = "Broken") then {
             unfold FirstProj(#left, #leftRProps);

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/deserialize_factory.js
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/deserialize_factory.js
@@ -35,7 +35,7 @@ function needs(condition, errorMessage) {
 /**
     @id readElements
 
-    @pred nounfold innerLoopInvariantFacts(+definition, +remElsList, +view, +innerLoopReadPos, +fLeft, +remElList, +eLength, +remElsLength, +doneElLength, remElLength) :
+    @pred nounfold innerLoopInvariantFacts(definition, remElsList, view, innerLoopReadPos, fLeft, remElList, eLength, remElsLength, doneElLength; remElLength) :
       (definition == "Complete") * CElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (eLength == doneElLength + remElLength),
       (definition == "Incomplete") * (remElsList == {{ }}) * IElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (remElsLength == doneElLength + remElLength),
       (definition == "Incomplete") * (! (remElsList == {{ }})) * CElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (eLength == doneElLength + remElLength);
@@ -268,7 +268,7 @@ var toUtf8 = function (buffer) { };
 
 /**
 
-    @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List) :
+    @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List;) :
         (definition == "Complete") * Unique(lst1),
         (definition == "Broken") * Duplicated(lst2, lst3);
 

--- a/Gillian-JS/Examples/Amazon/bugs/frozen/deserialize_factory.js
+++ b/Gillian-JS/Examples/Amazon/bugs/frozen/deserialize_factory.js
@@ -36,41 +36,41 @@ function needs(condition, errorMessage) {
     @id readElements
 
     @pred nounfold innerLoopInvariantFacts(definition, remElsList, view, innerLoopReadPos, fLeft, remElList, eLength, remElsLength, doneElLength; remElLength) :
-      (definition == "Complete") * CElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (eLength == doneElLength + remElLength),
-      (definition == "Incomplete") * (remElsList == {{ }}) * IElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (remElsLength == doneElLength + remElLength),
-      (definition == "Incomplete") * (! (remElsList == {{ }})) * CElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (eLength == doneElLength + remElLength);
+      (definition == "Complete") * CElement(view, innerLoopReadPos, fLeft; remElList, remElLength) * (eLength == doneElLength + remElLength),
+      (definition == "Incomplete") * (remElsList == {{ }}) * IElement(view, innerLoopReadPos, fLeft; remElList, remElLength) * (remElsLength == doneElLength + remElLength),
+      (definition == "Incomplete") * (! (remElsList == {{ }})) * CElement(view, innerLoopReadPos, fLeft; remElList, remElLength) * (eLength == doneElLength + remElLength);
 
     @pre
       (elementCount == #eCount) * (fieldsPerElement == #fCount) * (buffer == #buffer) * (readPos == #readPos) *
-      Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
-      ArrayBuffer(#ab, #data) *
+      Uint8Array (#buffer; #ab, #viewOffset, #viewSize) *
+      ArrayBuffer(#ab; #data) *
       (#view == l-sub(#data, #viewOffset, #viewSize)) *
-      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
+      Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
 
-      scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals ()
+      scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+      JSInternals (;)
 
     @post
       (#definition == "Complete") *
-      Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
-      ArrayBuffer(#ab, #data) *
-      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
-      scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals () *
+      Uint8Array (#buffer; #ab, #viewOffset, #viewSize) *
+      ArrayBuffer(#ab; #data) *
+      Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
+      scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+      JSInternals (;) *
 
-      JSObject(ret) *
-        DataProp(ret, "elements", #elements) *
-            ArrayOfArraysOfUInt8Arrays(#elements, #eList) *
-        DataProp(ret, "readPos", #ret_readPos) *
+      JSObject(ret;) *
+        DataProp(ret, "elements"; #elements) *
+            ArrayOfArraysOfUInt8Arrays(#elements; #eList) *
+        DataProp(ret, "readPos"; #ret_readPos) *
             (#ret_readPos == #readPos + #esLength);
 
       (#definition == "Incomplete") *
-      Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
-      ArrayBuffer(#ab, #data) *
-      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
+      Uint8Array (#buffer; #ab, #viewOffset, #viewSize) *
+      ArrayBuffer(#ab; #data) *
+      Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
 
-      scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals () *
+      scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+      JSInternals (;) *
 
       (ret == false)
 */
@@ -88,61 +88,61 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
   var elements = [];
 
   /* @invariant
-      scope(buffer: #buffer) * Uint8Array (#buffer, #ab, #viewOffset, #viewSize) * ArrayBuffer(#ab, #data) *
-      scope(dataView: #dataView) * DataView(#dataView, #ab, #viewOffset, #viewSize) *
+      scope(buffer: #buffer) * Uint8Array (#buffer; #ab, #viewOffset, #viewSize) * ArrayBuffer(#ab; #data) *
+      scope(dataView: #dataView) * DataView(#dataView; #ab, #viewOffset, #viewSize) *
       scope(elements : #doneEls) * scope(readPos : #outerLoopReadPos) *
       scope(elementCount : #eLeft) * scope(fieldsPerElement: #fCount) *
       scope(element: _) * scope(fieldCount: _) * scope(fieldBinary: _) * scope(length: _) *
-      JSInternals() *
+      JSInternals(;) *
 
-      CElements(#view, #readPos, #eCount - #eLeft, #fCount, #doneElsList, #doneElsLength) *
-      Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength) *
+      CElements(#view, #readPos, #eCount - #eLeft, #fCount; #doneElsList, #doneElsLength) *
+      Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength) *
       (#eList == l+ (#doneElsList, #remElsList)) *
       (#esLength == #doneElsLength + #remElsLength) *
       (#readPos + #doneElsLength == #outerLoopReadPos) *
-      ArrayOfArraysOfUInt8Arrays(#doneEls, #doneElsList)
+      ArrayOfArraysOfUInt8Arrays(#doneEls; #doneElsList)
       [bind : #doneEls, #outerLoopReadPos, #eLeft, #remElsList, #remElsLength, #doneElsList, #doneElsLength] */
   while (elementCount--) {
     /* @tactic
-        unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
+        unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength);
         if (#definition = "Complete") then {
-            unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength) [bind: (#fList := #element) and (#eLength := #eLength)]
+            unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount; #remElsList, #remElsLength) [bind: (#fList := #element) and (#eLength := #eLength)]
         } else {
-            unfold IElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength) [bind: (#fList := #fList) and (#eLength := #eLength)]
+            unfold IElements(#view, #outerLoopReadPos, #eLeft, #fCount; #remElsList, #remElsLength) [bind: (#fList := #fList) and (#eLength := #eLength)]
         } */
     var element = []
     var fieldCount = fieldsPerElement
 
     /* @invariant
-        scope(buffer: #buffer) * Uint8Array (#buffer, #ab, #viewOffset, #viewSize) * ArrayBuffer(#ab, #data) *
-        scope(dataView: #dataView) * DataView(#dataView, #ab, #viewOffset, #viewSize) *
+        scope(buffer: #buffer) * Uint8Array (#buffer; #ab, #viewOffset, #viewSize) * ArrayBuffer(#ab; #data) *
+        scope(dataView: #dataView) * DataView(#dataView; #ab, #viewOffset, #viewSize) *
         scope(element : #doneEl) * scope(readPos : #innerLoopReadPos) * scope(fieldCount : #fLeft) *
         scope(fieldBinary: _) * scope(length: _) *
-        JSInternals() *
+        JSInternals(;) *
 
-        CElement(#view, #outerLoopReadPos, #fCount - #fLeft, #doneElList, #doneElLength) *
+        CElement(#view, #outerLoopReadPos, #fCount - #fLeft; #doneElList, #doneElLength) *
         (#fList == l+ (#doneElList, #remElList)) *
-        innerLoopInvariantFacts(#definition, #remElsList, #view, #innerLoopReadPos, #fLeft, #remElList, #eLength, #remElsLength, #doneElLength, #remElLength) *
+        innerLoopInvariantFacts(#definition, #remElsList, #view, #innerLoopReadPos, #fLeft, #remElList, #eLength, #remElsLength, #doneElLength; #remElLength) *
         (#outerLoopReadPos + #doneElLength == #innerLoopReadPos) *
-        ArrayOfUInt8Arrays(#doneEl, #doneElList, #fCount - #fLeft)
+        ArrayOfUInt8Arrays(#doneEl; #doneElList, #fCount - #fLeft)
         [bind: #doneEl, #innerLoopReadPos, #fLeft, #remElList, #remElLength, #doneElList, #doneElLength] */
     while (fieldCount--) {
       /* @tactic
-          unfold innerLoopInvariantFacts(#definition, #remElsList, #view, #innerLoopReadPos, #fLeft, #remElList, #eLength, #remElsLength, #doneElLength, #remElLength);
+          unfold innerLoopInvariantFacts(#definition, #remElsList, #view, #innerLoopReadPos, #fLeft, #remElList, #eLength, #remElsLength, #doneElLength; #remElLength);
           if (#definition = "Complete") then {
-              unfold CElement(#view, #innerLoopReadPos, #fLeft, #remElList, #remElLength)
+              unfold CElement(#view, #innerLoopReadPos, #fLeft; #remElList, #remElLength)
           } else {
               if (#remElsList = {{ }}) then {
-                  unfold IElement(#view, #innerLoopReadPos, #fLeft, #remElList, #remElLength)
+                  unfold IElement(#view, #innerLoopReadPos, #fLeft; #remElList, #remElLength)
               } else {
-                  unfold CElement(#view, #innerLoopReadPos, #fLeft, #remElList, #remElLength)
+                  unfold CElement(#view, #innerLoopReadPos, #fLeft; #remElList, #remElLength)
               }
           } */
       if (readPos + 2 > dataView.byteLength)
         /* @tactic
             apply PrependCElementI(#view, #outerLoopReadPos, (#fCount - #fLeft), #doneElList, #doneElLength, #fLeft, #remElList, #remElLength);
-            assert IElement(#view, #outerLoopReadPos, #fCount, #fList, #remElsLength);
-            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
+            assert IElement(#view, #outerLoopReadPos, #fCount; #fList, #remElsLength);
+            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength);
             apply PrependCElementsE(#definition, #view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #eLeft, #remElsList, #remElsLength)
         */
         return false
@@ -153,8 +153,8 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
       if (readPos + length > dataView.byteLength)
         /* @tactic
             apply PrependCElementI(#view, #outerLoopReadPos, (#fCount - #fLeft), #doneElList, #doneElLength, #fLeft, #remElList, #remElLength);
-            assert IElement(#view, #outerLoopReadPos, #fCount, #fList, #remElsLength);
-            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
+            assert IElement(#view, #outerLoopReadPos, #fCount; #fList, #remElsLength);
+            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength);
             apply PrependCElementsE(#definition, #view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #eLeft, #remElsList, #remElsLength)
         */
         return false
@@ -172,17 +172,17 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
     }
 
     /* @tactic
-        unfold CElement(#view, #innerLoopReadPos, #fLeft, #remElList, #remElLength);
+        unfold CElement(#view, #innerLoopReadPos, #fLeft; #remElList, #remElLength);
         apply CElementsAppend(#view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #doneElList, #doneElLength) */
     elements.push(element);
   }
 
   /* @tactic
-      unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
+      unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength);
       if (#definition = "Complete") then {
-          unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength)
+          unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount; #remElsList, #remElsLength)
       } else {
-          unfold IElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength)
+          unfold IElements(#view, #outerLoopReadPos, #eLeft, #fCount; #remElsList, #remElsLength)
       } */
   return { elements, readPos }
 }
@@ -201,31 +201,31 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
     @onlyspec EncryptedDataKey (edk)
     [[
         (edk == #edk) *
-        JSObject(#edk) *
-        DataProp(#edk, "providerId", #pId) * types(#pId : Str) *
-        DataProp(#edk, "providerInfo", #pInfo) * types(#pInfo : Str) *
-        DataProp(#edk, "encryptedDataKey", #aEDK) *
-            Uint8Array (#aEDK, #abEDK, 0, #viewSizeEDK) *
-            ArrayBuffer(#abEDK, #encryptedDataKey) *
+        JSObject(#edk;) *
+        DataProp(#edk, "providerId"; #pId) * types(#pId : Str) *
+        DataProp(#edk, "providerInfo"; #pInfo) * types(#pInfo : Str) *
+        DataProp(#edk, "encryptedDataKey"; #aEDK) *
+            Uint8Array (#aEDK; #abEDK, 0, #viewSizeEDK) *
+            ArrayBuffer(#abEDK; #encryptedDataKey) *
             (#viewSizeEDK == l-len #encryptedDataKey) *
-        DataProp(#edk, "rawInfo", #aRInfo) *
-            Uint8Array (#aRInfo, #abRInfo, 0, #viewSizeRInfo) *
-            ArrayBuffer(#abRInfo, #rawInfo) *
+        DataProp(#edk, "rawInfo"; #aRInfo) *
+            Uint8Array (#aRInfo; #abRInfo, 0, #viewSizeRInfo) *
+            ArrayBuffer(#abRInfo; #rawInfo) *
             (#viewSizeRInfo == l-len #rawInfo) *
-        JSObjWithProto (this, $l_edk_proto)
+        JSObjWithProto (this; $l_edk_proto)
     ]]
     [[
-        JSObject(#edk) *
-        DataProp(#edk, "providerId", #pId) *
-        DataProp(#edk, "providerInfo", #pInfo) *
-        DataProp(#edk, "encryptedDataKey", #aEDK) *
-            Uint8Array (#aEDK, #abEDK, 0, #viewSizeEDK) *
-            ArrayBuffer(#abEDK, #encryptedDataKey) *
-        DataProp(#edk, "rawInfo", #aRInfo) *
-            Uint8Array (#aRInfo, #abRInfo, 0, #viewSizeRInfo) *
-            ArrayBuffer(#abRInfo, #rawInfo) *
+        JSObject(#edk;) *
+        DataProp(#edk, "providerId"; #pId) *
+        DataProp(#edk, "providerInfo"; #pInfo) *
+        DataProp(#edk, "encryptedDataKey"; #aEDK) *
+            Uint8Array (#aEDK; #abEDK, 0, #viewSizeEDK) *
+            ArrayBuffer(#abEDK; #encryptedDataKey) *
+        DataProp(#edk, "rawInfo"; #aRInfo) *
+            Uint8Array (#aRInfo; #abRInfo, 0, #viewSizeRInfo) *
+            ArrayBuffer(#abRInfo; #rawInfo) *
 
-        EncryptedDataKey(this, #pId, #pInfo, #encryptedDataKey, #rawInfo) *
+        EncryptedDataKey(this; #pId, #pInfo, #encryptedDataKey, #rawInfo) *
         (ret == this)
     ]]
     normal
@@ -246,13 +246,13 @@ var EncryptedDataKey = function (edk) { };
    @onlyspec toUtf8 (buffer)
        [[
            (buffer == #buffer) *
-           Uint8Array (#buffer, #ab, 0, #length) *
-           ArrayBuffer(#ab, #element)
+           Uint8Array (#buffer; #ab, 0, #length) *
+           ArrayBuffer(#ab; #element)
        ]]
        [[
-           Uint8Array (#buffer, #ab, 0, #length) *
-           ArrayBuffer(#ab, #element) *
-           toUtf8(#element, ret)
+           Uint8Array (#buffer; #ab, 0, #length) *
+           ArrayBuffer(#ab; #element) *
+           toUtf8(#element; ret)
        ]]
        normal
 */
@@ -269,38 +269,38 @@ var toUtf8 = function (buffer) { };
 /**
 
     @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List;) :
-        (definition == "Complete") * Unique(lst1),
-        (definition == "Broken") * Duplicated(lst2, lst3);
+        (definition == "Complete") * Unique(lst1;),
+        (definition == "Broken") * Duplicated(lst2, lst3;);
 
     @id decodeEncryptionContext
 
     @pre (this == undefined) * (encodedEncryptionContext == #eEC) *
-         Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
+         Uint8Array(#eEC; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
          (#EC == l-sub(#data, #byteOffset, #byteLength)) *
          (#definition == "Complete") *
-         RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
+         RawEncryptionContext(#EC; #definition, #ECKs, #errorMessage) *
 
-         scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-         scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-         JSInternals()
+         scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+         scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+         JSInternals(;)
 
-    @post Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
-          RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
+    @post Uint8Array(#eEC; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
+          RawEncryptionContext(#EC; #definition, #ECKs, #errorMessage) *
 
-          DecodedEncryptionContext(ret, #ECKs) *
+          DecodedEncryptionContext(ret, #ECKs;) *
 
-          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-          scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-          JSInternals ()
+          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+          JSInternals (;)
 */
 function decodeEncryptionContext(encodedEncryptionContext) {
   /* @tactic
       if (#definition = "Complete") then {
-        unfold CRawEncryptionContext(#EC, #ECKs)
+        unfold CRawEncryptionContext(#EC; #ECKs)
       } else {
-        unfold BRawEncryptionContext(#EC, #errorMessage, #ECKs)
+        unfold BRawEncryptionContext(#EC; #errorMessage, #ECKs)
       }
    */
 
@@ -340,43 +340,43 @@ function decodeEncryptionContext(encodedEncryptionContext) {
     @tactic
         assert (
             (#EC == l+ ({{ #b0, #b1 }}, #rest)) *
-            Elements(#EC, 2, ((256 * #b0) + #b1), 2, "Complete", #ECKs, l-len #rest)
+            Elements(#EC, 2, ((256 * #b0) + #b1), 2; "Complete", #ECKs, l-len #rest)
         ) [bind: #b0, #b1, #rest];
-        unfold Elements(#EC, 2, ((256 * #b0) + #b1), 2, "Complete", #ECKs, l-len #rest);
+        unfold Elements(#EC, 2, ((256 * #b0) + #b1), 2; "Complete", #ECKs, l-len #rest);
         assert (
             scope(pairsCount: #pairsCount) * (#pairsCount == l-len #ECKs) *
-            scope(elements: #elements) * ArrayOfArraysOfUInt8Arrays(#elements, #ECKs) *
-            scope(encryptionContext: #dECObj) * JSObjWithProto(#dECObj, null) * empty_fields(#dECObj : -{ }-) *
-            toUtf8PairMap(#ECKs, #utf8ECKs) * FirstProj(#ECKs, #rProps) * UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps)
+            scope(elements: #elements) * ArrayOfArraysOfUInt8Arrays(#elements; #ECKs) *
+            scope(encryptionContext: #dECObj) * JSObjWithProto(#dECObj; null) * empty_fields(#dECObj : -{ }-) *
+            toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) * UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;)
         ) [bind: #pairsCount, #elements, #dECObj, #utf8ECKs, #rProps]
 
     @invariant
         scope(pairsCount: #pairsCount) * scope(elements: #elements) * scope(encryptionContext: #dECObj) *
-        scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-        scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
+        scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+        scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
         scope(key: _) * scope(value: _) *
-        toUtf8PairMap(#ECKs, #utf8ECKs) * FirstProj(#ECKs, #rProps) *
-        CElements(#EC, 2., ((256. * #b0) + #b1), 2., #ECKs, (l-len #rest)) *
-        UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps) *
-        JSInternals() *
+        toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) *
+        CElements(#EC, 2., ((256. * #b0) + #b1), 2.; #ECKs, (l-len #rest)) *
+        UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;) *
+        JSInternals(;) *
 
         scope(count: #count) * (#count <=# #pairsCount) *
-        ArrayStructure(#elements, #pairsCount) *
-        ArrayOfArraysOfUInt8ArraysContents(#elements, 0, #count, #done) *
-        ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left) *
+        ArrayStructure(#elements, #pairsCount;) *
+        ArrayOfArraysOfUInt8ArraysContents(#elements, 0, #count; #done) *
+        ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left) *
         (#ECKs == l+ (#done, #left)) *
-        FirstProj(#done, #doneRProps) * Unique(#doneRProps) *
-        FirstProj(#left, #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps) *
-        toUtf8PairMap(#done, #utf8Done) *
-        JSObjWithProto(#dECObj, null) * ObjectTable(#dECObj, #utf8Done)
+        FirstProj(#done; #doneRProps) * Unique(#doneRProps;) *
+        FirstProj(#left; #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;) *
+        toUtf8PairMap(#done; #utf8Done) *
+        JSObjWithProto(#dECObj; null) * ObjectTable(#dECObj, #utf8Done;)
         [bind: #count, #done, #left, #doneRProps, #leftRProps, #utf8Done] */
   for (var count = 0; count < pairsCount; count++) {
     /*
         @tactic
-            unfold ArrayStructure(#elements, #pairsCount);
-            unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps);
-            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
-            unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
+            unfold ArrayStructure(#elements, #pairsCount;);
+            unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;);
+            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;);
+            unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
             apply CElementsElementLength(#EC, 2., ((256. * #b0) + #b1), 2., #ECKs, #done, #ECK, #rest_left);
             assert (#ECK == {{ #new_prop, #new_value }})
     */
@@ -389,13 +389,13 @@ function decodeEncryptionContext(encodedEncryptionContext) {
      */
     /*
         @tactic
-            assert (toUtf8(#new_prop, #utf8NProp)) [bind: #utf8NProp];
-            assert (toUtf8(#new_value, #utf8NVal)) [bind: #utf8NVal];
-            unfold ObjectTable(#dECObj, #utf8Done) [bind: (#doneProps := #pList) and (#donePropsSet := #pSet)];
+            assert (toUtf8(#new_prop; #utf8NProp)) [bind: #utf8NProp];
+            assert (toUtf8(#new_value; #utf8NVal)) [bind: #utf8NVal];
+            unfold ObjectTable(#dECObj, #utf8Done;) [bind: (#doneProps := #pList) and (#donePropsSet := #pSet)];
             apply FirstProjConcatSplit(#ECKs, #done, #left);
             apply ProduceListToSet(#doneRProps); apply ProduceListToSet(#leftRProps);
-            assert (ListToSet(#doneRProps, #doneRPropsSet)) [bind: #doneRPropsSet];
-            unfold FirstProj(#left, #leftRProps);
+            assert (ListToSet(#doneRProps; #doneRPropsSet)) [bind: #doneRPropsSet];
+            unfold FirstProj(#left; #leftRProps);
             apply HeadInSet(#leftRProps);
             if (#definition = "Complete") then {
                 apply UniqueConcatSplitNotInSuffix(#rProps, #doneRProps, #leftRProps, #new_prop);
@@ -404,7 +404,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
                 apply ObjectTableAbsentProperty(#dECObj, #utf8Done, #utf8NProp)
             } else {
                 apply FirstProjToUtf8MapPairCompat(#done);
-                unfold Duplicated(#doneRProps, #leftRProps) [bind: (#doneRPropsSet2 := #preSet)];
+                unfold Duplicated(#doneRProps, #leftRProps;) [bind: (#doneRPropsSet2 := #preSet)];
                 apply ListToSetFunction(#doneRProps, #doneRPropsSet, #doneRProps, #doneRPropsSet2);
                 if (#new_prop -e- #doneRPropsSet) then {
                     apply InListToUtf8(#new_prop, #doneRProps);
@@ -431,7 +431,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
             apply ListToSetAddElement(#doneProps, #donePropsSet, #utf8NProp);
             apply UniqueAppendElement(#doneRProps, #new_prop);
             if (#definition = "Complete") then {
-                unfold Unique(#leftRProps)
+                unfold Unique(#leftRProps;)
             }
     */
     0 === 0;
@@ -439,12 +439,12 @@ function decodeEncryptionContext(encodedEncryptionContext) {
 
   /*
     @tactic
-        unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left);
+        unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left);
         apply toUtf8PairMapInjective(#ECKs, #utf8ECKs, #done, #utf8Done);
         if (#definition = "Broken") then {
-            unfold FirstProj(#left, #leftRProps);
-            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
-            unfold Duplicated(#doneRProps, #leftRProps)
+            unfold FirstProj(#left; #leftRProps);
+            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;);
+            unfold Duplicated(#doneRProps, #leftRProps;)
         };
         use_subst [object_table : (#PVPairs: #utf8ECKs) ]
   */

--- a/Gillian-JS/Examples/Amazon/bugs/pp/AmazonLogic.jsil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/AmazonLogic.jsil
@@ -110,17 +110,17 @@ lemma PrependCElementI(buffer, readPos, fCount1, fList1, eLength1, fCount2, fLis
 lemma PrependCElementsE(definition, buffer, readPos, eCount1, fCount, fList1, esLength1, eCount2, fList2, esLength2)
 [[
     CElements(#buffer, #readPos, #eCount1, #fCount, #fList1, #esLength1) *
-    Elements(#definition, #buffer, #readPos + #esLength1, #eCount2, #fCount, #fList2, #esLength2)
+    Elements(#buffer, #readPos + #esLength1, #eCount2, #fCount, #definition, #fList2, #esLength2)
 ]]
 [[
-    Elements(#definition, #buffer, #readPos, #eCount1 + #eCount2, #fCount, l+ (#fList1, #fList2), #esLength1 + #esLength2)
+    Elements(#buffer, #readPos, #eCount1 + #eCount2, #fCount, #definition, l+ (#fList1, #fList2), #esLength1 + #esLength2)
 ]]
 [*
     unfold CElements(#buffer, #readPos, #eCount1, #fCount, #fList1, #esLength1)
       [bind: (#fList := #element) and (#eLength := #eLength) and (#restElements := #restElements) and (#restESLength := #restLength)] ;
     if (0 < #eCount1) then {
         apply PrependCElementsE(#definition, #buffer, #readPos + #eLength, #eCount1 - 1, #fCount, #restElements, #restESLength, #eCount2, #fList2, #esLength2);
-        unfold Elements(#definition, #buffer, (#eLength + #readPos), ((-1. + #eCount1) + #eCount2), #fCount, l+ (#restElements, #fList2), (#restESLength + #esLength2));
+        unfold Elements(#buffer, (#eLength + #readPos), ((-1. + #eCount1) + #eCount2), #fCount, #definition, l+ (#restElements, #fList2), (#restESLength + #esLength2));
         if (definition = "Incomplete") then {
             fold IElements(#buffer, #readPos, #eCount1 + #eCount2, #fCount, l+ (#fList1, #fList2), #esLength1 + #esLength2)
         }
@@ -167,13 +167,13 @@ lemma CElementsElementLength(buffer, readPos, eCount, fCount, eList, prefix, ele
 *)
 
 (* Broken serialised encryption context *)
-nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:List) :
+nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (2 <# l-len buffer) *
     (#rawKC == l-sub (buffer, 0, 2)) *
     rawToUInt16(#rawKC, false, #keyCount) *
     (0 <# #keyCount) * (ECKs == {{ }}) *
-    Elements("Incomplete", buffer, 2, #keyCount, 2, #eList, #esLength) *
+    Elements(buffer, 2, #keyCount, 2, "Incomplete", #eList, #esLength) *
     (errorMessage == "decodeEncryptionContext: Underflow, not enough data."),
 
     (* Too much data provided *)
@@ -181,7 +181,7 @@ nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:List) :
     (#rawKC == l-sub (buffer, 0, 2)) *
     rawToUInt16(#rawKC, false, #keyCount) *
     (0 <# #keyCount) *
-    Elements("Complete", buffer, 2, #keyCount, 2, ECKs, #ECKsLength) *
+    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
     (! (#ECKsLength + 2 == l-len buffer)) *
     (errorMessage == "decodeEncryptionContext: Overflow, too much data."),
 
@@ -190,15 +190,15 @@ nounfold pred BRawEncryptionContext(errorMessage:Str, +buffer:List, ECKs:List) :
     (#rawKC == l-sub (buffer, 0, 2)) *
     rawToUInt16(#rawKC, false, #keyCount) *
     (0 <# #keyCount) *
-    Elements("Complete", buffer, 2, #keyCount, 2, ECKs, #ECKsLength) *
+    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Duplicated({{ }}, #ECKeys) *
     (2 + #ECKsLength == l-len buffer) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
 (* General serialised encryption context *)
-pred RawEncryptionContext(definition:Str, +buffer:List, ECKs:List, errorMessage:Str) :
+pred RawEncryptionContext(+buffer:List, definition:Str, ECKs:List, errorMessage:Str) :
   (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
-  (definition == "Broken")   * BRawEncryptionContext(errorMessage, buffer, ECKs);
+  (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
 
 (* Live decoded encryption context *)
 pred LiveDecodedEncryptionContext(+dECObj : Obj, +ECKs : List) :
@@ -247,7 +247,7 @@ nounfold pred EncryptedDataKey(+EDK, pId:Str, pInfo:Str, encryptedDataKey:List, 
 (***** Arrays of deserialised EDKs *****)
 
 (* Live array of deserialised EDKs *)
-pred ArrayOfDEDKsContents(+a:Obj, contents:List, +start:Num) :
+pred ArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
@@ -257,10 +257,10 @@ pred ArrayOfDEDKsContents(+a:Obj, contents:List, +start:Num) :
     (#element == {{ #rawId, #rawInfo, #encryptedDataKey }}) *
     (contents == #element :: #rest) *
     (#rest_start == start + 1) *
-    ArrayOfDEDKsContents(a, #rest, #rest_start);
+    ArrayOfDEDKsContents(a, #rest_start, #rest);
 
 (* Frozen array of deserialised EDKs *)
-pred FrozenArrayOfDEDKsContents(+a:Obj, contents:List, +start:Num) :
+pred FrozenArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
@@ -270,19 +270,19 @@ pred FrozenArrayOfDEDKsContents(+a:Obj, contents:List, +start:Num) :
     (#edk == {{ #rawId, #rawInfo, #encryptedDataKey }}) *
     (contents == #edk :: #rest_contents) *
     (#rest_start == start + 1) *
-    FrozenArrayOfDEDKsContents(a, #rest_contents, #rest_start);
+    FrozenArrayOfDEDKsContents(a, #rest_start, #rest_contents);
 
 (***** Deserialised EDKs *****)
 
 (* EDKs are first deserialised into a live array *)
 pred LiveDeserialisedEncryptedDataKeys (+a:Obj, EDKs:List) :
     ArrayStructure(a, l-len EDKs) *
-    ArrayOfDEDKsContents(a, EDKs, 0);
+    ArrayOfDEDKsContents(a, 0, EDKs);
 
 (* Deserialised EDKs are ultimately provided as a frozen array *)
 pred DeserialisedEncryptedDataKeys (+a:Obj, contents:List) :
     FrozenArrayStructure(a, l-len contents) *
-    FrozenArrayOfDEDKsContents(a, contents, 0);
+    FrozenArrayOfDEDKsContents(a, 0, contents);
 
 (************************************
  ************************************
@@ -500,7 +500,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
 
-    RawEncryptedDataKeys("Incomplete", rawHeaderData, 22 + ECLength, EDKs, _, errorMessage) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Incomplete", EDKs, _, errorMessage) *
     (contentType == 0) * (frameLength == 0) * (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
 
     (* Not enough data to read the header IV and the authentication tag *)
@@ -522,7 +522,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     CRawEncryptionContext(#EC, ECKs) *
 
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rawFrameLength, #rest)) *
-    RawEncryptedDataKeys("Complete", rawHeaderData, 22 + ECLength, EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (l-len #rawFrameLength == 4) *
     rawToUInt32(#rawFrameLength, false, frameLength) *
@@ -575,7 +575,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    BRawEncryptionContext(errorMessage, #EC, ECKs) *
+    BRawEncryptionContext(#EC, errorMessage, ECKs) *
 
     (EDKs == {{ }}) * (contentType == 0) * (frameLength == 0) *
     (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -597,7 +597,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
-    RawEncryptedDataKeys("Broken", rawHeaderData, 22 + ECLength, _, _, errorMessage) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Broken", _, _, errorMessage) *
 
     (EDKs == {{ }}) * (contentType == 0) * (frameLength == 0) *
     (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -620,7 +620,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, #rawReservedBytes, #rest)) *
-    RawEncryptedDataKeys("Complete", rawHeaderData, 22 + ECLength, EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (l-len #rawReservedBytes == 4) *
     rawToUInt32(#rawReservedBytes, false, #reservedBytes) *
@@ -649,7 +649,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (l-len #EC == ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rest)) *
-    RawEncryptedDataKeys("Complete", rawHeaderData, 22 + ECLength, EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (headerLength == 22 + ECLength + #EDKsLength + 1 + 4 + 1 + 4) *
     (headerLength + #ivLength + (#tagLength / 8) <=# l-len rawHeaderData) *
@@ -659,7 +659,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (frameLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }});
 
 (* General serialised header *)
-nounfold pred Header(definition, +rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
+nounfold pred Header(+rawHeaderData, definition, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
     (* Complete header *)
     (definition == "Complete") *
     CHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
@@ -678,7 +678,7 @@ nounfold pred Header(definition, +rawHeaderData, part_one, version, type, suiteI
   ********   Header         *******)
 
 (* Deserialised main part of the message header *)
-nounfold pred MessageHeader(+messageHeader, version, type, suiteId, messageId, +ECKs, EDKs, contentType, headerIvLength, frameLength) :
+nounfold pred MessageHeader(+messageHeader, +ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
     JSObject(messageHeader) *
     DataProp(messageHeader, "version", version) *
     DataProp(messageHeader, "type", type) *
@@ -695,11 +695,11 @@ nounfold pred MessageHeader(+messageHeader, version, type, suiteId, messageId, +
     DataProp(messageHeader, "frameLength", frameLength);
 
 (* Entire deserialised header *)
-nounfold pred HeaderInfo(+headerInfo, version, type, suiteId, messageId, +ECKs, EDKs, contentType, headerIvLength,
+nounfold pred HeaderInfo(+headerInfo, +ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
                             frameLength, headerLength, rawHeaderData, headerIv, headerAuthTag) :
     JSObject(headerInfo) *
     DataProp(headerInfo, "messageHeader", #messageHeader) *
-        MessageHeader(#messageHeader, version, type, suiteId, messageId, ECKs, EDKs, contentType, headerIvLength, frameLength) *
+        MessageHeader(#messageHeader, ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) *
     DataProp(headerInfo, "headerLength", headerLength) *
     DataProp(headerInfo, "algorithmSuite", #algoSuiteObject) *
         AlgorithmSuiteObject(#algoSuiteObject, headerIvLength, #tagLength) *

--- a/Gillian-JS/Examples/Amazon/bugs/pp/AmazonLogic.jsil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/AmazonLogic.jsil
@@ -1,10 +1,10 @@
 (* The length of an element is not smaller than the length of its first field *)
 lemma CElementFirstFieldLength(buffer, readPos, fCount, field, restFields, eLength)
 [[
-    CElement(#buffer, #readPos, #fCount, l+({{ #field }}, #restFields), #eLength)
+    CElement(#buffer, #readPos, #fCount; l+({{ #field }}, #restFields), #eLength)
 ]]
 [[
-    CElement(#buffer, #readPos, #fCount, l+({{ #field }}, #restFields), #eLength) *
+    CElement(#buffer, #readPos, #fCount; l+({{ #field }}, #restFields), #eLength) *
     (2 + l-len #field <=# #eLength)
 ]]
 [*
@@ -14,35 +14,35 @@ lemma CElementFirstFieldLength(buffer, readPos, fCount, field, restFields, eLeng
 (* The length of a non-empty complete element is strictly positive *)
 lemma CElementNonEmptyPositiveLength(buffer, readPos, fCount, fList, eLength)
 [[
-    CElement(#buffer, #readPos, #fCount, #fList, #eLength) * (0 <# #fCount)
+    CElement(#buffer, #readPos, #fCount; #fList, #eLength) * (0 <# #fCount)
 ]]
 [[
-    CElement(#buffer, #readPos, #fCount, #fList, #eLength) *
+    CElement(#buffer, #readPos, #fCount; #fList, #eLength) *
     (0 <# #eLength)
 ]]
 [*
     unfold CElement(#buffer, #readPos, #fCount, #fList, #eLength);
-    sep_assert (Field(#buffer, #readPos, #field, #fLength)) [bind: #fLength];
-    sep_assert (CElement(#buffer, #readPos + #fLength, #fCount - 1, #restFields, #restELength)) [bind: #restELength]
+    sep_assert (Field(#buffer, #readPos; #field, #fLength)) [bind: #fLength];
+    sep_assert (CElement(#buffer, #readPos + #fLength, #fCount - 1; #restFields, #restELength)) [bind: #restELength]
 *]
 
 (* Appending the first field of a given complete element to a complete element on its left *)
 lemma AppendFieldCC(buffer, readPos, fCount1, fList1, eLength1, fCount2, field, fList2, eLength2)
 [[
-    CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1) *
-    CElement(#buffer, #readPos + #eLength1, #fCount2, l+({{ #field }}, #fList2), #eLength2) *
+    CElement(#buffer, #readPos, #fCount1; #fList1, #eLength1) *
+    CElement(#buffer, #readPos + #eLength1, #fCount2; l+({{ #field }}, #fList2), #eLength2) *
     (#shift == 2 + l-len #field)
 ]]
 [[
-    CElement(#buffer, #readPos, #fCount1 + 1, l+ (#fList1, {{ #field }}), #eLength1 + #shift) *
-    CElement(#buffer, #readPos + #eLength1 + #shift, #fCount2 - 1, #fList2, #eLength2 - #shift)
+    CElement(#buffer, #readPos, #fCount1 + 1; l+ (#fList1, {{ #field }}), #eLength1 + #shift) *
+    CElement(#buffer, #readPos + #eLength1 + #shift, #fCount2 - 1; #fList2, #eLength2 - #shift)
 ]]
 [*
     apply CElementFirstFieldLength(#buffer, #readPos + #eLength1, #fCount2, #field, #fList2, #eLength2);
     unfold CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1);
     if (0 < #fCount1) then {
         sep_assert (#fList1 == l+ ({{ #fl1 }}, #rfl1)) [bind: #fl1, #rfl1];
-        sep_assert (CElement(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1)) [bind: #reL1];
+        sep_assert (CElement(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1; #rfl1, #reL1)) [bind: #reL1];
         apply AppendFieldCC(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1, #fCount2, #field, #fList2, #eLength2)
     }
 *]
@@ -52,18 +52,18 @@ lemma AppendFieldCC(buffer, readPos, fCount1, fList1, eLength1, fCount2, field, 
 (* Appending a complete element to the given complete elements from the right *)
 lemma CElementsAppend(buffer, readPos, eCount, fCount, eList, esLength, fList, eLength)
 [[
-    CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
-    CElement(#buffer, #readPos + #esLength, #fCount, #fList, #eLength)
+    CElements(#buffer, #readPos, #eCount, #fCount; #eList, #esLength) *
+    CElement(#buffer, #readPos + #esLength, #fCount; #fList, #eLength)
 ]]
 [[
-    CElements(#buffer, #readPos, #eCount + 1, #fCount, l+ (#eList, {{ #fList }}), #esLength + #eLength)
+    CElements(#buffer, #readPos, #eCount + 1, #fCount; l+ (#eList, {{ #fList }}), #esLength + #eLength)
 ]]
 [*
     apply CElementNonEmptyPositiveLength(#buffer, #readPos + #esLength, #fCount, #fList, #eLength);
     unfold CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength);
     if (0 < #eCount) then {
-        sep_assert (CElement(#buffer, #readPos, #fCount, #newElementFieldList, #newElementLength)) [bind: #newElementFieldList, #newElementLength];
-        sep_assert (CElements(#buffer, (#readPos + #newElementLength), (#eCount - 1), #fCount, #remainingElementsList, #remainingElementsLength)) [bind: #remainingElementsList, #remainingElementsLength];
+        sep_assert (CElement(#buffer, #readPos, #fCount; #newElementFieldList, #newElementLength)) [bind: #newElementFieldList, #newElementLength];
+        sep_assert (CElements(#buffer, (#readPos + #newElementLength), (#eCount - 1), #fCount; #remainingElementsList, #remainingElementsLength)) [bind: #remainingElementsList, #remainingElementsLength];
         apply CElementsAppend(#buffer, (#readPos + #newElementLength), (#eCount - 1), #fCount, #remainingElementsList, #remainingElementsLength, #fList, #eLength)
     }
  *]
@@ -71,19 +71,19 @@ lemma CElementsAppend(buffer, readPos, eCount, fCount, eList, esLength, fList, e
 (* Appending the first field of a given incomplete element to a complete element on its left *)
 lemma AppendFieldCI(buffer, readPos, fCount1, fList1, eLength1, fCount2, field, fList2, eLength2)
 [[
-    CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1) *
-    IElement(#buffer, #readPos + #eLength1, #fCount2, l+({{ #field }}, #fList2), #eLength2) *
+    CElement(#buffer, #readPos, #fCount1; #fList1, #eLength1) *
+    IElement(#buffer, #readPos + #eLength1, #fCount2; l+({{ #field }}, #fList2), #eLength2) *
     (#shift == 2 + l-len #field)
 ]]
 [[
-    CElement(#buffer, #readPos, #fCount1 + 1, l+ (#fList1, {{ #field }}), #eLength1 + #shift) *
-    IElement(#buffer, #readPos + #eLength1 + #shift, #fCount2 - 1, #fList2, #eLength2 - #shift)
+    CElement(#buffer, #readPos, #fCount1 + 1; l+ (#fList1, {{ #field }}), #eLength1 + #shift) *
+    IElement(#buffer, #readPos + #eLength1 + #shift, #fCount2 - 1; #fList2, #eLength2 - #shift)
 ]]
 [*
     unfold CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1);
     if (0 < #fCount1) then {
         sep_assert (#fList1 == l+ ({{ #fl1 }}, #rfl1)) [bind: #fl1, #rfl1];
-        sep_assert (CElement(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1)) [bind: #reL1];
+        sep_assert (CElement(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1; #rfl1, #reL1)) [bind: #reL1];
         apply AppendFieldCI(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1, #fCount2, #field, #fList2, #eLength2)
     }
 *]
@@ -91,17 +91,17 @@ lemma AppendFieldCI(buffer, readPos, fCount1, fList1, eLength1, fCount2, field, 
 (* Prepend an entire complete element to an incomplete element following it *)
 lemma PrependCElementI(buffer, readPos, fCount1, fList1, eLength1, fCount2, fList2, eLength2)
 [[
-    CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1) *
-    IElement(#buffer, #readPos + #eLength1, #fCount2, #fList2, #eLength2)
+    CElement(#buffer, #readPos, #fCount1; #fList1, #eLength1) *
+    IElement(#buffer, #readPos + #eLength1, #fCount2; #fList2, #eLength2)
 ]]
 [[
-    IElement(#buffer, #readPos, #fCount1 + #fCount2, l+ (#fList1, #fList2), #eLength1 + #eLength2)
+    IElement(#buffer, #readPos, #fCount1 + #fCount2; l+ (#fList1, #fList2), #eLength1 + #eLength2)
 ]]
 [*
     unfold CElement(#buffer, #readPos, #fCount1, #fList1, #eLength1);
     if (0 < #fCount1) then {
         sep_assert (#fList1 == l+ ({{ #fl1 }}, #rfl1)) [bind: #fl1, #rfl1];
-        sep_assert (CElement(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1)) [bind: #reL1];
+        sep_assert (CElement(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1; #rfl1, #reL1)) [bind: #reL1];
         apply PrependCElementI(#buffer, 2 + (l-len #fl1) + #readPos, #fCount1 - 1, #rfl1, #reL1, #fCount2, #fList2, #eLength2)
     }
 *]
@@ -109,11 +109,11 @@ lemma PrependCElementI(buffer, readPos, fCount1, fList1, eLength1, fCount2, fLis
 (* An entire complete element sequence can be prepended to a general element sequence *)
 lemma PrependCElementsE(definition, buffer, readPos, eCount1, fCount, fList1, esLength1, eCount2, fList2, esLength2)
 [[
-    CElements(#buffer, #readPos, #eCount1, #fCount, #fList1, #esLength1) *
-    Elements(#buffer, #readPos + #esLength1, #eCount2, #fCount, #definition, #fList2, #esLength2)
+    CElements(#buffer, #readPos, #eCount1, #fCount; #fList1, #esLength1) *
+    Elements(#buffer, #readPos + #esLength1, #eCount2, #fCount; #definition, #fList2, #esLength2)
 ]]
 [[
-    Elements(#buffer, #readPos, #eCount1 + #eCount2, #fCount, #definition, l+ (#fList1, #fList2), #esLength1 + #esLength2)
+    Elements(#buffer, #readPos, #eCount1 + #eCount2, #fCount; #definition, l+ (#fList1, #fList2), #esLength1 + #esLength2)
 ]]
 [*
     unfold CElements(#buffer, #readPos, #eCount1, #fCount, #fList1, #esLength1)
@@ -130,20 +130,20 @@ lemma PrependCElementsE(definition, buffer, readPos, eCount1, fCount, fList1, es
 (* Every element of an element sequence has the same number of fields *)
 lemma CElementsElementLength(buffer, readPos, eCount, fCount, eList, prefix, element, suffix)
 [[
-    CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
+    CElements(#buffer, #readPos, #eCount, #fCount; #eList, #esLength) *
     (#eList == l+ (#prefix, {{ #element }}, #suffix))
 ]]
 [[
-    CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength) *
+    CElements(#buffer, #readPos, #eCount, #fCount; #eList, #esLength) *
     (l-len #element == #fCount)
 ]]
 [*
     apply DestructList(#prefix);
     unfold CElements(#buffer, #readPos, #eCount, #fCount, #eList, #esLength);
     if (not (#prefix = {{ }})) then {
-        sep_assert (CElement(#buffer, #readPos, #fCount, #fList, #elementLength)) [bind: #elementLength];
+        sep_assert (CElement(#buffer, #readPos, #fCount; #fList, #elementLength)) [bind: #elementLength];
         sep_assert (#prefix == #head :: #rest) [bind: #head, #rest];
-        sep_assert (CElements(#buffer, (#readPos + #elementLength), (#eCount - 1), #fCount, l+ (#rest, {{#element}}, #suffix), #restESLength)) [bind: #restESLength];
+        sep_assert (CElements(#buffer, (#readPos + #elementLength), (#eCount - 1), #fCount; l+ (#rest, {{#element}}, #suffix), #restESLength)) [bind: #restESLength];
         apply CElementsElementLength(#buffer, (#readPos + #elementLength), (#eCount - 1), #fCount, l+ (#rest, {{#element}}, #suffix), #rest, #element, #suffix)
     }
  *]
@@ -171,46 +171,46 @@ nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (2 <# l-len buffer) *
     (#rawKC == l-sub (buffer, 0, 2)) *
-    rawToUInt16(#rawKC, false, #keyCount) *
+    rawToUInt16(#rawKC, false; #keyCount) *
     (0 <# #keyCount) * (ECKs == {{ }}) *
-    Elements(buffer, 2, #keyCount, 2, "Incomplete", #eList, #esLength) *
+    Elements(buffer, 2, #keyCount, 2; "Incomplete", #eList, #esLength) *
     (errorMessage == "decodeEncryptionContext: Underflow, not enough data."),
 
     (* Too much data provided *)
     (2 <# l-len buffer) *
     (#rawKC == l-sub (buffer, 0, 2)) *
-    rawToUInt16(#rawKC, false, #keyCount) *
+    rawToUInt16(#rawKC, false; #keyCount) *
     (0 <# #keyCount) *
-    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
+    Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
     (! (#ECKsLength + 2 == l-len buffer)) *
     (errorMessage == "decodeEncryptionContext: Overflow, too much data."),
 
     (* Duplicated key in context *)
     (2 <# l-len buffer) *
     (#rawKC == l-sub (buffer, 0, 2)) *
-    rawToUInt16(#rawKC, false, #keyCount) *
+    rawToUInt16(#rawKC, false; #keyCount) *
     (0 <# #keyCount) *
-    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) * Duplicated({{ }}, #ECKeys) *
+    Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Duplicated({{ }}, #ECKeys;) *
     (2 + #ECKsLength == l-len buffer) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
 (* General serialised encryption context *)
 pred RawEncryptionContext(buffer:List; definition:Str, ECKs:List, errorMessage:Str) :
-  (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
-  (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
+  (definition == "Complete") * CRawEncryptionContext(buffer; ECKs) * (errorMessage == ""),
+  (definition == "Broken")   * BRawEncryptionContext(buffer; errorMessage, ECKs);
 
 (* Live decoded encryption context *)
 pred LiveDecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
-    JSObjWithProto(dECObj, null) *
-    toUtf8PairMap(ECKs, #utf8ECKs) *
-    ObjectTable(dECObj, #utf8ECKs);
+    JSObjWithProto(dECObj; null) *
+    toUtf8PairMap(ECKs; #utf8ECKs) *
+    ObjectTable(dECObj, #utf8ECKs;);
 
 (* Decoded encryption context *)
 pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
-    JSObjGeneral(dECObj, $lobj_proto, "Object", false) *
-    toUtf8PairMap(ECKs, #utf8ECKs) *
-    FrozenObjectTable(dECObj, #utf8ECKs);
+    JSObjGeneral(dECObj; $lobj_proto, "Object", false) *
+    toUtf8PairMap(ECKs; #utf8ECKs) *
+    FrozenObjectTable(dECObj, #utf8ECKs;);
 
 
 (*****************************
@@ -227,21 +227,21 @@ pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
 
 (* Prototype of EDK objects *)
 pred EDKPrototype (;) :
-    JSObjGeneral($l_edk_proto, null, "Object", false) *
+    JSObjGeneral($l_edk_proto; null, "Object", false) *
     empty_fields($l_edk_proto : -{ }-);
 
 (* EDK objects *)
 nounfold pred EncryptedDataKey(EDK; pId:Str, pInfo:Str, encryptedDataKey:List, rawInfo:List) :
-    JSObjGeneral(EDK, $l_edk_proto, "Object", false) *
-    readOnlyProperty(EDK, "providerId", pId) *
-    readOnlyProperty(EDK, "providerInfo", pInfo) *
-    readOnlyProperty(EDK, "encryptedDataKey", #aEDK) *
-        Uint8Array(#aEDK, #abEDK, 0, #viewSizeEDK) *
-        ArrayBuffer(#abEDK, encryptedDataKey) *
+    JSObjGeneral(EDK; $l_edk_proto, "Object", false) *
+    readOnlyProperty(EDK, "providerId"; pId) *
+    readOnlyProperty(EDK, "providerInfo"; pInfo) *
+    readOnlyProperty(EDK, "encryptedDataKey"; #aEDK) *
+        Uint8Array(#aEDK; #abEDK, 0, #viewSizeEDK) *
+        ArrayBuffer(#abEDK; encryptedDataKey) *
         (#viewSizeEDK == l-len encryptedDataKey) *
-    readOnlyProperty(EDK, "rawInfo", #aRInfo) *
-        Uint8Array(#aRInfo, #abRInfo, 0, #viewSizeRInfo) *
-        ArrayBuffer(#abRInfo, rawInfo) *
+    readOnlyProperty(EDK, "rawInfo"; #aRInfo) *
+        Uint8Array(#aRInfo; #abRInfo, 0, #viewSizeRInfo) *
+        ArrayBuffer(#abRInfo; rawInfo) *
         (#viewSizeRInfo == l-len rawInfo);
 
 (***** Arrays of deserialised EDKs *****)
@@ -251,38 +251,38 @@ pred ArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
-    DataProp(a, #index, #edk) *
-    EncryptedDataKey(#edk, #pId, #pInfo, #encryptedDataKey, #rawInfo) *
-    fromUtf8(#rawId, #pId) * fromUtf8(#pInfo, #rawInfo) *
+    DataProp(a, #index; #edk) *
+    EncryptedDataKey(#edk; #pId, #pInfo, #encryptedDataKey, #rawInfo) *
+    fromUtf8(#rawId; #pId) * fromUtf8(#pInfo; #rawInfo) *
     (#element == {{ #rawId, #rawInfo, #encryptedDataKey }}) *
     (contents == #element :: #rest) *
     (#rest_start == start + 1) *
-    ArrayOfDEDKsContents(a, #rest_start, #rest);
+    ArrayOfDEDKsContents(a, #rest_start; #rest);
 
 (* Frozen array of deserialised EDKs *)
 pred FrozenArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
-    readOnlyProperty(a, #index, #edk) *
-    EncryptedDataKey(#edk, #pId, #pInfo, #encryptedDataKey, #rawInfo) *
-    fromUtf8(#rawId, #pId) * fromUtf8(#pInfo, #rawInfo) *
+    readOnlyProperty(a, #index; #edk) *
+    EncryptedDataKey(#edk; #pId, #pInfo, #encryptedDataKey, #rawInfo) *
+    fromUtf8(#rawId; #pId) * fromUtf8(#pInfo; #rawInfo) *
     (#edk == {{ #rawId, #rawInfo, #encryptedDataKey }}) *
     (contents == #edk :: #rest_contents) *
     (#rest_start == start + 1) *
-    FrozenArrayOfDEDKsContents(a, #rest_start, #rest_contents);
+    FrozenArrayOfDEDKsContents(a, #rest_start; #rest_contents);
 
 (***** Deserialised EDKs *****)
 
 (* EDKs are first deserialised into a live array *)
 pred LiveDeserialisedEncryptedDataKeys (a:Obj; EDKs:List) :
-    ArrayStructure(a, l-len EDKs) *
-    ArrayOfDEDKsContents(a, 0, EDKs);
+    ArrayStructure(a, l-len EDKs;) *
+    ArrayOfDEDKsContents(a, 0; EDKs);
 
 (* Deserialised EDKs are ultimately provided as a frozen array *)
 pred DeserialisedEncryptedDataKeys (a:Obj; contents:List) :
-    FrozenArrayStructure(a, l-len contents) *
-    FrozenArrayOfDEDKsContents(a, 0, contents);
+    FrozenArrayStructure(a, l-len contents;) *
+    FrozenArrayOfDEDKsContents(a, 0; contents);
 
 (************************************
  ************************************
@@ -297,7 +297,7 @@ pred DeserialisedEncryptedDataKeys (a:Obj; contents:List) :
 (* toUtf8 is injective *)
 lemma toUtf8Injective(rawData1, utf8Data1, rawData2, utf8Data2)
 [[
-    toUtf8(#rawData1, #utf8Data1) * toUtf8(#rawData2, #utf8Data2)
+    toUtf8(#rawData1; #utf8Data1) * toUtf8(#rawData2; #utf8Data2)
 ]]
 [[
     (#rawData1 == #rawData2) * (#utf8Data1 == #utf8Data2);
@@ -305,7 +305,7 @@ lemma toUtf8Injective(rawData1, utf8Data1, rawData2, utf8Data2)
 ]]
 
 (*
-    fromUtf8(utf8Data, rawData) is an abstract predicate which
+    fromUtf8(utf8Data; rawData) is an abstract predicate which
     denotes that the raw bytes rawData are obtained by converting
     the string utf8Data into bytes
 *)
@@ -314,7 +314,7 @@ abstract pure pred fromUtf8(utf8Data:Str; rawData:List);
 (* fromUtf8 is injective *)
 lemma fromUtf8Injective(utf8Data1, rawData1, utf8Data2, rawData2)
 [[
-    fromUtf8(#utf8Data1, #rawData1) * fromUtf8(#utf8Data2, #rawData2)
+    fromUtf8(#utf8Data1; #rawData1) * fromUtf8(#utf8Data2; #rawData2)
 ]]
 [[
     (#utf8Data1 == #utf8Data2) * (#rawData1 == #rawData2);
@@ -324,19 +324,19 @@ lemma fromUtf8Injective(utf8Data1, rawData1, utf8Data2, rawData2)
 (* Invertibility of toUtf8 with respect to fromUtf8 *)
 lemma toUtf8fromUtf8(rawData)
 [[
-    toUtf8(#rawData, #utf8Data)
+    toUtf8(#rawData; #utf8Data)
 ]]
 [[
-    fromUtf8(#utf8Data, #rawData)
+    fromUtf8(#utf8Data; #rawData)
 ]]
 
 (* Invertibility of fromUtf8 with respect to toUtf8 *)
 lemma fromUtf8toUtf8(utf8Data)
 [[
-    fromUtf8(#utf8Data, #rawData)
+    fromUtf8(#utf8Data; #rawData)
 ]]
 [[
-    toUtf8(#rawData, #utf8Data)
+    toUtf8(#rawData; #utf8Data)
 ]]
 
 (* UTF-8 Mapping of lists *)
@@ -344,14 +344,14 @@ pure pred toUtf8Map(data : List; utf8Data : List) :
     (data == {{ }}) * (utf8Data == {{ }}),
 
     (data == #fst :: #rest) *
-    (toUtf8(#fst, #utf8Fst)) *
-    toUtf8Map(#rest, #utf8Rest) *
+    (toUtf8(#fst; #utf8Fst)) *
+    toUtf8Map(#rest; #utf8Rest) *
     (utf8Data == #utf8Fst :: #utf8Rest);
 
 (* toUtf8PairMap is injective *)
 lemma toUtf8MapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
 [[
-    toUtf8Map(#rawData1, #utf8Data1) * toUtf8Map(#rawData2, #utf8Data2)
+    toUtf8Map(#rawData1; #utf8Data1) * toUtf8Map(#rawData2; #utf8Data2)
 ]]
 [[
     (#rawData1 == #rawData2) * (#utf8Data1 == #utf8Data2);
@@ -372,7 +372,7 @@ lemma toUtf8MapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
 (* toUtf8PairMap is injective *)
 lemma toUtf8PairMapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
 [[
-    toUtf8PairMap(#rawData1, #utf8Data1) * toUtf8PairMap(#rawData2, #utf8Data2)
+    toUtf8PairMap(#rawData1; #utf8Data1) * toUtf8PairMap(#rawData2; #utf8Data2)
 ]]
 [[
     (#rawData1 == #rawData2) * (#utf8Data1 == #utf8Data2);
@@ -394,18 +394,18 @@ lemma toUtf8PairMapInjective(rawData1, utf8Data1, rawData2, utf8Data2)
 (* Appending a pair to a mapping of lists of pairs *)
 lemma toUtf8PairMapAppendPair(data, utf8Data, prop, value)
 [[
-    toUtf8PairMap(#data, #utf8Data) *
-    toUtf8(#prop, #utf8Prop) *
-    toUtf8(#value, #utf8Value)
+    toUtf8PairMap(#data; #utf8Data) *
+    toUtf8(#prop; #utf8Prop) *
+    toUtf8(#value; #utf8Value)
 ]]
 [[
-    toUtf8PairMap(l+ (#data, {{ {{ #prop, #value }} }}), l+ (#utf8Data, {{ {{ #utf8Prop, #utf8Value }} }}))
+    toUtf8PairMap(l+ (#data, {{ {{ #prop, #value }} }}); l+ (#utf8Data, {{ {{ #utf8Prop, #utf8Value }} }}))
 ]]
 [*
     unfold toUtf8PairMap(#data, #utf8Data);
     if (not (#data = {{ }})) then {
         sep_assert (#data == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (toUtf8PairMap(#restPVPairs, #restUtf8Data)) [bind: #restUtf8Data];
+        sep_assert (toUtf8PairMap(#restPVPairs; #restUtf8Data)) [bind: #restUtf8Data];
         apply toUtf8PairMapAppendPair(#restPVPairs, #restUtf8Data, #prop, #value)
     }
 *]
@@ -421,9 +421,9 @@ lemma toUtf8PairMapAppendPair(data, utf8Data, prop, value)
 
 (* The object that holds information about allowed algorithm suites *)
 pred AlgorithmSuiteIdentifierObject(o;) :
-    JSObject(o) *
-    DataProp(o, "20",  "ALG_AES128_GCM_IV12_TAG16") * DataProp(o, "ALG_AES128_GCM_IV12_TAG16", 20) *
-    DataProp(o, "70",  "ALG_AES192_GCM_IV12_TAG16") * DataProp(o, "ALG_AES192_GCM_IV12_TAG16", 70) *
+    JSObject(o;) *
+    DataProp(o, "20";  "ALG_AES128_GCM_IV12_TAG16") * DataProp(o, "ALG_AES128_GCM_IV12_TAG16"; 20) *
+    DataProp(o, "70";  "ALG_AES192_GCM_IV12_TAG16") * DataProp(o, "ALG_AES192_GCM_IV12_TAG16"; 70) *
     empty_fields(o : -{ "20", "70", "ALG_AES128_GCM_IV12_TAG16", "ALG_AES192_GCM_IV12_TAG16" }-);
 
 (*
@@ -431,9 +431,9 @@ pred AlgorithmSuiteIdentifierObject(o;) :
     TODO: This object is more complex than presented here.
  *)
 pred AlgorithmSuiteObject(aso: Obj; ivLength: Num, tagLength: Num) :
-    JSObject(aso) *
-    readOnlyProperty(aso, "ivLength",  ivLength) *
-    readOnlyProperty(aso, "tagLength", tagLength);
+    JSObject(aso;) *
+    readOnlyProperty(aso, "ivLength";  ivLength) *
+    readOnlyProperty(aso, "tagLength"; tagLength);
 
 (***************************
  ***************************
@@ -472,10 +472,10 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (l-len rawHeaderData <# 22 + ECLength) *
 
     (ECKs == {{ }}) *
@@ -490,17 +490,17 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
 
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Incomplete", EDKs, _, errorMessage) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Incomplete", EDKs, _, errorMessage) *
     (contentType == 0) * (frameLength == 0) * (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
 
     (* Not enough data to read the header IV and the authentication tag *)
@@ -511,21 +511,21 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
 
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rawFrameLength, #rest)) *
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (l-len #rawFrameLength == 4) *
-    rawToUInt32(#rawFrameLength, false, frameLength) *
+    rawToUInt32(#rawFrameLength, false; frameLength) *
     (headerLength == 22 + ECLength + #EDKsLength + 1 + 4 + 1 + 4) *
     (l-len rawHeaderData <# headerLength + headerIvLength + (#tagLength / 8)) *
 
@@ -538,7 +538,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (* Incorrect version and/or type *)
     (22 <=# l-len rawHeaderData) *
     (rawHeaderData == l+ ({{ version, type }}, #rest)) *
-    BVersionAndType(version, type, errorMessage) *
+    BVersionAndType(version, type; errorMessage) *
 
     (part_one == {{ }}) *
     (suiteId == 0) * (messageId == {{ }}) * (ECLength == 0) *
@@ -550,9 +550,9 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (22 <=# l-len rawHeaderData) *
     (rawHeaderData == l+ ({{ version, type }}, #rawSuiteId, #rest)) *
     (l-len #rawSuiteId == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    BAlgorithmSuite(suiteId, errorMessage) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    BAlgorithmSuite(suiteId; errorMessage) *
 
     (part_one == {{ }}) * (messageId == {{ }}) * (ECLength == 0) *
     (part_two == {{ }}) * (ECKs == {{ }}) *
@@ -567,15 +567,15 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    BRawEncryptionContext(#EC, errorMessage, ECKs) *
+    BRawEncryptionContext(#EC; errorMessage, ECKs) *
 
     (EDKs == {{ }}) * (contentType == 0) * (frameLength == 0) *
     (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -588,16 +588,16 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Broken", _, _, errorMessage) *
+    CRawEncryptionContext(#EC; ECKs) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Broken", _, _, errorMessage) *
 
     (EDKs == {{ }}) * (contentType == 0) * (frameLength == 0) *
     (headerLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }}),
@@ -610,20 +610,20 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, #rawReservedBytes, #rest)) *
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (l-len #rawReservedBytes == 4) *
-    rawToUInt32(#rawReservedBytes, false, #reservedBytes) *
+    rawToUInt32(#rawReservedBytes, false; #reservedBytes) *
     (! (#reservedBytes == 0)) *
     (headerLength == 22 + ECLength + #EDKsLength + 1 + 4 + 1 + 4) *
     (headerLength + headerIvLength + (#tagLength / 8) <=# l-len rawHeaderData) *
@@ -639,17 +639,17 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, #ivLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, #ivLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (22 + ECLength <=# l-len rawHeaderData) *
 
     (part_two == l+ (#EC, part_three)) *
     (l-len #EC == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rest)) *
-    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength, "Complete", EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, 22 + ECLength; "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == l-len #edks) *
     (headerLength == 22 + ECLength + #EDKsLength + 1 + 4 + 1 + 4) *
     (headerLength + #ivLength + (#tagLength / 8) <=# l-len rawHeaderData) *
@@ -662,56 +662,56 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
 nounfold pred Header(rawHeaderData; definition, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
     (* Complete header *)
     (definition == "Complete") *
-    CHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
+    CHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
     (errorMessage == ""),
 
     (* Incomplete header *)
     (definition == "Incomplete") *
-    IHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
+    IHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
     (errorMessage == ""),
 
     (* Broken header *)
     (definition == "Broken") *
-    BHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage);
+    BHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage);
 
  (********   Deserialised   *******
   ********   Header         *******)
 
 (* Deserialised main part of the message header *)
 nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
-    JSObject(messageHeader) *
-    DataProp(messageHeader, "version", version) *
-    DataProp(messageHeader, "type", type) *
-    DataProp(messageHeader, "suiteId", suiteId) *
-    DataProp(messageHeader, "messageId", #ui8aMessageId) *
-        Uint8Array(#ui8aMessageId, #abMessageId, 0, 16) *
-        ArrayBuffer(#abMessageId, messageId) *
-    DataProp(messageHeader, "encryptionContext", #dECObj) *
-        DecodedEncryptionContext(#dECObj, ECKs) *
-    DataProp(messageHeader, "encryptedDataKeys", #dEDKs) *
-        DeserialisedEncryptedDataKeys(#dEDKs, EDKs) *
-    DataProp(messageHeader, "contentType", contentType) *
-    DataProp(messageHeader, "headerIvLength", headerIvLength) *
-    DataProp(messageHeader, "frameLength", frameLength);
+    JSObject(messageHeader;) *
+    DataProp(messageHeader, "version"; version) *
+    DataProp(messageHeader, "type"; type) *
+    DataProp(messageHeader, "suiteId"; suiteId) *
+    DataProp(messageHeader, "messageId"; #ui8aMessageId) *
+        Uint8Array(#ui8aMessageId; #abMessageId, 0, 16) *
+        ArrayBuffer(#abMessageId; messageId) *
+    DataProp(messageHeader, "encryptionContext"; #dECObj) *
+        DecodedEncryptionContext(#dECObj, ECKs;) *
+    DataProp(messageHeader, "encryptedDataKeys"; #dEDKs) *
+        DeserialisedEncryptedDataKeys(#dEDKs; EDKs) *
+    DataProp(messageHeader, "contentType"; contentType) *
+    DataProp(messageHeader, "headerIvLength"; headerIvLength) *
+    DataProp(messageHeader, "frameLength"; frameLength);
 
 (* Entire deserialised header *)
 nounfold pred HeaderInfo(headerInfo, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
                             frameLength, headerLength, rawHeaderData, headerIv, headerAuthTag) :
-    JSObject(headerInfo) *
-    DataProp(headerInfo, "messageHeader", #messageHeader) *
-        MessageHeader(#messageHeader, ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) *
-    DataProp(headerInfo, "headerLength", headerLength) *
-    DataProp(headerInfo, "algorithmSuite", #algoSuiteObject) *
-        AlgorithmSuiteObject(#algoSuiteObject, headerIvLength, #tagLength) *
-    DataProp(headerInfo, "rawHeader", #rawHeader) *
-        Uint8Array(#rawHeader, #rawBuffer, 0, headerLength) *
-        ArrayBuffer(#rawBuffer, rawHeaderData) *
-    DataProp(headerInfo, "headerIv", #ui8aHeaderIv) *
-        Uint8Array(#ui8aHeaderIv, #abHeaderIv, 0, headerIvLength) *
-        ArrayBuffer(#abHeaderIv, headerIv) *
-    DataProp(headerInfo, "headerAuthTag", #ui8aHeaderAuthTag) *
-        Uint8Array(#ui8aHeaderAuthTag, #abHeaderAuthTag, 0, #tagLength / 8) *
-        ArrayBuffer(#abHeaderAuthTag, headerAuthTag);
+    JSObject(headerInfo;) *
+    DataProp(headerInfo, "messageHeader"; #messageHeader) *
+        MessageHeader(#messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) *
+    DataProp(headerInfo, "headerLength"; headerLength) *
+    DataProp(headerInfo, "algorithmSuite"; #algoSuiteObject) *
+        AlgorithmSuiteObject(#algoSuiteObject; headerIvLength, #tagLength) *
+    DataProp(headerInfo, "rawHeader"; #rawHeader) *
+        Uint8Array(#rawHeader; #rawBuffer, 0, headerLength) *
+        ArrayBuffer(#rawBuffer; rawHeaderData) *
+    DataProp(headerInfo, "headerIv"; #ui8aHeaderIv) *
+        Uint8Array(#ui8aHeaderIv; #abHeaderIv, 0, headerIvLength) *
+        ArrayBuffer(#abHeaderIv; headerIv) *
+    DataProp(headerInfo, "headerAuthTag"; #ui8aHeaderAuthTag) *
+        Uint8Array(#ui8aHeaderAuthTag; #abHeaderAuthTag, 0, #tagLength / 8) *
+        ArrayBuffer(#abHeaderAuthTag; headerAuthTag);
 
 (*****************************
  *****************************
@@ -762,7 +762,7 @@ lemma DestructList(lst)
 (* FirstProj is a function *)
 lemma FirstProjFunction(lst1, proj1, lst2, proj2)
 [[
-    FirstProj(#lst1, #proj1) * FirstProj(#lst2, #proj2) * (#lst1 == #lst2)
+    FirstProj(#lst1; #proj1) * FirstProj(#lst2; #proj2) * (#lst1 == #lst2)
 ]]
 [[
     (#proj1 == #proj2)
@@ -778,16 +778,16 @@ lemma FirstProjFunction(lst1, proj1, lst2, proj2)
 (* Adding a pair to a first projection *)
 lemma FirstProjAppendPair(lst, fProj, prop, value)
 [[
-    FirstProj(#lst, #fProj)
+    FirstProj(#lst; #fProj)
 ]]
 [[
-    FirstProj(l+ (#lst, {{ {{ #prop, #value }} }}), l+ (#fProj, {{ #prop }}))
+    FirstProj(l+ (#lst, {{ {{ #prop, #value }} }}); l+ (#fProj, {{ #prop }}))
 ]]
 [*
     unfold FirstProj(#lst, #fProj);
     if (not (#lst = {{ }})) then {
         sep_assert (#lst == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (FirstProj(#restPVPairs, #restProj)) [bind: #restProj];
+        sep_assert (FirstProj(#restPVPairs; #restProj)) [bind: #restProj];
         apply FirstProjAppendPair(#restPVPairs, #restProj, #prop, #value)
     }
 *]
@@ -795,8 +795,8 @@ lemma FirstProjAppendPair(lst, fProj, prop, value)
 (* First projection goes through concatenation *)
 lemma FirstProjConcatSplit(PVPairs, prefix, suffix)
 [[
-    (#PVPairs == l+ (#prefix, #suffix)) * FirstProj(#PVPairs, #props) *
-    FirstProj(#prefix, #preProps) * FirstProj(#suffix, #sufProps)
+    (#PVPairs == l+ (#prefix, #suffix)) * FirstProj(#PVPairs; #props) *
+    FirstProj(#prefix; #preProps) * FirstProj(#suffix; #sufProps)
 ]]
 [[
     (#props == l+ (#preProps, #sufProps))
@@ -816,12 +816,12 @@ lemma FirstProjConcatSplit(PVPairs, prefix, suffix)
 (* Compatibility of first projection and toUtf8 *)
 lemma FirstProjToUtf8MapPairCompat(PVPairs)
 [[
-    FirstProj(#PVPairs, #props) *
-    toUtf8PairMap(#PVPairs, #utf8PVPairs) *
-    FirstProj(#utf8PVPairs, #utf8Props)
+    FirstProj(#PVPairs; #props) *
+    toUtf8PairMap(#PVPairs; #utf8PVPairs) *
+    FirstProj(#utf8PVPairs; #utf8Props)
 ]]
 [[
-    toUtf8Map(#props, #utf8Props)
+    toUtf8Map(#props; #utf8Props)
 ]]
 [*
     unfold FirstProj(#PVPairs, #props);
@@ -844,7 +844,7 @@ lemma FirstProjToUtf8MapPairCompat(PVPairs)
 (* ListToSet is a function *)
 lemma ListToSetFunction(lst1, set1, lst2, set2)
 [[
-    ListToSet(#lst1, #set1) * ListToSet(#lst2, #set2) * (#lst1 == #lst2)
+    ListToSet(#lst1; #set1) * ListToSet(#lst2; #set2) * (#lst1 == #lst2)
 ]]
 [[
     (#set1 == #set2)
@@ -860,7 +860,7 @@ lemma ListToSetFunction(lst1, set1, lst2, set2)
 (* ListToSet concat-union compatibility *)
 lemma ListToSetUnion(lst1, lst2)
 [[
-    ListToSet(#lst1, #set1) * ListToSet(#lst2, #set2) * ListToSet(l+ (#lst1, #lst2), #uset)
+    ListToSet(#lst1; #set1) * ListToSet(#lst2; #set2) * ListToSet(l+ (#lst1, #lst2); #uset)
 ]]
 [[
     (#uset == -u- (#set1, #set2))
@@ -882,7 +882,7 @@ lemma ProduceListToSet(lst)
     types(lst: List)
 ]]
 [[
-    ListToSet(#lst, #set)
+    ListToSet(#lst; #set)
 ]]
 [*
     apply DestructList(#lst);
@@ -895,16 +895,16 @@ lemma ProduceListToSet(lst)
 (* Adding an element in list-to-set conversion *)
 lemma ListToSetAddElement(lst, set, element)
 [[
-    ListToSet(#lst, #set)
+    ListToSet(#lst; #set)
 ]]
 [[
-    ListToSet(l+ (#lst, {{ #element }}), -u- (#set, -{ #element }-))
+    ListToSet(l+ (#lst, {{ #element }}); -u- (#set, -{ #element }-))
 ]]
 [*
     unfold ListToSet(#lst, #element);
     if (not (#lst = {{ }})) then {
         sep_assert (#lst == l+ ({{ #fProp }}, #restLst)) [bind: #fProp, #restLst];
-        sep_assert (ListToSet(#restLst, #restSet)) [bind: #restSet];
+        sep_assert (ListToSet(#restLst; #restSet)) [bind: #restSet];
         apply ListToSetAddElement(#restLst, #restSet, #element)
     }
 *]
@@ -913,7 +913,7 @@ lemma ListToSetAddElement(lst, set, element)
 lemma HeadInSet(lst)
 [[
     (#lst == #hd :: #tl) *
-    ListToSet(#lst, #set)
+    ListToSet(#lst; #set)
 ]]
 [[
     (#hd --e-- #set)
@@ -923,11 +923,11 @@ lemma HeadInSet(lst)
 (* toUtf8 mapping and list membership, positive *)
 lemma InListToUtf8(prop, props)
 [[
-    ListToSet(#props, #propsSet) *
+    ListToSet(#props; #propsSet) *
     (#prop --e-- #propsSet) *
-    toUtf8(#prop, #utf8Prop) *
-    toUtf8Map(#props, #utf8Props) *
-    ListToSet(#utf8Props, #utf8PropsSet)
+    toUtf8(#prop; #utf8Prop) *
+    toUtf8Map(#props; #utf8Props) *
+    ListToSet(#utf8Props; #utf8PropsSet)
 ]]
 [[
     (#utf8Prop --e-- #utf8PropsSet)
@@ -937,7 +937,7 @@ lemma InListToUtf8(prop, props)
     if (not (#props = {{ }})) then {
         sep_assert (#props == #fstProp :: #rest) [bind: #rest];
         unfold toUtf8Map(#props, #utf8Props);
-        sep_assert (toUtf8(#fstProp, #utf8FstProp)) [bind: #utf8FstProp];
+        sep_assert (toUtf8(#fstProp; #utf8FstProp)) [bind: #utf8FstProp];
         sep_assert (#utf8Props == #utf8FstProp :: #restUtf8) [bind: #restUtf8];
         unfold ListToSet(#utf8Props, #utf8PropsSet);
         if (#prop = #fstProp) then {
@@ -952,11 +952,11 @@ lemma InListToUtf8(prop, props)
 (* toUtf8 mapping and list membership, negative *)
 lemma NotInListToUtf8(prop, props)
 [[
-    ListToSet(#props, #propsSet) *
+    ListToSet(#props; #propsSet) *
     (! (#prop --e-- #propsSet)) *
-    toUtf8(#prop, #utf8Prop) *
-    toUtf8Map(#props, #utf8Props) *
-    ListToSet(#utf8Props, #utf8PropsSet)
+    toUtf8(#prop; #utf8Prop) *
+    toUtf8Map(#props; #utf8Props) *
+    ListToSet(#utf8Props; #utf8PropsSet)
 ]]
 [[
     (! (#utf8Prop --e-- #utf8PropsSet))
@@ -968,7 +968,7 @@ lemma NotInListToUtf8(prop, props)
 
     if (not (#props = {{ }})) then {
         sep_assert (#props == #fstProp :: #rest) [bind: #rest];
-        sep_assert (toUtf8(#fstProp, #utf8FstProp)) [bind: #utf8FstProp];
+        sep_assert (toUtf8(#fstProp; #utf8FstProp)) [bind: #utf8FstProp];
         apply toUtf8Injective(#prop, #utf8Prop, #fstProp, #utf8FstProp);
         apply NotInListToUtf8(#prop, #rest)
     }
@@ -987,8 +987,8 @@ lemma NotInListToUtf8(prop, props)
    no element from the right is on the left *)
 lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
 [[
-    (#props == l+ (#prefix, #suffix)) * Unique(#props) *
-    ListToSet(#prefix, #setPrefix) * ListToSet(#suffix, #setSuffix) *
+    (#props == l+ (#prefix, #suffix)) * Unique(#props;) *
+    ListToSet(#prefix; #setPrefix) * ListToSet(#suffix; #setSuffix) *
     (#prop --e-- #setSuffix)
 ]]
 [[
@@ -1012,11 +1012,11 @@ lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
 (* Appending an element to a unique list *)
 lemma UniqueAppendElement(lst, element)
 [[
-    Unique(#lst) * ListToSet(#lst, #set) *
+    Unique(#lst;) * ListToSet(#lst; #set) *
     (! (#element --e-- #set))
 ]]
 [[
-    Unique(l+ (#lst, {{ #element }}))
+    Unique(l+ (#lst, {{ #element }});)
 ]]
 [*
     unfold Unique(#lst) [bind: (#fst := #fst) and (#rest := #rest) and (#setRest1 := #setRest)];
@@ -1040,14 +1040,14 @@ lemma UniqueAppendElement(lst, element)
 pure pred Duplicated(prefix:List, suffix:List;) :
     (* Either the head is duplicated *)
     (suffix == #fst :: #rest) *
-    ListToSet(prefix, #preSet) *
+    ListToSet(prefix; #preSet) *
     (#fst --e-- #preSet),
 
     (* Or the duplication is in the tail *)
     (suffix == #fst :: #rest) *
-    ListToSet(prefix, #preSet) *
+    ListToSet(prefix; #preSet) *
     (! (#fst --e-- #preSet)) *
-    Duplicated(l+ (prefix, {{ #fst }}), #rest);
+    Duplicated(l+ (prefix, {{ #fst }}), #rest;);
 
 (*************************************
  *************************************
@@ -1064,27 +1064,27 @@ pred ObjectTableStructure(l:Obj, PVPairs:List;) :
 
     (* Recursive case - one property and the rest *)
     (PVPairs == {{ #prop, #value }} :: #restPVPairs) *
-    DataProp(l, #prop, #value) * types(#value : Str) *
-    ObjectTableStructure(l, #restPVPairs);
+    DataProp(l, #prop; #value) * types(#value : Str) *
+    ObjectTableStructure(l, #restPVPairs;);
 
 (* Complete Object-as-Table predicate *)
 nounfold pred ObjectTable(l:Obj, PVPairs:List;) :
-    ObjectTableStructure(l, PVPairs) *
-    FirstProj(PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(l, PVPairs;) *
+    FirstProj(PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet);
 
 (* Object-as-Table absent property *)
 lemma ObjectTableAbsentProperty(l, PVPairs, prop)
 [[
-    ObjectTableStructure(#l, #PVPairs) *
-    FirstProj(#PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(#l, #PVPairs;) *
+    FirstProj(#PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet) *
     (! (#prop --e-- #pSet))
 ]]
 [[
-    ObjectTableStructure(#l, #PVPairs) *
+    ObjectTableStructure(#l, #PVPairs;) *
     ((#l, #prop) -> none) *
     empty_fields(#l : -u- (#pSet, -{ #prop }-))
 ]]
@@ -1097,25 +1097,25 @@ pred RemoveProp(PVPairs : List, prop : Str; found : Bool, value : Str, newPairs 
     (PVPairs == {{ prop, value }} :: newPairs) * (found == true),
 
     (PVPairs == {{ #fstProp, #fstValue }} :: #restPVPairs) *
-    (! (#fstProp == prop)) * RemoveProp(#restPVPairs, prop, false, value, newPairs) *
+    (! (#fstProp == prop)) * RemoveProp(#restPVPairs, prop; false, value, newPairs) *
     (found == false),
 
     (PVPairs == {{ #fstProp, #fstValue }} :: #restPVPairs) *
-    (! (#fstProp == prop)) * RemoveProp(#restPVPairs, prop, true, value, #restNewPairs) *
+    (! (#fstProp == prop)) * RemoveProp(#restPVPairs, prop; true, value, #restNewPairs) *
     (found == true) * (newPairs == {{ #fstProp, #fstValue }} :: #restNewPairs);
 
 (* Object-as-Table present property *)
 lemma ObjectTablePresentProperty(l, PVPairs, prop)
 [[
-    ObjectTableStructure(#l, #PVPairs) *
-    FirstProj(#PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(#l, #PVPairs;) *
+    FirstProj(#PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     (#prop --e-- #pSet)
 ]]
 [[
-    RemoveProp(#PVPairs, #prop, true, #value, #newPairs) *
-    ObjectTableStructure(#l, #newPairs) *
-    DataProp(#l, #prop, #value) * types(#value : Str)
+    RemoveProp(#PVPairs, #prop; true, #value, #newPairs) *
+    ObjectTableStructure(#l, #newPairs;) *
+    DataProp(#l, #prop; #value) * types(#value : Str)
 ]]
 [*
     unfold ObjectTableStructure(#l, #PVPairs);
@@ -1124,7 +1124,7 @@ lemma ObjectTablePresentProperty(l, PVPairs, prop)
         unfold ListToSet(#pList, #pSet)
     } else {
         sep_assert (#PVPairs == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (ObjectTableStructure(#l, #restPVPairs));
+        sep_assert (ObjectTableStructure(#l, #restPVPairs;));
         if (not (#fProp = #prop)) then {
             unfold FirstProj(#PVPairs, #pList);
             unfold ListToSet(#pList, #pSet);
@@ -1136,20 +1136,20 @@ lemma ObjectTablePresentProperty(l, PVPairs, prop)
 (* Appending property to Object-as-Table structure from the right *)
 lemma ObjectTableStructureAppendPVPair(l, PVPairs, prop, value)
 [[
-    ObjectTableStructure(#l, #PVPairs) *
-    FirstProj(#PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(#l, #PVPairs;) *
+    FirstProj(#PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     (! (#prop --e-- #pSet)) *
-    DataProp(#l, #prop, #value) * types(#value : Str)
+    DataProp(#l, #prop; #value) * types(#value : Str)
 ]]
 [[
-    ObjectTableStructure(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }}))
+    ObjectTableStructure(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }});)
 ]]
 [*
     unfold ObjectTableStructure(#l, #PVPairs);
     if (not (#PVPairs = {{ }})) then {
         sep_assert (#PVPairs == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (ObjectTableStructure(#l, #restPVPairs));
+        sep_assert (ObjectTableStructure(#l, #restPVPairs;));
         unfold FirstProj(#PVPairs, #pList);
         unfold ListToSet(#pList, #pSet);
         apply ObjectTableStructureAppendPVPair(#l, #restPVPairs, #prop, #value);
@@ -1160,15 +1160,15 @@ lemma ObjectTableStructureAppendPVPair(l, PVPairs, prop, value)
 (* Appending property to Object-as-Table from the right *)
 lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
 [[
-    ObjectTableStructure(#l, #PVPairs) *
-    FirstProj(#PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    ObjectTableStructure(#l, #PVPairs;) *
+    FirstProj(#PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     (! (#prop --e-- #pSet)) *
-    DataProp(#l, #prop, #value) * types(#value : Str) *
+    DataProp(#l, #prop; #value) * types(#value : Str) *
     empty_fields(l : -u- (#pSet, -{ #prop }-))
 ]]
 [[
-    ObjectTable(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }}))
+    ObjectTable(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }});)
 ]]
 [*
     apply FirstProjAppendPair(#PVPairs, #pList, #prop, #value);
@@ -1183,14 +1183,14 @@ pred FrozenObjectTableStructure(l:Obj, PVPairs:List;) :
 
     (* Recursive case - one property and the rest *)
     (PVPairs == {{ #prop, #value }} :: #restPVPairs) *
-    DataPropConst(l, #prop, #value, true) *
-    FrozenObjectTableStructure(l, #restPVPairs);
+    DataPropConst(l, #prop; #value, true) *
+    FrozenObjectTableStructure(l, #restPVPairs;);
 
 (* Frozen Object-as-Table predicate *)
 nounfold pred FrozenObjectTable(l:Obj, PVPairs:List;) :
-    FrozenObjectTableStructure(l, PVPairs) *
-    FirstProj(PVPairs, #pList) *
-    ListToSet(#pList, #pSet) *
+    FrozenObjectTableStructure(l, PVPairs;) *
+    FirstProj(PVPairs; #pList) *
+    ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet);
 
 (******************************
@@ -1209,13 +1209,13 @@ axiomatic incomplete spec AP_map (xsc, vthis, cfun)
 (* Mapping EDKs into the resulting decoded EDK array *)
 [[
     (vthis == #vthis) * (cfun == #cfun) *
-    JSFunctionObject(#cfun, "aux_deserializeEncryptedDataKey", #a_sc, #a_len, #a_proto) *
-    ArrayOfArraysOfUInt8Arrays(#vthis, #EDKs)
+    JSFunctionObject(#cfun; "aux_deserializeEncryptedDataKey", #a_sc, #a_len, #a_proto) *
+    ArrayOfArraysOfUInt8Arrays(#vthis; #EDKs)
 ]]
 [[
-    JSFunctionObject(#cfun, "aux_deserializeEncryptedDataKey", #a_sc, #a_len, #a_proto) *
-    ArrayOfArraysOfUInt8Arrays(#vthis, #EDKs) *
-    types(ret : Obj) * LiveDeserialisedEncryptedDataKeys(ret, #EDKs)
+    JSFunctionObject(#cfun; "aux_deserializeEncryptedDataKey", #a_sc, #a_len, #a_proto) *
+    ArrayOfArraysOfUInt8Arrays(#vthis; #EDKs) *
+    types(ret : Obj) * LiveDeserialisedEncryptedDataKeys(ret; #EDKs)
 ]]
 normal
 
@@ -1224,10 +1224,10 @@ axiomatic spec Object_freeze(xsc, vthis, l)
 (* Freezing an array of deserialised EDKs *)
 <deserialised_EDKS>
 [[
-    (l == #l) * LiveDeserialisedEncryptedDataKeys(#l, #EDKs)
+    (l == #l) * LiveDeserialisedEncryptedDataKeys(#l; #EDKs)
 ]]
 [[
-    DeserialisedEncryptedDataKeys(#l, #EDKs) * (ret == #l)
+    DeserialisedEncryptedDataKeys(#l; #EDKs) * (ret == #l)
 ]]
 normal;
 
@@ -1235,12 +1235,12 @@ normal;
 <object_table : #PVPairs>
 [[
     (l == #l) *
-    JSObjGeneral(#l, #proto, #class, #ext) *
-    ObjectTable(#l, #PVPairs)
+    JSObjGeneral(#l; #proto, #class, #ext) *
+    ObjectTable(#l, #PVPairs;)
 ]]
 [[
-    JSObjGeneral(#l, #proto, #class, false) *
-    FrozenObjectTable(#l, #PVPairs)
+    JSObjGeneral(#l; #proto, #class, false) *
+    FrozenObjectTable(#l, #PVPairs;)
 ]]
 normal
 

--- a/Gillian-JS/Examples/Amazon/bugs/pp/AmazonLogic.jsil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/AmazonLogic.jsil
@@ -167,7 +167,7 @@ lemma CElementsElementLength(buffer, readPos, eCount, fCount, eList, prefix, ele
 *)
 
 (* Broken serialised encryption context *)
-nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:List) :
+nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
     (* Not enough data provided *)
     (2 <# l-len buffer) *
     (#rawKC == l-sub (buffer, 0, 2)) *
@@ -196,18 +196,18 @@ nounfold pred BRawEncryptionContext(+buffer:List, errorMessage:Str, ECKs:List) :
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
 (* General serialised encryption context *)
-pred RawEncryptionContext(+buffer:List, definition:Str, ECKs:List, errorMessage:Str) :
+pred RawEncryptionContext(buffer:List; definition:Str, ECKs:List, errorMessage:Str) :
   (definition == "Complete") * CRawEncryptionContext(buffer, ECKs) * (errorMessage == ""),
   (definition == "Broken")   * BRawEncryptionContext(buffer, errorMessage, ECKs);
 
 (* Live decoded encryption context *)
-pred LiveDecodedEncryptionContext(+dECObj : Obj, +ECKs : List) :
+pred LiveDecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
     JSObjWithProto(dECObj, null) *
     toUtf8PairMap(ECKs, #utf8ECKs) *
     ObjectTable(dECObj, #utf8ECKs);
 
 (* Decoded encryption context *)
-pred DecodedEncryptionContext(+dECObj : Obj, +ECKs : List) :
+pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
     JSObjGeneral(dECObj, $lobj_proto, "Object", false) *
     toUtf8PairMap(ECKs, #utf8ECKs) *
     FrozenObjectTable(dECObj, #utf8ECKs);
@@ -226,12 +226,12 @@ pred DecodedEncryptionContext(+dECObj : Obj, +ECKs : List) :
 (***** EDK objects *****)
 
 (* Prototype of EDK objects *)
-pred EDKPrototype () :
+pred EDKPrototype (;) :
     JSObjGeneral($l_edk_proto, null, "Object", false) *
     empty_fields($l_edk_proto : -{ }-);
 
 (* EDK objects *)
-nounfold pred EncryptedDataKey(+EDK, pId:Str, pInfo:Str, encryptedDataKey:List, rawInfo:List) :
+nounfold pred EncryptedDataKey(EDK; pId:Str, pInfo:Str, encryptedDataKey:List, rawInfo:List) :
     JSObjGeneral(EDK, $l_edk_proto, "Object", false) *
     readOnlyProperty(EDK, "providerId", pId) *
     readOnlyProperty(EDK, "providerInfo", pInfo) *
@@ -247,7 +247,7 @@ nounfold pred EncryptedDataKey(+EDK, pId:Str, pInfo:Str, encryptedDataKey:List, 
 (***** Arrays of deserialised EDKs *****)
 
 (* Live array of deserialised EDKs *)
-pred ArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
+pred ArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
@@ -260,7 +260,7 @@ pred ArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
     ArrayOfDEDKsContents(a, #rest_start, #rest);
 
 (* Frozen array of deserialised EDKs *)
-pred FrozenArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
+pred FrozenArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
     (contents == {{ }}) * (contentsLength == 0),
 
     (#index == num_to_string start) *
@@ -275,12 +275,12 @@ pred FrozenArrayOfDEDKsContents(+a:Obj, +start:Num, contents:List) :
 (***** Deserialised EDKs *****)
 
 (* EDKs are first deserialised into a live array *)
-pred LiveDeserialisedEncryptedDataKeys (+a:Obj, EDKs:List) :
+pred LiveDeserialisedEncryptedDataKeys (a:Obj; EDKs:List) :
     ArrayStructure(a, l-len EDKs) *
     ArrayOfDEDKsContents(a, 0, EDKs);
 
 (* Deserialised EDKs are ultimately provided as a frozen array *)
-pred DeserialisedEncryptedDataKeys (+a:Obj, contents:List) :
+pred DeserialisedEncryptedDataKeys (a:Obj; contents:List) :
     FrozenArrayStructure(a, l-len contents) *
     FrozenArrayOfDEDKsContents(a, 0, contents);
 
@@ -309,7 +309,7 @@ lemma toUtf8Injective(rawData1, utf8Data1, rawData2, utf8Data2)
     denotes that the raw bytes rawData are obtained by converting
     the string utf8Data into bytes
 *)
-abstract pure pred fromUtf8(+utf8Data:Str, rawData:List);
+abstract pure pred fromUtf8(utf8Data:Str; rawData:List);
 
 (* fromUtf8 is injective *)
 lemma fromUtf8Injective(utf8Data1, rawData1, utf8Data2, rawData2)
@@ -340,7 +340,7 @@ lemma fromUtf8toUtf8(utf8Data)
 ]]
 
 (* UTF-8 Mapping of lists *)
-pure pred toUtf8Map(+data : List, utf8Data : List) :
+pure pred toUtf8Map(data : List; utf8Data : List) :
     (data == {{ }}) * (utf8Data == {{ }}),
 
     (data == #fst :: #rest) *
@@ -420,7 +420,7 @@ lemma toUtf8PairMapAppendPair(data, utf8Data, prop, value)
  *****************************)
 
 (* The object that holds information about allowed algorithm suites *)
-pred AlgorithmSuiteIdentifierObject(o) :
+pred AlgorithmSuiteIdentifierObject(o;) :
     JSObject(o) *
     DataProp(o, "20",  "ALG_AES128_GCM_IV12_TAG16") * DataProp(o, "ALG_AES128_GCM_IV12_TAG16", 20) *
     DataProp(o, "70",  "ALG_AES192_GCM_IV12_TAG16") * DataProp(o, "ALG_AES192_GCM_IV12_TAG16", 70) *
@@ -430,7 +430,7 @@ pred AlgorithmSuiteIdentifierObject(o) :
     The object representing a given algorithm suite.
     TODO: This object is more complex than presented here.
  *)
-pred AlgorithmSuiteObject(+aso: Obj, ivLength: Num, tagLength: Num) :
+pred AlgorithmSuiteObject(aso: Obj; ivLength: Num, tagLength: Num) :
     JSObject(aso) *
     readOnlyProperty(aso, "ivLength",  ivLength) *
     readOnlyProperty(aso, "tagLength", tagLength);
@@ -445,7 +445,7 @@ pred AlgorithmSuiteObject(+aso: Obj, ivLength: Num, tagLength: Num) :
  ***************************)
 
 (* Broken version and type *)
-pred BVersionAndType(+version:Num, +type:Num, errorMessage:Str) :
+pred BVersionAndType(version:Num, type:Num; errorMessage:Str) :
     (version == 65) * (type == 89) * (errorMessage == "Malformed Header: This blob may be base64 encoded."),
     (! (version == 1) \/ ! (type == 128)) * (! (version == 65) \/ ! (type == 89)) * (errorMessage == "Malformed Header: Unsupported version and/or type.");
 
@@ -453,7 +453,7 @@ pred BVersionAndType(+version:Num, +type:Num, errorMessage:Str) :
   ********   Header       *******)
 
 (* Serialised incomplete header *)
-nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageId, ECLength,
+nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength,
                                       part_two, ECKs,
                                       part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) :
     (* Not enough data to read first part *)
@@ -532,7 +532,7 @@ nounfold pred IHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (headerIv == {{ }}) * (headerAuthTag == {{ }});
 
 (* Broken serialised header *)
-nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageId, ECLength,
+nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId, ECLength,
                                       part_two, ECKs,
                                       part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
     (* Incorrect version and/or type *)
@@ -659,7 +659,7 @@ nounfold pred BHeader(+rawHeaderData, part_one, version, type, suiteId, messageI
     (frameLength == 0) * (headerIv == {{ }}) * (headerAuthTag == {{ }});
 
 (* General serialised header *)
-nounfold pred Header(+rawHeaderData, definition, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
+nounfold pred Header(rawHeaderData; definition, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag, errorMessage) :
     (* Complete header *)
     (definition == "Complete") *
     CHeader(rawHeaderData, part_one, version, type, suiteId, messageId, ECLength, part_two, ECKs, part_three, EDKs, contentType, headerIvLength, frameLength, headerLength, headerIv, headerAuthTag) *
@@ -678,7 +678,7 @@ nounfold pred Header(+rawHeaderData, definition, part_one, version, type, suiteI
   ********   Header         *******)
 
 (* Deserialised main part of the message header *)
-nounfold pred MessageHeader(+messageHeader, +ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
+nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
     JSObject(messageHeader) *
     DataProp(messageHeader, "version", version) *
     DataProp(messageHeader, "type", type) *
@@ -695,7 +695,7 @@ nounfold pred MessageHeader(+messageHeader, +ECKs, version, type, suiteId, messa
     DataProp(messageHeader, "frameLength", frameLength);
 
 (* Entire deserialised header *)
-nounfold pred HeaderInfo(+headerInfo, +ECKs, version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
+nounfold pred HeaderInfo(headerInfo, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
                             frameLength, headerLength, rawHeaderData, headerIv, headerAuthTag) :
     JSObject(headerInfo) *
     DataProp(headerInfo, "messageHeader", #messageHeader) *
@@ -1037,7 +1037,7 @@ lemma UniqueAppendElement(lst, element)
  ************************************)
 
 (* Lists with duplicates *)
-pure pred Duplicated(+prefix:List, +suffix:List) :
+pure pred Duplicated(prefix:List, suffix:List;) :
     (* Either the head is duplicated *)
     (suffix == #fst :: #rest) *
     ListToSet(prefix, #preSet) *
@@ -1058,7 +1058,7 @@ pure pred Duplicated(+prefix:List, +suffix:List) :
  *************************************)
 
 (* Object properties as a table *)
-pred ObjectTableStructure(+l:Obj, +PVPairs:List) :
+pred ObjectTableStructure(l:Obj, PVPairs:List;) :
     (* Base case - no properties left *)
     (PVPairs == {{ }}),
 
@@ -1068,7 +1068,7 @@ pred ObjectTableStructure(+l:Obj, +PVPairs:List) :
     ObjectTableStructure(l, #restPVPairs);
 
 (* Complete Object-as-Table predicate *)
-nounfold pred ObjectTable(+l:Obj, +PVPairs:List) :
+nounfold pred ObjectTable(l:Obj, PVPairs:List;) :
     ObjectTableStructure(l, PVPairs) *
     FirstProj(PVPairs, #pList) *
     ListToSet(#pList, #pSet) *
@@ -1091,7 +1091,7 @@ lemma ObjectTableAbsentProperty(l, PVPairs, prop)
 [*  *]
 
 (* Removing a property from a list of prop-value pairs *)
-pred RemoveProp(+PVPairs : List, +prop : Str, found : Bool, value : Str, newPairs : List) :
+pred RemoveProp(PVPairs : List, prop : Str; found : Bool, value : Str, newPairs : List) :
     (PVPairs == {{ }}) * (found == false) * (value == "") * (newPairs == {{ }}),
 
     (PVPairs == {{ prop, value }} :: newPairs) * (found == true),
@@ -1177,7 +1177,7 @@ lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
  *]
 
 (* Frozen object properties *)
-pred FrozenObjectTableStructure(+l:Obj, +PVPairs:List) :
+pred FrozenObjectTableStructure(l:Obj, PVPairs:List;) :
     (* Base case - no properties left *)
     (PVPairs == {{ }}),
 
@@ -1187,7 +1187,7 @@ pred FrozenObjectTableStructure(+l:Obj, +PVPairs:List) :
     FrozenObjectTableStructure(l, #restPVPairs);
 
 (* Frozen Object-as-Table predicate *)
-nounfold pred FrozenObjectTable(+l:Obj, +PVPairs:List) :
+nounfold pred FrozenObjectTable(l:Obj, PVPairs:List;) :
     FrozenObjectTableStructure(l, PVPairs) *
     FirstProj(PVPairs, #pList) *
     ListToSet(#pList, #pSet) *

--- a/Gillian-JS/Examples/Amazon/bugs/pp/AmazonLogic.jsil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/AmazonLogic.jsil
@@ -191,7 +191,7 @@ nounfold pred BRawEncryptionContext(buffer:List; errorMessage:Str, ECKs:List) :
     rawToUInt16(#rawKC, false; #keyCount) *
     (0 <# #keyCount) *
     Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Duplicated({{ }}, #ECKeys;) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) * Duplicated({{ }}, #ECKeys) *
     (2 + #ECKsLength == l-len buffer) *
     (errorMessage == "decodeEncryptionContext: Duplicate encryption context key value.");
 
@@ -201,16 +201,16 @@ pred RawEncryptionContext(buffer:List; definition:Str, ECKs:List, errorMessage:S
   (definition == "Broken")   * BRawEncryptionContext(buffer; errorMessage, ECKs);
 
 (* Live decoded encryption context *)
-pred LiveDecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
+pred LiveDecodedEncryptionContext(dECObj : Obj, ECKs : List) :
     JSObjWithProto(dECObj; null) *
     toUtf8PairMap(ECKs; #utf8ECKs) *
-    ObjectTable(dECObj, #utf8ECKs;);
+    ObjectTable(dECObj, #utf8ECKs);
 
 (* Decoded encryption context *)
-pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
+pred DecodedEncryptionContext(dECObj : Obj, ECKs : List) :
     JSObjGeneral(dECObj; $lobj_proto, "Object", false) *
     toUtf8PairMap(ECKs; #utf8ECKs) *
-    FrozenObjectTable(dECObj, #utf8ECKs;);
+    FrozenObjectTable(dECObj, #utf8ECKs);
 
 
 (*****************************
@@ -226,7 +226,7 @@ pred DecodedEncryptionContext(dECObj : Obj, ECKs : List;) :
 (***** EDK objects *****)
 
 (* Prototype of EDK objects *)
-pred EDKPrototype (;) :
+pred EDKPrototype () :
     JSObjGeneral($l_edk_proto; null, "Object", false) *
     empty_fields($l_edk_proto : -{ }-);
 
@@ -276,12 +276,12 @@ pred FrozenArrayOfDEDKsContents(a:Obj, start:Num; contents:List) :
 
 (* EDKs are first deserialised into a live array *)
 pred LiveDeserialisedEncryptedDataKeys (a:Obj; EDKs:List) :
-    ArrayStructure(a, l-len EDKs;) *
+    ArrayStructure(a, l-len EDKs) *
     ArrayOfDEDKsContents(a, 0; EDKs);
 
 (* Deserialised EDKs are ultimately provided as a frozen array *)
 pred DeserialisedEncryptedDataKeys (a:Obj; contents:List) :
-    FrozenArrayStructure(a, l-len contents;) *
+    FrozenArrayStructure(a, l-len contents) *
     FrozenArrayOfDEDKsContents(a, 0; contents);
 
 (************************************
@@ -420,8 +420,8 @@ lemma toUtf8PairMapAppendPair(data, utf8Data, prop, value)
  *****************************)
 
 (* The object that holds information about allowed algorithm suites *)
-pred AlgorithmSuiteIdentifierObject(o;) :
-    JSObject(o;) *
+pred AlgorithmSuiteIdentifierObject(o) :
+    JSObject(o) *
     DataProp(o, "20";  "ALG_AES128_GCM_IV12_TAG16") * DataProp(o, "ALG_AES128_GCM_IV12_TAG16"; 20) *
     DataProp(o, "70";  "ALG_AES192_GCM_IV12_TAG16") * DataProp(o, "ALG_AES192_GCM_IV12_TAG16"; 70) *
     empty_fields(o : -{ "20", "70", "ALG_AES128_GCM_IV12_TAG16", "ALG_AES192_GCM_IV12_TAG16" }-);
@@ -431,7 +431,7 @@ pred AlgorithmSuiteIdentifierObject(o;) :
     TODO: This object is more complex than presented here.
  *)
 pred AlgorithmSuiteObject(aso: Obj; ivLength: Num, tagLength: Num) :
-    JSObject(aso;) *
+    JSObject(aso) *
     readOnlyProperty(aso, "ivLength";  ivLength) *
     readOnlyProperty(aso, "tagLength"; tagLength);
 
@@ -472,7 +472,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -490,7 +490,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -511,7 +511,7 @@ nounfold pred IHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -550,7 +550,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (22 <=# l-len rawHeaderData) *
     (rawHeaderData == l+ ({{ version, type }}, #rawSuiteId, #rest)) *
     (l-len #rawSuiteId == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     BAlgorithmSuite(suiteId; errorMessage) *
 
@@ -567,7 +567,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -588,7 +588,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -610,7 +610,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -639,7 +639,7 @@ nounfold pred BHeader(rawHeaderData; part_one, version, type, suiteId, messageId
     (l-len #rawSuiteId == 2) *
     (l-len messageId == 16) *
     (l-len #rawContextLength == 2) *
-    CVersionAndType(version, type;) *
+    CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, #ivLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *
@@ -679,7 +679,7 @@ nounfold pred Header(rawHeaderData; definition, part_one, version, type, suiteId
 
 (* Deserialised main part of the message header *)
 nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) :
-    JSObject(messageHeader;) *
+    JSObject(messageHeader) *
     DataProp(messageHeader, "version"; version) *
     DataProp(messageHeader, "type"; type) *
     DataProp(messageHeader, "suiteId"; suiteId) *
@@ -687,7 +687,7 @@ nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, message
         Uint8Array(#ui8aMessageId; #abMessageId, 0, 16) *
         ArrayBuffer(#abMessageId; messageId) *
     DataProp(messageHeader, "encryptionContext"; #dECObj) *
-        DecodedEncryptionContext(#dECObj, ECKs;) *
+        DecodedEncryptionContext(#dECObj, ECKs) *
     DataProp(messageHeader, "encryptedDataKeys"; #dEDKs) *
         DeserialisedEncryptedDataKeys(#dEDKs; EDKs) *
     DataProp(messageHeader, "contentType"; contentType) *
@@ -697,7 +697,7 @@ nounfold pred MessageHeader(messageHeader, ECKs; version, type, suiteId, message
 (* Entire deserialised header *)
 nounfold pred HeaderInfo(headerInfo, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength,
                             frameLength, headerLength, rawHeaderData, headerIv, headerAuthTag) :
-    JSObject(headerInfo;) *
+    JSObject(headerInfo) *
     DataProp(headerInfo, "messageHeader"; #messageHeader) *
         MessageHeader(#messageHeader, ECKs; version, type, suiteId, messageId, EDKs, contentType, headerIvLength, frameLength) *
     DataProp(headerInfo, "headerLength"; headerLength) *
@@ -987,7 +987,7 @@ lemma NotInListToUtf8(prop, props)
    no element from the right is on the left *)
 lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
 [[
-    (#props == l+ (#prefix, #suffix)) * Unique(#props;) *
+    (#props == l+ (#prefix, #suffix)) * Unique(#props) *
     ListToSet(#prefix; #setPrefix) * ListToSet(#suffix; #setSuffix) *
     (#prop --e-- #setSuffix)
 ]]
@@ -1012,11 +1012,11 @@ lemma UniqueConcatSplitNotInSuffix(props, prefix, suffix, prop)
 (* Appending an element to a unique list *)
 lemma UniqueAppendElement(lst, element)
 [[
-    Unique(#lst;) * ListToSet(#lst; #set) *
+    Unique(#lst) * ListToSet(#lst; #set) *
     (! (#element --e-- #set))
 ]]
 [[
-    Unique(l+ (#lst, {{ #element }});)
+    Unique(l+ (#lst, {{ #element }}))
 ]]
 [*
     unfold Unique(#lst) [bind: (#fst := #fst) and (#rest := #rest) and (#setRest1 := #setRest)];
@@ -1037,7 +1037,7 @@ lemma UniqueAppendElement(lst, element)
  ************************************)
 
 (* Lists with duplicates *)
-pure pred Duplicated(prefix:List, suffix:List;) :
+pure pred Duplicated(prefix:List, suffix:List) :
     (* Either the head is duplicated *)
     (suffix == #fst :: #rest) *
     ListToSet(prefix; #preSet) *
@@ -1047,7 +1047,7 @@ pure pred Duplicated(prefix:List, suffix:List;) :
     (suffix == #fst :: #rest) *
     ListToSet(prefix; #preSet) *
     (! (#fst --e-- #preSet)) *
-    Duplicated(l+ (prefix, {{ #fst }}), #rest;);
+    Duplicated(l+ (prefix, {{ #fst }}), #rest);
 
 (*************************************
  *************************************
@@ -1058,18 +1058,18 @@ pure pred Duplicated(prefix:List, suffix:List;) :
  *************************************)
 
 (* Object properties as a table *)
-pred ObjectTableStructure(l:Obj, PVPairs:List;) :
+pred ObjectTableStructure(l:Obj, PVPairs:List) :
     (* Base case - no properties left *)
     (PVPairs == {{ }}),
 
     (* Recursive case - one property and the rest *)
     (PVPairs == {{ #prop, #value }} :: #restPVPairs) *
     DataProp(l, #prop; #value) * types(#value : Str) *
-    ObjectTableStructure(l, #restPVPairs;);
+    ObjectTableStructure(l, #restPVPairs);
 
 (* Complete Object-as-Table predicate *)
-nounfold pred ObjectTable(l:Obj, PVPairs:List;) :
-    ObjectTableStructure(l, PVPairs;) *
+nounfold pred ObjectTable(l:Obj, PVPairs:List) :
+    ObjectTableStructure(l, PVPairs) *
     FirstProj(PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet);
@@ -1077,14 +1077,14 @@ nounfold pred ObjectTable(l:Obj, PVPairs:List;) :
 (* Object-as-Table absent property *)
 lemma ObjectTableAbsentProperty(l, PVPairs, prop)
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     FirstProj(#PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet) *
     (! (#prop --e-- #pSet))
 ]]
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     ((#l, #prop) -> none) *
     empty_fields(#l : -u- (#pSet, -{ #prop }-))
 ]]
@@ -1107,14 +1107,14 @@ pred RemoveProp(PVPairs : List, prop : Str; found : Bool, value : Str, newPairs 
 (* Object-as-Table present property *)
 lemma ObjectTablePresentProperty(l, PVPairs, prop)
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     FirstProj(#PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     (#prop --e-- #pSet)
 ]]
 [[
     RemoveProp(#PVPairs, #prop; true, #value, #newPairs) *
-    ObjectTableStructure(#l, #newPairs;) *
+    ObjectTableStructure(#l, #newPairs) *
     DataProp(#l, #prop; #value) * types(#value : Str)
 ]]
 [*
@@ -1124,7 +1124,7 @@ lemma ObjectTablePresentProperty(l, PVPairs, prop)
         unfold ListToSet(#pList, #pSet)
     } else {
         sep_assert (#PVPairs == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (ObjectTableStructure(#l, #restPVPairs;));
+        sep_assert (ObjectTableStructure(#l, #restPVPairs));
         if (not (#fProp = #prop)) then {
             unfold FirstProj(#PVPairs, #pList);
             unfold ListToSet(#pList, #pSet);
@@ -1136,20 +1136,20 @@ lemma ObjectTablePresentProperty(l, PVPairs, prop)
 (* Appending property to Object-as-Table structure from the right *)
 lemma ObjectTableStructureAppendPVPair(l, PVPairs, prop, value)
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     FirstProj(#PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     (! (#prop --e-- #pSet)) *
     DataProp(#l, #prop; #value) * types(#value : Str)
 ]]
 [[
-    ObjectTableStructure(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }});)
+    ObjectTableStructure(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }}))
 ]]
 [*
     unfold ObjectTableStructure(#l, #PVPairs);
     if (not (#PVPairs = {{ }})) then {
         sep_assert (#PVPairs == l+ ({{{{ #fProp, #fValue }}}}, #restPVPairs)) [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (ObjectTableStructure(#l, #restPVPairs;));
+        sep_assert (ObjectTableStructure(#l, #restPVPairs));
         unfold FirstProj(#PVPairs, #pList);
         unfold ListToSet(#pList, #pSet);
         apply ObjectTableStructureAppendPVPair(#l, #restPVPairs, #prop, #value);
@@ -1160,7 +1160,7 @@ lemma ObjectTableStructureAppendPVPair(l, PVPairs, prop, value)
 (* Appending property to Object-as-Table from the right *)
 lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
 [[
-    ObjectTableStructure(#l, #PVPairs;) *
+    ObjectTableStructure(#l, #PVPairs) *
     FirstProj(#PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     (! (#prop --e-- #pSet)) *
@@ -1168,7 +1168,7 @@ lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
     empty_fields(l : -u- (#pSet, -{ #prop }-))
 ]]
 [[
-    ObjectTable(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }});)
+    ObjectTable(#l, l+ (#PVPairs, {{ {{ #prop, #value }} }}))
 ]]
 [*
     apply FirstProjAppendPair(#PVPairs, #pList, #prop, #value);
@@ -1177,18 +1177,18 @@ lemma ObjectTableAppendPVPair(l, PVPairs, prop, value)
  *]
 
 (* Frozen object properties *)
-pred FrozenObjectTableStructure(l:Obj, PVPairs:List;) :
+pred FrozenObjectTableStructure(l:Obj, PVPairs:List) :
     (* Base case - no properties left *)
     (PVPairs == {{ }}),
 
     (* Recursive case - one property and the rest *)
     (PVPairs == {{ #prop, #value }} :: #restPVPairs) *
     DataPropConst(l, #prop; #value, true) *
-    FrozenObjectTableStructure(l, #restPVPairs;);
+    FrozenObjectTableStructure(l, #restPVPairs);
 
 (* Frozen Object-as-Table predicate *)
-nounfold pred FrozenObjectTable(l:Obj, PVPairs:List;) :
-    FrozenObjectTableStructure(l, PVPairs;) *
+nounfold pred FrozenObjectTable(l:Obj, PVPairs:List) :
+    FrozenObjectTableStructure(l, PVPairs) *
     FirstProj(PVPairs; #pList) *
     ListToSet(#pList; #pSet) *
     empty_fields(l : #pSet);
@@ -1236,11 +1236,11 @@ normal;
 [[
     (l == #l) *
     JSObjGeneral(#l; #proto, #class, #ext) *
-    ObjectTable(#l, #PVPairs;)
+    ObjectTable(#l, #PVPairs)
 ]]
 [[
     JSObjGeneral(#l; #proto, #class, false) *
-    FrozenObjectTable(#l, #PVPairs;)
+    FrozenObjectTable(#l, #PVPairs)
 ]]
 normal
 

--- a/Gillian-JS/Examples/Amazon/bugs/pp/ByteLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/ByteLogic.gil
@@ -7,13 +7,13 @@
  ****************************************)
 
 (* Interpretation: one byte as an unsigned 8-bit integer *)
-pure pred rawToUInt8(+bytes:List, num:Num) :
+pure pred rawToUInt8(bytes:List; num:Num) :
     (bytes == {{ #b0 }}) * (num == #b0) *
     (0 <=# #b0) * (#b0 <# 256);
 
 (* Interpretation: two bytes as an unsigned 16-bit integer *)
 @nopath
-pure pred rawToUInt16(+bytes:List, +littleEndian:Bool, num:Num) :
+pure pred rawToUInt16(bytes:List, littleEndian:Bool; num:Num) :
     (littleEndian == false) *
       (bytes == {{ #b0, #b1 }}) *
       (0 <=# #b0) * (#b0 <# 256) *
@@ -28,7 +28,7 @@ pure pred rawToUInt16(+bytes:List, +littleEndian:Bool, num:Num) :
 
 (* Interpretation: four bytes as an unsigned 32-bit integer *)
 @nopath
-pure pred rawToUInt32(+bytes:List, +littleEndian:Bool, num:Num) :
+pure pred rawToUInt32(bytes:List, littleEndian:Bool; num:Num) :
     (littleEndian == false) *
       (bytes == {{ #b0, #b1, #b2, #b3 }}) *
       (0 <=# #b0) * (#b0 <# 256) *

--- a/Gillian-JS/Examples/Amazon/bugs/pp/EncryptionHeaderLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/EncryptionHeaderLogic.gil
@@ -16,7 +16,7 @@
 *)
 pred Field(buffer : List, readPos : Num; field : List, length : Num) :
   (0 <=# readPos) * (#rawFL == l-sub(buffer, readPos, 2)) *
-    rawToUInt16(#rawFL, false, #fLength) *
+    rawToUInt16(#rawFL, false; #fLength) *
     (field == l-sub(buffer, (readPos + 2), #fLength)) *
     (length == (2 + #fLength)) * ((readPos + length) <=# (l-len buffer));
   facts: (2 <=# length);
@@ -71,14 +71,14 @@ pred IElement(buffer : List, readPos : Num, fCount : Num; fList : List, eLength 
 
   (* Base case: enough data to read length of next field, but not enough data to read next field *)
   (0 <=# readPos) * (0 <# fCount) * ((readPos + 2) <=# (l-len buffer)) *
-    (#rawFL == l-sub(buffer, readPos, 2)) * rawToUInt16(#rawFL, false, #fLength) *
+    (#rawFL == l-sub(buffer, readPos, 2)) * rawToUInt16(#rawFL, false; #fLength) *
     ((l-len buffer) <# ((readPos + 2) + #fLength)) * (fList == {{  }}) *
     (eLength == ((l-len buffer) - (readPos + 2))),
 
   (* Recursive case: enough data to read one field, but not enough data to read the remaining ones *)
-  (0 <=# readPos) * (1 <# fCount) * Field(buffer, readPos, #field, #fLength) *
+  (0 <=# readPos) * (1 <# fCount) * Field(buffer, readPos; #field, #fLength) *
     (#restFCount == (fCount - 1)) * ((readPos + #fLength) <=# (l-len buffer)) *
-    IElement(buffer, (readPos + #fLength), #restFCount, #restFList, #restELength) *
+    IElement(buffer, (readPos + #fLength), #restFCount; #restFList, #restELength) *
     (fList == l+ ({{ #field }}, #restFList)) *
     (eLength == (#fLength + #restELength));
 
@@ -125,13 +125,13 @@ pred IElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
                eList : List, esLength : Num) :
   (* Base case: single incomplete element *)
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * (0 <# eCount) * (0 <# fCount) *
-    IElement(buffer, readPos, fCount, #fList, esLength) * (eList == {{  }}),
+    IElement(buffer, readPos, fCount; #fList, esLength) * (eList == {{  }}),
 
   (* Recursive case: enough data to read first element, but not enough data to read the remaining ones *)
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * (1 <# eCount) * (0 <# fCount) *
-    CElement(buffer, readPos, fCount, #fList, #eLength) *
+    CElement(buffer, readPos, fCount; #fList, #eLength) *
     (#restECount == (eCount - 1)) *
-    IElements(buffer, (readPos + #eLength), #restECount, fCount, #restEList, #restESLength) *
+    IElements(buffer, (readPos + #eLength), #restECount, fCount; #restEList, #restESLength) *
     (eList == l+ ({{ #fList }}, #restEList)) * (esLength == (#eLength + #restESLength));
   facts: (0 <=# readPos) and (readPos <=# (l-len buffer)) and (0 <# eCount) and (0 <# fCount) and (0 <=# esLength);
 
@@ -160,9 +160,9 @@ pred IElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
 pred CElement(buffer : List, readPos : Num, fCount : Num; element : List, length : Num) :
   (0 <=# readPos) * (readPos <=# (l-len buffer)) *
     (fCount == 0) * (element == {{  }}) * (length == 0),
-  (0 <# fCount) * Field(buffer, readPos, #field, #fLength) *
+  (0 <# fCount) * Field(buffer, readPos; #field, #fLength) *
     (#restFCount == (fCount - 1)) *
-    CElement(buffer, (readPos + #fLength), #restFCount, #restFields, #restLength) *
+    CElement(buffer, (readPos + #fLength), #restFCount; #restFields, #restLength) *
     (element == l+ ({{ #field }}, #restFields)) * (length == (#fLength + #restLength));
   (*
       A complete element has a non-negative number of fields
@@ -195,8 +195,8 @@ pred CElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * (eCount == 0) *
   (0 <# fCount) * (elements == {{  }}) * (length == 0),
   (0 <=# readPos) * (0 <# eCount) * (0 <# fCount) * (0 <# length) *
-    CElement(buffer, readPos, fCount, #element, #eLength) * (#restECount == (eCount - 1)) *
-    CElements(buffer, (readPos + #eLength), #restECount, fCount, #restElements, #restLength) *
+    CElement(buffer, readPos, fCount; #element, #eLength) * (#restECount == (eCount - 1)) *
+    CElements(buffer, (readPos + #eLength), #restECount, fCount; #restElements, #restLength) *
     (elements == l+ ({{ #element }}, #restElements)) *
     (length == (#eLength + #restLength));
   (*
@@ -224,8 +224,8 @@ pred CElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
 nounfold pred Elements(buffer : List, readPos : Num, eCount : Num,
                        fCount : Num; definition : Str, eList : List,
                        esLength : Num) :
-  (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
-  (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
+  (definition == "Complete") * CElements(buffer, readPos, eCount, fCount; eList, esLength),
+  (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount; eList, esLength);
   facts: (0 <=# readPos) and (readPos <=# (l-len buffer)) and (0 <=# eCount) and (0 <# fCount) and (0 <=# esLength);
 
 (*****************************
@@ -253,8 +253,8 @@ nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Num;
                                     EDKs : List, EDKsLength : Num) :
     (0 <=# readPos) * (readPos <=# (l-len buffer)) *
     (#rawEC == l-sub(buffer, readPos, 2)) *
-    rawToUInt16(#rawEC, false, #keyCount) * (0 <# #keyCount) *
-    Elements(buffer, (readPos + 2), #keyCount, 3, "Complete", EDKs, #EDKsLength) *
+    rawToUInt16(#rawEC, false; #keyCount) * (0 <# #keyCount) *
+    Elements(buffer, (readPos + 2), #keyCount, 3; "Complete", EDKs, #EDKsLength) *
     (EDKsLength == (#EDKsLength + 2));
 
 (* Incomplete serialised EDKs *)
@@ -265,8 +265,8 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num;) :
 
     (* Enough data to read the number of EDKs, but not enough data to read the EDKs *)
   (0 <=# readPos) * ((readPos + 2) <=# (l-len buffer)) * (#rawEC == l-sub(buffer, readPos, 2)) *
-    rawToUInt16(#rawEC, false, #keyCount) * (0 <# #keyCount) *
-    Elements(buffer, (readPos + 2), #keyCount, 3, "Incomplete", #eList, #esLength);
+    rawToUInt16(#rawEC, false; #keyCount) * (0 <# #keyCount) *
+    Elements(buffer, (readPos + 2), #keyCount, 3; "Incomplete", #eList, #esLength);
 
 (* Broken serialised EDKs *)
 @nopath
@@ -277,15 +277,15 @@ nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Num; errorMessage :
 
   (* Zero EDKs provided *)
   (0 <=# readPos) * ((readPos + 2) <=# (l-len buffer)) *
-    (#rawEC == l-sub(buffer, readPos, 2)) * rawToUInt16(#rawEC, false, 0) *
+    (#rawEC == l-sub(buffer, readPos, 2)) * rawToUInt16(#rawEC, false; 0) *
     (errorMessage == "Malformed Header: No EncryptedDataKey found.");
 
 (* General serialised EDKs *)
 @nopath
 nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Num; definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
-  (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
-  (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
-  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
+  (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos; EDKs, EDKsLength),
+  (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos;) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
+  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos; errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
 
 
 (******************************
@@ -311,10 +311,10 @@ nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Num; definition : St
 nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
   ((l-len buffer) == 0) * (ECKs == {{  }}),
   (#rawKC == l-sub(buffer, 0, 2)) *
-    rawToUInt16(#rawKC, false, #keyCount) * (0 <# #keyCount) *
-    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
-    toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) *
-    Unique(#ECKeys) * ((2 + #ECKsLength) == (l-len buffer));
+    rawToUInt16(#rawKC, false; #keyCount) * (0 <# #keyCount) *
+    Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
+    toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) *
+    Unique(#ECKeys;) * ((2 + #ECKsLength) == (l-len buffer));
 
 
 (****************************
@@ -366,17 +366,17 @@ nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     ((l-len #rawSuiteId) == 2) *
     ((l-len messageId) == 16) *
-    ((l-len #rawContextLength) == 2) * CVersionAndType(version, type) *
-    rawToUInt16(#rawSuiteId, false, suiteId) *
-    CAlgorithmSuite(suiteId, #stringId, headerIvLength, #tagLength) *
-    rawToUInt16(#rawContextLength, false, ECLength) *
+    ((l-len #rawContextLength) == 2) * CVersionAndType(version, type;) *
+    rawToUInt16(#rawSuiteId, false; suiteId) *
+    CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
+    rawToUInt16(#rawContextLength, false; ECLength) *
     (part_two == l+ (#EC, part_three)) *
     ((l-len #EC) == ECLength) *
-    CRawEncryptionContext(#EC, ECKs) *
+    CRawEncryptionContext(#EC; ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rawFrameLength, headerIv, headerAuthTag)) *
-    RawEncryptedDataKeys(rawHeaderData, (22 + ECLength), "Complete", EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, (22 + ECLength); "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == (l-len #edks)) * ((l-len #rawFrameLength) == 4) *
-    rawToUInt32(#rawFrameLength, false, frameLength) *
+    rawToUInt32(#rawFrameLength, false; frameLength) *
     (headerLength == ((((((22 + ECLength) + #EDKsLength) + 1) + 4) + 1) + 4)) *
     ((l-len headerIv) == headerIvLength) *
     ((l-len headerAuthTag) == (#tagLength / 8)) *

--- a/Gillian-JS/Examples/Amazon/bugs/pp/EncryptionHeaderLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/EncryptionHeaderLogic.gil
@@ -221,8 +221,8 @@ pred CElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
 
 (* A general element sequene is either a complete or an incomplete element sequence *)
 @nopath
-nounfold pred Elements(definition : Str, +buffer : List, +readPos : Num,
-                       +eCount : Num, +fCount : Num, eList : List,
+nounfold pred Elements(+buffer : List, +readPos : Num, +eCount : Num,
+                       +fCount : Num, definition : Str, eList : List,
                        esLength : Num) :
   (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
   (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
@@ -254,7 +254,7 @@ nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Num,
     (0 <=# readPos) * (readPos <=# (l-len buffer)) *
     (#rawEC == l-sub(buffer, readPos, 2)) *
     rawToUInt16(#rawEC, false, #keyCount) * (0 <# #keyCount) *
-    Elements("Complete", buffer, (readPos + 2), #keyCount, 3, EDKs, #EDKsLength) *
+    Elements(buffer, (readPos + 2), #keyCount, 3, "Complete", EDKs, #EDKsLength) *
     (EDKsLength == (#EDKsLength + 2));
 
 (* Incomplete serialised EDKs *)
@@ -266,11 +266,11 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num) :
     (* Enough data to read the number of EDKs, but not enough data to read the EDKs *)
   (0 <=# readPos) * ((readPos + 2) <=# (l-len buffer)) * (#rawEC == l-sub(buffer, readPos, 2)) *
     rawToUInt16(#rawEC, false, #keyCount) * (0 <# #keyCount) *
-    Elements("Incomplete", buffer, (readPos + 2), #keyCount, 3, #eList, #esLength);
+    Elements(buffer, (readPos + 2), #keyCount, 3, "Incomplete", #eList, #esLength);
 
 (* Broken serialised EDKs *)
 @nopath
-nounfold pred BRawEncryptedDataKeys(errorMessage : Str, +buffer : List, +readPos : Num) :
+nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Num, errorMessage : Str) :
   (* Incorrect starting position *)
   ((readPos <# 0) \/ ((l-len buffer) <# readPos)) *
     (errorMessage == "deserializeMessageHeader: startPos out of bounds."),
@@ -282,10 +282,10 @@ nounfold pred BRawEncryptedDataKeys(errorMessage : Str, +buffer : List, +readPos
 
 (* General serialised EDKs *)
 @nopath
-nounfold pred RawEncryptedDataKeys(definition : Str, +buffer : List, +readPos : Num, EDKs : List, EDKsLength : Num, errorMessage : Str) :
+nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Num, definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
   (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
   (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
-  (definition == "Broken") * BRawEncryptedDataKeys(errorMessage, buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0);
+  (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
 
 
 (******************************
@@ -312,7 +312,7 @@ nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
   ((l-len buffer) == 0) * (ECKs == {{  }}),
   (#rawKC == l-sub(buffer, 0, 2)) *
     rawToUInt16(#rawKC, false, #keyCount) * (0 <# #keyCount) *
-    Elements("Complete", buffer, 2, #keyCount, 2, ECKs, #ECKsLength) *
+    Elements(buffer, 2, #keyCount, 2, "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs, #utf8ECKs) * FirstProj(ECKs, #ECKeys) *
     Unique(#ECKeys) * ((2 + #ECKsLength) == (l-len buffer));
 
@@ -374,7 +374,7 @@ nounfold pred CHeader(+rawHeaderData, part_one, version, type, suiteId,
     ((l-len #EC) == ECLength) *
     CRawEncryptionContext(#EC, ECKs) *
     (part_three == l+ (#edks, {{ contentType }}, {{ 0, 0, 0, 0 }}, {{ headerIvLength }}, #rawFrameLength, headerIv, headerAuthTag)) *
-    RawEncryptedDataKeys("Complete", rawHeaderData, (22 + ECLength), EDKs, #EDKsLength, _) *
+    RawEncryptedDataKeys(rawHeaderData, (22 + ECLength), "Complete", EDKs, #EDKsLength, _) *
     (#EDKsLength == (l-len #edks)) * ((l-len #rawFrameLength) == 4) *
     rawToUInt32(#rawFrameLength, false, frameLength) *
     (headerLength == ((((((22 + ECLength) + #EDKsLength) + 1) + 4) + 1) + 4)) *

--- a/Gillian-JS/Examples/Amazon/bugs/pp/EncryptionHeaderLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/EncryptionHeaderLogic.gil
@@ -14,7 +14,7 @@
     ----------------||----|----|---- ... ----||----------------
                 readPos
 *)
-pred Field(+buffer : List, +readPos : Num, field : List, length : Num) :
+pred Field(buffer : List, readPos : Num; field : List, length : Num) :
   (0 <=# readPos) * (#rawFL == l-sub(buffer, readPos, 2)) *
     rawToUInt16(#rawFL, false, #fLength) *
     (field == l-sub(buffer, (readPos + 2), #fLength)) *
@@ -63,7 +63,7 @@ pred Field(+buffer : List, +readPos : Num, field : List, length : Num) :
                 readPos
 *)
 @nopath
-pred IElement(+buffer : List, +readPos : Num, +fCount : Num, fList : List, eLength : Num) :
+pred IElement(buffer : List, readPos : Num, fCount : Num; fList : List, eLength : Num) :
   (* Base case: not enough data to read length of next field *)
   (0 <=# readPos) * (0 <# fCount) * (readPos <=# (l-len buffer)) *
     ((l-len buffer) <# (readPos + 2)) * (fList == {{  }}) *
@@ -121,7 +121,7 @@ pred IElement(+buffer : List, +readPos : Num, +fCount : Num, fList : List, eLeng
                 readPos
 *)
 @nopath
-pred IElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
+pred IElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
                eList : List, esLength : Num) :
   (* Base case: single incomplete element *)
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * (0 <# eCount) * (0 <# fCount) *
@@ -157,7 +157,7 @@ pred IElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
                 readPos
 *)
 @nopath
-pred CElement(+buffer : List, +readPos : Num, +fCount : Num, element : List, length : Num) :
+pred CElement(buffer : List, readPos : Num, fCount : Num; element : List, length : Num) :
   (0 <=# readPos) * (readPos <=# (l-len buffer)) *
     (fCount == 0) * (element == {{  }}) * (length == 0),
   (0 <# fCount) * Field(buffer, readPos, #field, #fLength) *
@@ -190,7 +190,7 @@ pred CElement(+buffer : List, +readPos : Num, +fCount : Num, element : List, len
     ----------------||-------| ... |-------||----------------
                  readPos
 *)
-pred CElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
+pred CElements(buffer : List, readPos : Num, eCount : Num, fCount : Num;
                elements : List, length : Num) :
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * (eCount == 0) *
   (0 <# fCount) * (elements == {{  }}) * (length == 0),
@@ -221,8 +221,8 @@ pred CElements(+buffer : List, +readPos : Num, +eCount : Num, +fCount : Num,
 
 (* A general element sequene is either a complete or an incomplete element sequence *)
 @nopath
-nounfold pred Elements(+buffer : List, +readPos : Num, +eCount : Num,
-                       +fCount : Num, definition : Str, eList : List,
+nounfold pred Elements(buffer : List, readPos : Num, eCount : Num,
+                       fCount : Num; definition : Str, eList : List,
                        esLength : Num) :
   (definition == "Complete") * CElements(buffer, readPos, eCount, fCount, eList, esLength),
   (definition == "Incomplete") * IElements(buffer, readPos, eCount, fCount, eList, esLength);
@@ -249,7 +249,7 @@ nounfold pred Elements(+buffer : List, +readPos : Num, +eCount : Num,
 
 (* Complete serialised EDKs *)
 @nopath
-nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Num,
+nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Num;
                                     EDKs : List, EDKsLength : Num) :
     (0 <=# readPos) * (readPos <=# (l-len buffer)) *
     (#rawEC == l-sub(buffer, readPos, 2)) *
@@ -259,7 +259,7 @@ nounfold pred CRawEncryptedDataKeys(+buffer : List, +readPos : Num,
 
 (* Incomplete serialised EDKs *)
 @nopath
-nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num) :
+nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num;) :
   (* Not enough data to read the number of EDKs *)
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * ((l-len buffer) <# (readPos + 2)),
 
@@ -270,7 +270,7 @@ nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num) :
 
 (* Broken serialised EDKs *)
 @nopath
-nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Num, errorMessage : Str) :
+nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Num; errorMessage : Str) :
   (* Incorrect starting position *)
   ((readPos <# 0) \/ ((l-len buffer) <# readPos)) *
     (errorMessage == "deserializeMessageHeader: startPos out of bounds."),
@@ -282,7 +282,7 @@ nounfold pred BRawEncryptedDataKeys(+buffer : List, +readPos : Num, errorMessage
 
 (* General serialised EDKs *)
 @nopath
-nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Num, definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
+nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Num; definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
   (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos, EDKs, EDKsLength),
   (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
   (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos, errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
@@ -308,7 +308,7 @@ nounfold pred RawEncryptedDataKeys(+buffer : List, +readPos : Num, definition : 
 
 (* Complete serialised encryption context *)
 @nopath
-nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
+nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
   ((l-len buffer) == 0) * (ECKs == {{  }}),
   (#rawKC == l-sub(buffer, 0, 2)) *
     rawToUInt16(#rawKC, false, #keyCount) * (0 <# #keyCount) *
@@ -328,7 +328,7 @@ nounfold pred CRawEncryptionContext(+buffer : List, ECKs : List) :
 
 (* Correctly formed algorithm suite *)
 @nopath
-pred CAlgorithmSuite(+numId, stringId, ivLength, tagLength) :
+pred CAlgorithmSuite(numId; stringId, ivLength, tagLength) :
   (numId == 20) * (stringId == "ALG_AES128_GCM_IV12_TAG16") *
     (ivLength == 12) * (tagLength == 128),
   (numId == 70) * (stringId == "ALG_AES192_GCM_IV12_TAG16") * (ivLength == 12) *
@@ -336,7 +336,7 @@ pred CAlgorithmSuite(+numId, stringId, ivLength, tagLength) :
 
 (* Broken algorithm suite *)
 @nopath
-pred BAlgorithmSuite(+numId, errorMessage) :
+pred BAlgorithmSuite(numId; errorMessage) :
   (! (numId == 20)) * (! (numId == 70)) *
   (errorMessage == "Malformed Header: Unsupported algorithm suite.");
 
@@ -351,13 +351,13 @@ pred BAlgorithmSuite(+numId, errorMessage) :
 
 (* The correct version and type *)
 @nopath
-pred CVersionAndType(version, type) :
+pred CVersionAndType(version, type;) :
   (version == 1) * (type == 128);
 
 
 (* Serialised complete header *)
 @nopath
-nounfold pred CHeader(+rawHeaderData, part_one, version, type, suiteId,
+nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
                       messageId, ECLength, part_two, ECKs, part_three, EDKs,
                       contentType, headerIvLength, frameLength, headerLength,
                       headerIv, headerAuthTag) :

--- a/Gillian-JS/Examples/Amazon/bugs/pp/EncryptionHeaderLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/EncryptionHeaderLogic.gil
@@ -259,7 +259,7 @@ nounfold pred CRawEncryptedDataKeys(buffer : List, readPos : Num;
 
 (* Incomplete serialised EDKs *)
 @nopath
-nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num;) :
+nounfold pred IRawEncryptedDataKeys(buffer : List, readPos : Num) :
   (* Not enough data to read the number of EDKs *)
   (0 <=# readPos) * (readPos <=# (l-len buffer)) * ((l-len buffer) <# (readPos + 2)),
 
@@ -284,7 +284,7 @@ nounfold pred BRawEncryptedDataKeys(buffer : List, readPos : Num; errorMessage :
 @nopath
 nounfold pred RawEncryptedDataKeys(buffer : List, readPos : Num; definition : Str, EDKs : List, EDKsLength : Num, errorMessage : Str) :
   (definition == "Complete") * (errorMessage == "") * CRawEncryptedDataKeys(buffer, readPos; EDKs, EDKsLength),
-  (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos;) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
+  (definition == "Incomplete") * IRawEncryptedDataKeys(buffer, readPos) * (EDKs == {{  }}) * (EDKsLength == 0) * (errorMessage == ""),
   (definition == "Broken") * BRawEncryptedDataKeys(buffer, readPos; errorMessage) * (EDKs == {{  }}) * (EDKsLength == 0);
 
 
@@ -314,7 +314,7 @@ nounfold pred CRawEncryptionContext(buffer : List; ECKs : List) :
     rawToUInt16(#rawKC, false; #keyCount) * (0 <# #keyCount) *
     Elements(buffer, 2, #keyCount, 2; "Complete", ECKs, #ECKsLength) *
     toUtf8PairMap(ECKs; #utf8ECKs) * FirstProj(ECKs; #ECKeys) *
-    Unique(#ECKeys;) * ((2 + #ECKsLength) == (l-len buffer));
+    Unique(#ECKeys) * ((2 + #ECKsLength) == (l-len buffer));
 
 
 (****************************
@@ -351,7 +351,7 @@ pred BAlgorithmSuite(numId; errorMessage) :
 
 (* The correct version and type *)
 @nopath
-pred CVersionAndType(version, type;) :
+pred CVersionAndType(version, type) :
   (version == 1) * (type == 128);
 
 
@@ -366,7 +366,7 @@ nounfold pred CHeader(rawHeaderData; part_one, version, type, suiteId,
     (part_one == l+ ({{ version, type }}, #rawSuiteId, messageId, #rawContextLength)) *
     ((l-len #rawSuiteId) == 2) *
     ((l-len messageId) == 16) *
-    ((l-len #rawContextLength) == 2) * CVersionAndType(version, type;) *
+    ((l-len #rawContextLength) == 2) * CVersionAndType(version, type) *
     rawToUInt16(#rawSuiteId, false; suiteId) *
     CAlgorithmSuite(suiteId; #stringId, headerIvLength, #tagLength) *
     rawToUInt16(#rawContextLength, false; ECLength) *

--- a/Gillian-JS/Examples/Amazon/bugs/pp/ListLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/ListLogic.gil
@@ -10,12 +10,12 @@
 @nopath
 pure pred FirstProj(lst : List; fProj : List) : (lst == {{  }}) *
   (fProj == {{  }}), (lst == l+ ({{ {{ #fst, #lvar_js_7 }} }}, #rest)) *
-  FirstProj(#rest, #fProjRest) * (fProj == l+ ({{ #fst }}, #fProjRest));
+  FirstProj(#rest; #fProjRest) * (fProj == l+ ({{ #fst }}, #fProjRest));
   
   
 (*
 lemma FirstProjFunction(lst1, proj1, lst2, proj2)
-  [[  FirstProj(#lst1, #proj1) * FirstProj(#lst2, #proj2) * (#lst1 == #lst2) ]]
+  [[  FirstProj(#lst1; #proj1) * FirstProj(#lst2; #proj2) * (#lst1 == #lst2) ]]
   [[  (#proj1 == #proj2) ]]
   [*  unfold FirstProj(#lst1, #proj1)  [bind: (#fst1 := #fst) and (#rest1 := #rest) and (#fProjRest1 := #fProjRest)];
       if ((not (#lst1 = {{  }}))) then {
@@ -25,13 +25,13 @@ lemma FirstProjFunction(lst1, proj1, lst2, proj2)
   *]
   
 lemma FirstProjAppendPair(lst, fProj, prop, value)
-  [[  FirstProj(#lst, #fProj) ]]
-  [[  FirstProj(l+ (#lst, {{ {{ #prop, #value }} }}), l+ (#fProj, {{ #prop }})) ]]
+  [[  FirstProj(#lst; #fProj) ]]
+  [[  FirstProj(l+ (#lst, {{ {{ #prop, #value }} }}); l+ (#fProj, {{ #prop }})) ]]
   [*  unfold FirstProj(#lst, #fProj) ;
       if ((not (#lst = {{  }}))) then {
         sep_assert ((#lst == l+ ({{ {{ #fProp, #fValue }} }}, #restPVPairs)))
           [bind: #fProp, #fValue, #restPVPairs];
-        sep_assert (FirstProj(#restPVPairs, #restProj)) [bind: #restProj];
+        sep_assert (FirstProj(#restPVPairs; #restProj)) [bind: #restProj];
         apply FirstProjAppendPair(#restPVPairs, #restProj, #prop, #value) 
       }  *]
 *)
@@ -48,8 +48,8 @@ lemma FirstProjAppendPair(lst, fProj, prop, value)
 @nopath
 pure pred Unique(l : List;) :
   (l == {{  }}),
-  (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest, #setRest) *
-    (! (#fst --e-- #setRest)) * Unique(#rest);
+  (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest; #setRest) *
+    (! (#fst --e-- #setRest)) * Unique(#rest;);
     
     
 (*****************************************
@@ -64,4 +64,4 @@ pure pred Unique(l : List;) :
 pure pred ListToSet(lst : List; set : Set) :
   (lst == {{  }}) * (set == -{  }-),
   (lst == l+ ({{ #e }}, #restLst)) *
-    ListToSet(#restLst, #restSet) * (set == -u- (#restSet, -{ #e }-));
+    ListToSet(#restLst; #restSet) * (set == -u- (#restSet, -{ #e }-));

--- a/Gillian-JS/Examples/Amazon/bugs/pp/ListLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/ListLogic.gil
@@ -8,7 +8,7 @@
 
 (* First projection of a list of pairs *)
 @nopath
-pure pred FirstProj(+lst : List, fProj : List) : (lst == {{  }}) *
+pure pred FirstProj(lst : List; fProj : List) : (lst == {{  }}) *
   (fProj == {{  }}), (lst == l+ ({{ {{ #fst, #lvar_js_7 }} }}, #rest)) *
   FirstProj(#rest, #fProjRest) * (fProj == l+ ({{ #fst }}, #fProjRest));
   
@@ -46,7 +46,7 @@ lemma FirstProjAppendPair(lst, fProj, prop, value)
  ********************************)
   
 @nopath
-pure pred Unique(l : List) :
+pure pred Unique(l : List;) :
   (l == {{  }}),
   (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest, #setRest) *
     (! (#fst --e-- #setRest)) * Unique(#rest);
@@ -61,7 +61,7 @@ pure pred Unique(l : List) :
 ******************************************)
 
 @nopath
-pure pred ListToSet(+lst : List, set : Set) :
+pure pred ListToSet(lst : List; set : Set) :
   (lst == {{  }}) * (set == -{  }-),
   (lst == l+ ({{ #e }}, #restLst)) *
     ListToSet(#restLst, #restSet) * (set == -u- (#restSet, -{ #e }-));

--- a/Gillian-JS/Examples/Amazon/bugs/pp/ListLogic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/ListLogic.gil
@@ -46,10 +46,10 @@ lemma FirstProjAppendPair(lst, fProj, prop, value)
  ********************************)
   
 @nopath
-pure pred Unique(l : List;) :
+pure pred Unique(l : List) :
   (l == {{  }}),
   (l == l+ ({{ #fst }}, #rest)) * ListToSet(#rest; #setRest) *
-    (! (#fst --e-- #setRest)) * Unique(#rest;);
+    (! (#fst --e-- #setRest)) * Unique(#rest);
     
     
 (*****************************************

--- a/Gillian-JS/Examples/Amazon/bugs/pp/Utf8Logic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/Utf8Logic.gil
@@ -14,11 +14,11 @@
     the raw bytes rawData to UTF-8 format
 *)
 @nopath
-abstract pure nounfold pred toUtf8(+rawData : List, utf8Data : Str);    
+abstract pure nounfold pred toUtf8(rawData : List; utf8Data : Str);    
     
 (* UTF-8 Mapping of lists of pairs *)
 @nopath
-pure pred toUtf8PairMap(+data : List, utf8Data : List) : (data == {{  }}) *
+pure pred toUtf8PairMap(data : List; utf8Data : List) : (data == {{  }}) *
   (utf8Data == {{  }}),
   (data == l+ ({{ {{ #prop, #value }} }}, #rest)) *
     toUtf8(#prop, #utf8Prop) * toUtf8(#value, #utf8Value) *

--- a/Gillian-JS/Examples/Amazon/bugs/pp/Utf8Logic.gil
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/Utf8Logic.gil
@@ -21,6 +21,6 @@ abstract pure nounfold pred toUtf8(rawData : List; utf8Data : Str);
 pure pred toUtf8PairMap(data : List; utf8Data : List) : (data == {{  }}) *
   (utf8Data == {{  }}),
   (data == l+ ({{ {{ #prop, #value }} }}, #rest)) *
-    toUtf8(#prop, #utf8Prop) * toUtf8(#value, #utf8Value) *
-    toUtf8PairMap(#rest, #utf8Rest) *
+    toUtf8(#prop; #utf8Prop) * toUtf8(#value; #utf8Value) *
+    toUtf8PairMap(#rest; #utf8Rest) *
     (utf8Data == l+ ({{ {{ #utf8Prop, #utf8Value }} }}, #utf8Rest));

--- a/Gillian-JS/Examples/Amazon/bugs/pp/deserialize_factory.js
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/deserialize_factory.js
@@ -48,7 +48,7 @@ function needs(condition, errorMessage) {
       Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
 
       scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals (;)
+      JSInternals ()
 
     @post
       (#definition == "Complete") *
@@ -56,9 +56,9 @@ function needs(condition, errorMessage) {
       ArrayBuffer(#ab; #data) *
       Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
       scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals (;) *
+      JSInternals () *
 
-      JSObject(ret;) *
+      JSObject(ret) *
         DataProp(ret, "elements"; #elements) *
             ArrayOfArraysOfUInt8Arrays(#elements; #eList) *
         DataProp(ret, "readPos"; #ret_readPos) *
@@ -70,7 +70,7 @@ function needs(condition, errorMessage) {
       Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
 
       scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals (;) *
+      JSInternals () *
 
       (ret == false)
 */
@@ -93,7 +93,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
       scope(elements : #doneEls) * scope(readPos : #outerLoopReadPos) *
       scope(elementCount : #eLeft) * scope(fieldsPerElement: #fCount) *
       scope(element: _) * scope(fieldCount: _) * scope(fieldBinary: _) * scope(length: _) *
-      JSInternals(;) *
+      JSInternals() *
 
       CElements(#view, #readPos, #eCount - #eLeft, #fCount; #doneElsList, #doneElsLength) *
       Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength) *
@@ -118,7 +118,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
         scope(dataView: #dataView) * DataView(#dataView; #ab, #viewOffset, #viewSize) *
         scope(element : #doneEl) * scope(readPos : #innerLoopReadPos) * scope(fieldCount : #fLeft) *
         scope(fieldBinary: _) * scope(length: _) *
-        JSInternals(;) *
+        JSInternals() *
 
         CElement(#view, #outerLoopReadPos, #fCount - #fLeft; #doneElList, #doneElLength) *
         (#fList == l+ (#doneElList, #remElList)) *
@@ -201,7 +201,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
     @onlyspec EncryptedDataKey (edk)
     [[
         (edk == #edk) *
-        JSObject(#edk;) *
+        JSObject(#edk) *
         DataProp(#edk, "providerId"; #pId) * types(#pId : Str) *
         DataProp(#edk, "providerInfo"; #pInfo) * types(#pInfo : Str) *
         DataProp(#edk, "encryptedDataKey"; #aEDK) *
@@ -215,7 +215,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
         JSObjWithProto (this; $l_edk_proto)
     ]]
     [[
-        JSObject(#edk;) *
+        JSObject(#edk) *
         DataProp(#edk, "providerId"; #pId) *
         DataProp(#edk, "providerInfo"; #pInfo) *
         DataProp(#edk, "encryptedDataKey"; #aEDK) *
@@ -268,9 +268,9 @@ var toUtf8 = function (buffer) { };
 
 /**
 
-    @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List;) :
-        (definition == "Complete") * Unique(lst1;),
-        (definition == "Broken") * Duplicated(lst2, lst3;);
+    @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List) :
+        (definition == "Complete") * Unique(lst1),
+        (definition == "Broken") * Duplicated(lst2, lst3);
 
     @id decodeEncryptionContext
 
@@ -283,17 +283,17 @@ var toUtf8 = function (buffer) { };
          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
-         JSInternals(;)
+         JSInternals()
 
     @post Uint8Array(#eEC; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
           RawEncryptionContext(#EC; #definition, #ECKs, #errorMessage) *
 
-          DecodedEncryptionContext(ret, #ECKs;) *
+          DecodedEncryptionContext(ret, #ECKs) *
 
           scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
           scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
           scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
-          JSInternals (;)
+          JSInternals ()
 */
 function decodeEncryptionContext(encodedEncryptionContext) {
   /* @tactic
@@ -347,8 +347,8 @@ function decodeEncryptionContext(encodedEncryptionContext) {
         assert (
             scope(pairsCount: #pairsCount) * (#pairsCount == l-len #ECKs) *
             scope(elements: #elements) * ArrayOfArraysOfUInt8Arrays(#elements; #ECKs) *
-            scope(encryptionContext: #dECObj) * JSObject(#dECObj;) * empty_fields(#dECObj : -{ }-) *
-            toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) * UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;)
+            scope(encryptionContext: #dECObj) * JSObject(#dECObj) * empty_fields(#dECObj : -{ }-) *
+            toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) * UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps)
         ) [bind: #pairsCount, #elements, #dECObj, #utf8ECKs, #rProps]
 
     @invariant
@@ -358,25 +358,25 @@ function decodeEncryptionContext(encodedEncryptionContext) {
         scope(key: _) * scope(value: _) *
         toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) *
         CElements(#EC, 2., ((256. * #b0) + #b1), 2.; #ECKs, (l-len #rest)) *
-        UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;) *
-        JSInternals(;) *
+        UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps) *
+        JSInternals() *
 
         scope(count: #count) * (#count <=# #pairsCount) *
-        ArrayStructure(#elements, #pairsCount;) *
+        ArrayStructure(#elements, #pairsCount) *
         ArrayOfArraysOfUInt8ArraysContents(#elements, 0, #count; #done) *
         ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left) *
         (#ECKs == l+ (#done, #left)) *
-        FirstProj(#done; #doneRProps) * Unique(#doneRProps;) *
-        FirstProj(#left; #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;) *
+        FirstProj(#done; #doneRProps) * Unique(#doneRProps) *
+        FirstProj(#left; #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps) *
         toUtf8PairMap(#done; #utf8Done) *
-        JSObject(#dECObj;) * ObjectTable(#dECObj, #utf8Done;)
+        JSObject(#dECObj) * ObjectTable(#dECObj, #utf8Done)
         [bind: #count, #done, #left, #doneRProps, #leftRProps, #utf8Done] */
   for (var count = 0; count < pairsCount; count++) {
     /*
         @tactic
-            unfold ArrayStructure(#elements, #pairsCount;);
-            unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;);
-            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;);
+            unfold ArrayStructure(#elements, #pairsCount);
+            unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps);
+            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
             unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
             apply CElementsElementLength(#EC, 2., ((256. * #b0) + #b1), 2., #ECKs, #done, #ECK, #rest_left);
             assert (#ECK == {{ #new_prop, #new_value }})
@@ -392,7 +392,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
         @tactic
             assert (toUtf8(#new_prop; #utf8NProp)) [bind: #utf8NProp];
             assert (toUtf8(#new_value; #utf8NVal)) [bind: #utf8NVal];
-            unfold ObjectTable(#dECObj, #utf8Done;) [bind: (#doneProps := #pList) and (#donePropsSet := #pSet)];
+            unfold ObjectTable(#dECObj, #utf8Done) [bind: (#doneProps := #pList) and (#donePropsSet := #pSet)];
             apply FirstProjConcatSplit(#ECKs, #done, #left);
             apply ProduceListToSet(#doneRProps); apply ProduceListToSet(#leftRProps);
             assert (ListToSet(#doneRProps; #doneRPropsSet)) [bind: #doneRPropsSet];
@@ -405,7 +405,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
                 apply ObjectTableAbsentProperty(#dECObj, #utf8Done, #utf8NProp)
             } else {
                 apply FirstProjToUtf8MapPairCompat(#done);
-                unfold Duplicated(#doneRProps, #leftRProps;) [bind: (#doneRPropsSet2 := #preSet)];
+                unfold Duplicated(#doneRProps, #leftRProps) [bind: (#doneRPropsSet2 := #preSet)];
                 apply ListToSetFunction(#doneRProps, #doneRPropsSet, #doneRProps, #doneRPropsSet2);
                 if (#new_prop -e- #doneRPropsSet) then {
                     apply InListToUtf8(#new_prop, #doneRProps);
@@ -432,7 +432,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
             apply ListToSetAddElement(#doneProps, #donePropsSet, #utf8NProp);
             apply UniqueAppendElement(#doneRProps, #new_prop);
             if (#definition = "Complete") then {
-                unfold Unique(#leftRProps;)
+                unfold Unique(#leftRProps)
             }
     */
     0 === 0;
@@ -444,8 +444,8 @@ function decodeEncryptionContext(encodedEncryptionContext) {
         apply toUtf8PairMapInjective(#ECKs, #utf8ECKs, #done, #utf8Done);
         if (#definition = "Broken") then {
             unfold FirstProj(#left; #leftRProps);
-            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;);
-            unfold Duplicated(#doneRProps, #leftRProps;)
+            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
+            unfold Duplicated(#doneRProps, #leftRProps)
         };
         use_subst [object_table : (#PVPairs: #utf8ECKs) ]
   */

--- a/Gillian-JS/Examples/Amazon/bugs/pp/deserialize_factory.js
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/deserialize_factory.js
@@ -36,41 +36,41 @@ function needs(condition, errorMessage) {
     @id readElements
 
     @pred nounfold innerLoopInvariantFacts(definition, remElsList, view, innerLoopReadPos, fLeft, remElList, eLength, remElsLength, doneElLength; remElLength) :
-      (definition == "Complete") * CElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (eLength == doneElLength + remElLength),
-      (definition == "Incomplete") * (remElsList == {{ }}) * IElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (remElsLength == doneElLength + remElLength),
-      (definition == "Incomplete") * (! (remElsList == {{ }})) * CElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (eLength == doneElLength + remElLength);
+      (definition == "Complete") * CElement(view, innerLoopReadPos, fLeft; remElList, remElLength) * (eLength == doneElLength + remElLength),
+      (definition == "Incomplete") * (remElsList == {{ }}) * IElement(view, innerLoopReadPos, fLeft; remElList, remElLength) * (remElsLength == doneElLength + remElLength),
+      (definition == "Incomplete") * (! (remElsList == {{ }})) * CElement(view, innerLoopReadPos, fLeft; remElList, remElLength) * (eLength == doneElLength + remElLength);
 
     @pre
       (elementCount == #eCount) * (fieldsPerElement == #fCount) * (buffer == #buffer) * (readPos == #readPos) *
-      Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
-      ArrayBuffer(#ab, #data) *
+      Uint8Array (#buffer; #ab, #viewOffset, #viewSize) *
+      ArrayBuffer(#ab; #data) *
       (#view == l-sub(#data, #viewOffset, #viewSize)) *
-      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
+      Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
 
-      scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals ()
+      scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+      JSInternals (;)
 
     @post
       (#definition == "Complete") *
-      Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
-      ArrayBuffer(#ab, #data) *
-      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
-      scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals () *
+      Uint8Array (#buffer; #ab, #viewOffset, #viewSize) *
+      ArrayBuffer(#ab; #data) *
+      Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
+      scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+      JSInternals (;) *
 
-      JSObject(ret) *
-        DataProp(ret, "elements", #elements) *
-            ArrayOfArraysOfUInt8Arrays(#elements, #eList) *
-        DataProp(ret, "readPos", #ret_readPos) *
+      JSObject(ret;) *
+        DataProp(ret, "elements"; #elements) *
+            ArrayOfArraysOfUInt8Arrays(#elements; #eList) *
+        DataProp(ret, "readPos"; #ret_readPos) *
             (#ret_readPos == #readPos + #esLength);
 
       (#definition == "Incomplete") *
-      Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
-      ArrayBuffer(#ab, #data) *
-      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
+      Uint8Array (#buffer; #ab, #viewOffset, #viewSize) *
+      ArrayBuffer(#ab; #data) *
+      Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
 
-      scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals () *
+      scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+      JSInternals (;) *
 
       (ret == false)
 */
@@ -88,61 +88,61 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
   var elements = [];
 
   /* @invariant
-      scope(buffer: #buffer) * Uint8Array (#buffer, #ab, #viewOffset, #viewSize) * ArrayBuffer(#ab, #data) *
-      scope(dataView: #dataView) * DataView(#dataView, #ab, #viewOffset, #viewSize) *
+      scope(buffer: #buffer) * Uint8Array (#buffer; #ab, #viewOffset, #viewSize) * ArrayBuffer(#ab; #data) *
+      scope(dataView: #dataView) * DataView(#dataView; #ab, #viewOffset, #viewSize) *
       scope(elements : #doneEls) * scope(readPos : #outerLoopReadPos) *
       scope(elementCount : #eLeft) * scope(fieldsPerElement: #fCount) *
       scope(element: _) * scope(fieldCount: _) * scope(fieldBinary: _) * scope(length: _) *
-      JSInternals() *
+      JSInternals(;) *
 
-      CElements(#view, #readPos, #eCount - #eLeft, #fCount, #doneElsList, #doneElsLength) *
-      Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength) *
+      CElements(#view, #readPos, #eCount - #eLeft, #fCount; #doneElsList, #doneElsLength) *
+      Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength) *
       (#eList == l+ (#doneElsList, #remElsList)) *
       (#esLength == #doneElsLength + #remElsLength) *
       (#readPos + #doneElsLength == #outerLoopReadPos) *
-      ArrayOfArraysOfUInt8Arrays(#doneEls, #doneElsList)
+      ArrayOfArraysOfUInt8Arrays(#doneEls; #doneElsList)
       [bind : #doneEls, #outerLoopReadPos, #eLeft, #remElsList, #remElsLength, #doneElsList, #doneElsLength] */
   while (elementCount--) {
     /* @tactic
-        unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
+        unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength);
         if (#definition = "Complete") then {
-            unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength) [bind: (#fList := #element) and (#eLength := #eLength)]
+            unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount; #remElsList, #remElsLength) [bind: (#fList := #element) and (#eLength := #eLength)]
         } else {
-            unfold IElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength) [bind: (#fList := #fList) and (#eLength := #eLength)]
+            unfold IElements(#view, #outerLoopReadPos, #eLeft, #fCount; #remElsList, #remElsLength) [bind: (#fList := #fList) and (#eLength := #eLength)]
         } */
     var element = []
     var fieldCount = fieldsPerElement
 
     /* @invariant
-        scope(buffer: #buffer) * Uint8Array (#buffer, #ab, #viewOffset, #viewSize) * ArrayBuffer(#ab, #data) *
-        scope(dataView: #dataView) * DataView(#dataView, #ab, #viewOffset, #viewSize) *
+        scope(buffer: #buffer) * Uint8Array (#buffer; #ab, #viewOffset, #viewSize) * ArrayBuffer(#ab; #data) *
+        scope(dataView: #dataView) * DataView(#dataView; #ab, #viewOffset, #viewSize) *
         scope(element : #doneEl) * scope(readPos : #innerLoopReadPos) * scope(fieldCount : #fLeft) *
         scope(fieldBinary: _) * scope(length: _) *
-        JSInternals() *
+        JSInternals(;) *
 
-        CElement(#view, #outerLoopReadPos, #fCount - #fLeft, #doneElList, #doneElLength) *
+        CElement(#view, #outerLoopReadPos, #fCount - #fLeft; #doneElList, #doneElLength) *
         (#fList == l+ (#doneElList, #remElList)) *
-        innerLoopInvariantFacts(#definition, #remElsList, #view, #innerLoopReadPos, #fLeft, #remElList, #eLength, #remElsLength, #doneElLength, #remElLength) *
+        innerLoopInvariantFacts(#definition, #remElsList, #view, #innerLoopReadPos, #fLeft, #remElList, #eLength, #remElsLength, #doneElLength; #remElLength) *
         (#outerLoopReadPos + #doneElLength == #innerLoopReadPos) *
-        ArrayOfUInt8Arrays(#doneEl, #doneElList, #fCount - #fLeft)
+        ArrayOfUInt8Arrays(#doneEl; #doneElList, #fCount - #fLeft)
         [bind: #doneEl, #innerLoopReadPos, #fLeft, #remElList, #remElLength, #doneElList, #doneElLength] */
     while (fieldCount--) {
       /* @tactic
-          unfold innerLoopInvariantFacts(#definition, #remElsList, #view, #innerLoopReadPos, #fLeft, #remElList, #eLength, #remElsLength, #doneElLength, #remElLength);
+          unfold innerLoopInvariantFacts(#definition, #remElsList, #view, #innerLoopReadPos, #fLeft, #remElList, #eLength, #remElsLength, #doneElLength; #remElLength);
           if (#definition = "Complete") then {
-              unfold CElement(#view, #innerLoopReadPos, #fLeft, #remElList, #remElLength)
+              unfold CElement(#view, #innerLoopReadPos, #fLeft; #remElList, #remElLength)
           } else {
               if (#remElsList = {{ }}) then {
-                  unfold IElement(#view, #innerLoopReadPos, #fLeft, #remElList, #remElLength)
+                  unfold IElement(#view, #innerLoopReadPos, #fLeft; #remElList, #remElLength)
               } else {
-                  unfold CElement(#view, #innerLoopReadPos, #fLeft, #remElList, #remElLength)
+                  unfold CElement(#view, #innerLoopReadPos, #fLeft; #remElList, #remElLength)
               }
           } */
       if (readPos + 2 > dataView.byteLength)
         /* @tactic
             apply PrependCElementI(#view, #outerLoopReadPos, (#fCount - #fLeft), #doneElList, #doneElLength, #fLeft, #remElList, #remElLength);
-            assert IElement(#view, #outerLoopReadPos, #fCount, #fList, #remElsLength);
-            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
+            assert IElement(#view, #outerLoopReadPos, #fCount; #fList, #remElsLength);
+            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength);
             apply PrependCElementsE(#definition, #view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #eLeft, #remElsList, #remElsLength)
         */
         return false
@@ -153,8 +153,8 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
       if (readPos + length > dataView.byteLength)
         /* @tactic
             apply PrependCElementI(#view, #outerLoopReadPos, (#fCount - #fLeft), #doneElList, #doneElLength, #fLeft, #remElList, #remElLength);
-            assert IElement(#view, #outerLoopReadPos, #fCount, #fList, #remElsLength);
-            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
+            assert IElement(#view, #outerLoopReadPos, #fCount; #fList, #remElsLength);
+            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength);
             apply PrependCElementsE(#definition, #view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #eLeft, #remElsList, #remElsLength)
         */
         return false
@@ -172,17 +172,17 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
     }
 
     /* @tactic
-        unfold CElement(#view, #innerLoopReadPos, #fLeft, #remElList, #remElLength);
+        unfold CElement(#view, #innerLoopReadPos, #fLeft; #remElList, #remElLength);
         apply CElementsAppend(#view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #doneElList, #doneElLength) */
     elements.push(element);
   }
 
   /* @tactic
-      unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
+      unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength);
       if (#definition = "Complete") then {
-          unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength)
+          unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount; #remElsList, #remElsLength)
       } else {
-          unfold IElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength)
+          unfold IElements(#view, #outerLoopReadPos, #eLeft, #fCount; #remElsList, #remElsLength)
       } */
   return { elements, readPos }
 }
@@ -201,31 +201,31 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
     @onlyspec EncryptedDataKey (edk)
     [[
         (edk == #edk) *
-        JSObject(#edk) *
-        DataProp(#edk, "providerId", #pId) * types(#pId : Str) *
-        DataProp(#edk, "providerInfo", #pInfo) * types(#pInfo : Str) *
-        DataProp(#edk, "encryptedDataKey", #aEDK) *
-            Uint8Array (#aEDK, #abEDK, 0, #viewSizeEDK) *
-            ArrayBuffer(#abEDK, #encryptedDataKey) *
+        JSObject(#edk;) *
+        DataProp(#edk, "providerId"; #pId) * types(#pId : Str) *
+        DataProp(#edk, "providerInfo"; #pInfo) * types(#pInfo : Str) *
+        DataProp(#edk, "encryptedDataKey"; #aEDK) *
+            Uint8Array (#aEDK; #abEDK, 0, #viewSizeEDK) *
+            ArrayBuffer(#abEDK; #encryptedDataKey) *
             (#viewSizeEDK == l-len #encryptedDataKey) *
-        DataProp(#edk, "rawInfo", #aRInfo) *
-            Uint8Array (#aRInfo, #abRInfo, 0, #viewSizeRInfo) *
-            ArrayBuffer(#abRInfo, #rawInfo) *
+        DataProp(#edk, "rawInfo"; #aRInfo) *
+            Uint8Array (#aRInfo; #abRInfo, 0, #viewSizeRInfo) *
+            ArrayBuffer(#abRInfo; #rawInfo) *
             (#viewSizeRInfo == l-len #rawInfo) *
-        JSObjWithProto (this, $l_edk_proto)
+        JSObjWithProto (this; $l_edk_proto)
     ]]
     [[
-        JSObject(#edk) *
-        DataProp(#edk, "providerId", #pId) *
-        DataProp(#edk, "providerInfo", #pInfo) *
-        DataProp(#edk, "encryptedDataKey", #aEDK) *
-            Uint8Array (#aEDK, #abEDK, 0, #viewSizeEDK) *
-            ArrayBuffer(#abEDK, #encryptedDataKey) *
-        DataProp(#edk, "rawInfo", #aRInfo) *
-            Uint8Array (#aRInfo, #abRInfo, 0, #viewSizeRInfo) *
-            ArrayBuffer(#abRInfo, #rawInfo) *
+        JSObject(#edk;) *
+        DataProp(#edk, "providerId"; #pId) *
+        DataProp(#edk, "providerInfo"; #pInfo) *
+        DataProp(#edk, "encryptedDataKey"; #aEDK) *
+            Uint8Array (#aEDK; #abEDK, 0, #viewSizeEDK) *
+            ArrayBuffer(#abEDK; #encryptedDataKey) *
+        DataProp(#edk, "rawInfo"; #aRInfo) *
+            Uint8Array (#aRInfo; #abRInfo, 0, #viewSizeRInfo) *
+            ArrayBuffer(#abRInfo; #rawInfo) *
 
-        EncryptedDataKey(this, #pId, #pInfo, #encryptedDataKey, #rawInfo) *
+        EncryptedDataKey(this; #pId, #pInfo, #encryptedDataKey, #rawInfo) *
         (ret == this)
     ]]
     normal
@@ -246,13 +246,13 @@ var EncryptedDataKey = function (edk) { };
    @onlyspec toUtf8 (buffer)
        [[
            (buffer == #buffer) *
-           Uint8Array (#buffer, #ab, 0, #length) *
-           ArrayBuffer(#ab, #element)
+           Uint8Array (#buffer; #ab, 0, #length) *
+           ArrayBuffer(#ab; #element)
        ]]
        [[
-           Uint8Array (#buffer, #ab, 0, #length) *
-           ArrayBuffer(#ab, #element) *
-           toUtf8(#element, ret)
+           Uint8Array (#buffer; #ab, 0, #length) *
+           ArrayBuffer(#ab; #element) *
+           toUtf8(#element; ret)
        ]]
        normal
 */
@@ -269,38 +269,38 @@ var toUtf8 = function (buffer) { };
 /**
 
     @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List;) :
-        (definition == "Complete") * Unique(lst1),
-        (definition == "Broken") * Duplicated(lst2, lst3);
+        (definition == "Complete") * Unique(lst1;),
+        (definition == "Broken") * Duplicated(lst2, lst3;);
 
     @id decodeEncryptionContext
 
     @pre (this == undefined) * (encodedEncryptionContext == #eEC) *
-         Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
+         Uint8Array(#eEC; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
          (#EC == l-sub(#data, #byteOffset, #byteLength)) *
          (#definition == "Complete") *
-         RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
+         RawEncryptionContext(#EC; #definition, #ECKs, #errorMessage) *
 
-         scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-         scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-         JSInternals()
+         scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+         scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+         JSInternals(;)
 
-    @post Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
-          RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
+    @post Uint8Array(#eEC; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
+          RawEncryptionContext(#EC; #definition, #ECKs, #errorMessage) *
 
-          DecodedEncryptionContext(ret, #ECKs) *
+          DecodedEncryptionContext(ret, #ECKs;) *
 
-          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-          scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-          JSInternals ()
+          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+          JSInternals (;)
 */
 function decodeEncryptionContext(encodedEncryptionContext) {
   /* @tactic
       if (#definition = "Complete") then {
-        unfold CRawEncryptionContext(#EC, #ECKs)
+        unfold CRawEncryptionContext(#EC; #ECKs)
       } else {
-        unfold BRawEncryptionContext(#EC, #errorMessage, #ECKs)
+        unfold BRawEncryptionContext(#EC; #errorMessage, #ECKs)
       }
    */
 
@@ -341,43 +341,43 @@ function decodeEncryptionContext(encodedEncryptionContext) {
     @tactic
         assert (
             (#EC == l+ ({{ #b0, #b1 }}, #rest)) *
-            Elements(#EC, 2, ((256 * #b0) + #b1), 2, "Complete", #ECKs, l-len #rest)
+            Elements(#EC, 2, ((256 * #b0) + #b1), 2; "Complete", #ECKs, l-len #rest)
         ) [bind: #b0, #b1, #rest];
-        unfold Elements(#EC, 2, ((256 * #b0) + #b1), 2, "Complete", #ECKs, l-len #rest);
+        unfold Elements(#EC, 2, ((256 * #b0) + #b1), 2; "Complete", #ECKs, l-len #rest);
         assert (
             scope(pairsCount: #pairsCount) * (#pairsCount == l-len #ECKs) *
-            scope(elements: #elements) * ArrayOfArraysOfUInt8Arrays(#elements, #ECKs) *
-            scope(encryptionContext: #dECObj) * JSObject(#dECObj) * empty_fields(#dECObj : -{ }-) *
-            toUtf8PairMap(#ECKs, #utf8ECKs) * FirstProj(#ECKs, #rProps) * UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps)
+            scope(elements: #elements) * ArrayOfArraysOfUInt8Arrays(#elements; #ECKs) *
+            scope(encryptionContext: #dECObj) * JSObject(#dECObj;) * empty_fields(#dECObj : -{ }-) *
+            toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) * UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;)
         ) [bind: #pairsCount, #elements, #dECObj, #utf8ECKs, #rProps]
 
     @invariant
         scope(pairsCount: #pairsCount) * scope(elements: #elements) * scope(encryptionContext: #dECObj) *
-        scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-        scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
+        scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+        scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
         scope(key: _) * scope(value: _) *
-        toUtf8PairMap(#ECKs, #utf8ECKs) * FirstProj(#ECKs, #rProps) *
-        CElements(#EC, 2., ((256. * #b0) + #b1), 2., #ECKs, (l-len #rest)) *
-        UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps) *
-        JSInternals() *
+        toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) *
+        CElements(#EC, 2., ((256. * #b0) + #b1), 2.; #ECKs, (l-len #rest)) *
+        UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;) *
+        JSInternals(;) *
 
         scope(count: #count) * (#count <=# #pairsCount) *
-        ArrayStructure(#elements, #pairsCount) *
-        ArrayOfArraysOfUInt8ArraysContents(#elements, 0, #count, #done) *
-        ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left) *
+        ArrayStructure(#elements, #pairsCount;) *
+        ArrayOfArraysOfUInt8ArraysContents(#elements, 0, #count; #done) *
+        ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left) *
         (#ECKs == l+ (#done, #left)) *
-        FirstProj(#done, #doneRProps) * Unique(#doneRProps) *
-        FirstProj(#left, #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps) *
-        toUtf8PairMap(#done, #utf8Done) *
-        JSObject(#dECObj) * ObjectTable(#dECObj, #utf8Done)
+        FirstProj(#done; #doneRProps) * Unique(#doneRProps;) *
+        FirstProj(#left; #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;) *
+        toUtf8PairMap(#done; #utf8Done) *
+        JSObject(#dECObj;) * ObjectTable(#dECObj, #utf8Done;)
         [bind: #count, #done, #left, #doneRProps, #leftRProps, #utf8Done] */
   for (var count = 0; count < pairsCount; count++) {
     /*
         @tactic
-            unfold ArrayStructure(#elements, #pairsCount);
-            unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps);
-            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
-            unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
+            unfold ArrayStructure(#elements, #pairsCount;);
+            unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;);
+            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;);
+            unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
             apply CElementsElementLength(#EC, 2., ((256. * #b0) + #b1), 2., #ECKs, #done, #ECK, #rest_left);
             assert (#ECK == {{ #new_prop, #new_value }})
     */
@@ -390,13 +390,13 @@ function decodeEncryptionContext(encodedEncryptionContext) {
      */
     /*
         @tactic
-            assert (toUtf8(#new_prop, #utf8NProp)) [bind: #utf8NProp];
-            assert (toUtf8(#new_value, #utf8NVal)) [bind: #utf8NVal];
-            unfold ObjectTable(#dECObj, #utf8Done) [bind: (#doneProps := #pList) and (#donePropsSet := #pSet)];
+            assert (toUtf8(#new_prop; #utf8NProp)) [bind: #utf8NProp];
+            assert (toUtf8(#new_value; #utf8NVal)) [bind: #utf8NVal];
+            unfold ObjectTable(#dECObj, #utf8Done;) [bind: (#doneProps := #pList) and (#donePropsSet := #pSet)];
             apply FirstProjConcatSplit(#ECKs, #done, #left);
             apply ProduceListToSet(#doneRProps); apply ProduceListToSet(#leftRProps);
-            assert (ListToSet(#doneRProps, #doneRPropsSet)) [bind: #doneRPropsSet];
-            unfold FirstProj(#left, #leftRProps);
+            assert (ListToSet(#doneRProps; #doneRPropsSet)) [bind: #doneRPropsSet];
+            unfold FirstProj(#left; #leftRProps);
             apply HeadInSet(#leftRProps);
             if (#definition = "Complete") then {
                 apply UniqueConcatSplitNotInSuffix(#rProps, #doneRProps, #leftRProps, #new_prop);
@@ -405,7 +405,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
                 apply ObjectTableAbsentProperty(#dECObj, #utf8Done, #utf8NProp)
             } else {
                 apply FirstProjToUtf8MapPairCompat(#done);
-                unfold Duplicated(#doneRProps, #leftRProps) [bind: (#doneRPropsSet2 := #preSet)];
+                unfold Duplicated(#doneRProps, #leftRProps;) [bind: (#doneRPropsSet2 := #preSet)];
                 apply ListToSetFunction(#doneRProps, #doneRPropsSet, #doneRProps, #doneRPropsSet2);
                 if (#new_prop -e- #doneRPropsSet) then {
                     apply InListToUtf8(#new_prop, #doneRProps);
@@ -432,7 +432,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
             apply ListToSetAddElement(#doneProps, #donePropsSet, #utf8NProp);
             apply UniqueAppendElement(#doneRProps, #new_prop);
             if (#definition = "Complete") then {
-                unfold Unique(#leftRProps)
+                unfold Unique(#leftRProps;)
             }
     */
     0 === 0;
@@ -440,12 +440,12 @@ function decodeEncryptionContext(encodedEncryptionContext) {
 
   /*
     @tactic
-        unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left);
+        unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left);
         apply toUtf8PairMapInjective(#ECKs, #utf8ECKs, #done, #utf8Done);
         if (#definition = "Broken") then {
-            unfold FirstProj(#left, #leftRProps);
-            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
-            unfold Duplicated(#doneRProps, #leftRProps)
+            unfold FirstProj(#left; #leftRProps);
+            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;);
+            unfold Duplicated(#doneRProps, #leftRProps;)
         };
         use_subst [object_table : (#PVPairs: #utf8ECKs) ]
   */

--- a/Gillian-JS/Examples/Amazon/bugs/pp/deserialize_factory.js
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/deserialize_factory.js
@@ -45,7 +45,7 @@ function needs(condition, errorMessage) {
       Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
       ArrayBuffer(#ab, #data) *
       (#view == l-sub(#data, #viewOffset, #viewSize)) *
-      Elements(#definition, #view, #readPos, #eCount, #fCount, #eList, #esLength) *
+      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
 
       scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
       JSInternals ()
@@ -54,7 +54,7 @@ function needs(condition, errorMessage) {
       (#definition == "Complete") *
       Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
       ArrayBuffer(#ab, #data) *
-      Elements(#definition, #view, #readPos, #eCount, #fCount, #eList, #esLength) *
+      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
       scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
       JSInternals () *
 
@@ -67,7 +67,7 @@ function needs(condition, errorMessage) {
       (#definition == "Incomplete") *
       Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
       ArrayBuffer(#ab, #data) *
-      Elements(#definition, #view, #readPos, #eCount, #fCount, #eList, #esLength) *
+      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
 
       scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
       JSInternals () *
@@ -96,7 +96,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
       JSInternals() *
 
       CElements(#view, #readPos, #eCount - #eLeft, #fCount, #doneElsList, #doneElsLength) *
-      Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength) *
+      Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength) *
       (#eList == l+ (#doneElsList, #remElsList)) *
       (#esLength == #doneElsLength + #remElsLength) *
       (#readPos + #doneElsLength == #outerLoopReadPos) *
@@ -104,7 +104,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
       [bind : #doneEls, #outerLoopReadPos, #eLeft, #remElsList, #remElsLength, #doneElsList, #doneElsLength] */
   while (elementCount--) {
     /* @tactic
-        unfold Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength);
+        unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
         if (#definition = "Complete") then {
             unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength) [bind: (#fList := #element) and (#eLength := #eLength)]
         } else {
@@ -142,7 +142,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
         /* @tactic
             apply PrependCElementI(#view, #outerLoopReadPos, (#fCount - #fLeft), #doneElList, #doneElLength, #fLeft, #remElList, #remElLength);
             assert IElement(#view, #outerLoopReadPos, #fCount, #fList, #remElsLength);
-            assert Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength);
+            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
             apply PrependCElementsE(#definition, #view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #eLeft, #remElsList, #remElsLength)
         */
         return false
@@ -154,7 +154,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
         /* @tactic
             apply PrependCElementI(#view, #outerLoopReadPos, (#fCount - #fLeft), #doneElList, #doneElLength, #fLeft, #remElList, #remElLength);
             assert IElement(#view, #outerLoopReadPos, #fCount, #fList, #remElsLength);
-            assert Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength);
+            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
             apply PrependCElementsE(#definition, #view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #eLeft, #remElsList, #remElsLength)
         */
         return false
@@ -178,7 +178,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
   }
 
   /* @tactic
-      unfold Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength);
+      unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
       if (#definition = "Complete") then {
           unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength)
       } else {
@@ -278,7 +278,7 @@ var toUtf8 = function (buffer) { };
          Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
          (#EC == l-sub(#data, #byteOffset, #byteLength)) *
          (#definition == "Complete") *
-         RawEncryptionContext(#definition, #EC, #ECKs, #errorMessage) *
+         RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
 
          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
          scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
@@ -286,7 +286,7 @@ var toUtf8 = function (buffer) { };
          JSInternals()
 
     @post Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
-          RawEncryptionContext(#definition, #EC, #ECKs, #errorMessage) *
+          RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
 
           DecodedEncryptionContext(ret, #ECKs) *
 
@@ -300,7 +300,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
       if (#definition = "Complete") then {
         unfold CRawEncryptionContext(#EC, #ECKs)
       } else {
-        unfold BRawEncryptionContext(#errorMessage, #EC, #ECKs)
+        unfold BRawEncryptionContext(#EC, #errorMessage, #ECKs)
       }
    */
 
@@ -341,9 +341,9 @@ function decodeEncryptionContext(encodedEncryptionContext) {
     @tactic
         assert (
             (#EC == l+ ({{ #b0, #b1 }}, #rest)) *
-            Elements("Complete", #EC, 2, ((256 * #b0) + #b1), 2, #ECKs, l-len #rest)
+            Elements(#EC, 2, ((256 * #b0) + #b1), 2, "Complete", #ECKs, l-len #rest)
         ) [bind: #b0, #b1, #rest];
-        unfold Elements("Complete", #EC, 2, ((256 * #b0) + #b1), 2, #ECKs, l-len #rest);
+        unfold Elements(#EC, 2, ((256 * #b0) + #b1), 2, "Complete", #ECKs, l-len #rest);
         assert (
             scope(pairsCount: #pairsCount) * (#pairsCount == l-len #ECKs) *
             scope(elements: #elements) * ArrayOfArraysOfUInt8Arrays(#elements, #ECKs) *
@@ -363,8 +363,8 @@ function decodeEncryptionContext(encodedEncryptionContext) {
 
         scope(count: #count) * (#count <=# #pairsCount) *
         ArrayStructure(#elements, #pairsCount) *
-        ArrayOfArraysOfUInt8ArraysContents(#elements, #done, 0, #count) *
-        ArrayOfArraysOfUInt8ArraysContents(#elements, #left, #count, #pairsCount - #count) *
+        ArrayOfArraysOfUInt8ArraysContents(#elements, 0, #count, #done) *
+        ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left) *
         (#ECKs == l+ (#done, #left)) *
         FirstProj(#done, #doneRProps) * Unique(#doneRProps) *
         FirstProj(#left, #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps) *
@@ -377,7 +377,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
             unfold ArrayStructure(#elements, #pairsCount);
             unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps);
             unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
-            unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #left, #count, #pairsCount - #count) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
+            unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
             apply CElementsElementLength(#EC, 2., ((256. * #b0) + #b1), 2., #ECKs, #done, #ECK, #rest_left);
             assert (#ECK == {{ #new_prop, #new_value }})
     */
@@ -440,7 +440,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
 
   /*
     @tactic
-        unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #left, #count, #pairsCount - #count);
+        unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left);
         apply toUtf8PairMapInjective(#ECKs, #utf8ECKs, #done, #utf8Done);
         if (#definition = "Broken") then {
             unfold FirstProj(#left, #leftRProps);

--- a/Gillian-JS/Examples/Amazon/bugs/pp/deserialize_factory.js
+++ b/Gillian-JS/Examples/Amazon/bugs/pp/deserialize_factory.js
@@ -35,7 +35,7 @@ function needs(condition, errorMessage) {
 /**
     @id readElements
 
-    @pred nounfold innerLoopInvariantFacts(+definition, +remElsList, +view, +innerLoopReadPos, +fLeft, +remElList, +eLength, +remElsLength, +doneElLength, remElLength) :
+    @pred nounfold innerLoopInvariantFacts(definition, remElsList, view, innerLoopReadPos, fLeft, remElList, eLength, remElsLength, doneElLength; remElLength) :
       (definition == "Complete") * CElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (eLength == doneElLength + remElLength),
       (definition == "Incomplete") * (remElsList == {{ }}) * IElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (remElsLength == doneElLength + remElLength),
       (definition == "Incomplete") * (! (remElsList == {{ }})) * CElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (eLength == doneElLength + remElLength);
@@ -268,7 +268,7 @@ var toUtf8 = function (buffer) { };
 
 /**
 
-    @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List) :
+    @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List;) :
         (definition == "Complete") * Unique(lst1),
         (definition == "Broken") * Duplicated(lst2, lst3);
 

--- a/Gillian-JS/Examples/Amazon/deserialize_factory.js
+++ b/Gillian-JS/Examples/Amazon/deserialize_factory.js
@@ -36,41 +36,41 @@ function needs(condition, errorMessage) {
     @id readElements
 
     @pred nounfold innerLoopInvariantFacts(definition, remElsList, view, innerLoopReadPos, fLeft, remElList, eLength, remElsLength, doneElLength; remElLength) :
-      (definition == "Complete") * CElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (eLength == doneElLength + remElLength),
-      (definition == "Incomplete") * (remElsList == {{ }}) * IElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (remElsLength == doneElLength + remElLength),
-      (definition == "Incomplete") * (! (remElsList == {{ }})) * CElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (eLength == doneElLength + remElLength);
+      (definition == "Complete") * CElement(view, innerLoopReadPos, fLeft; remElList, remElLength) * (eLength == doneElLength + remElLength),
+      (definition == "Incomplete") * (remElsList == {{ }}) * IElement(view, innerLoopReadPos, fLeft; remElList, remElLength) * (remElsLength == doneElLength + remElLength),
+      (definition == "Incomplete") * (! (remElsList == {{ }})) * CElement(view, innerLoopReadPos, fLeft; remElList, remElLength) * (eLength == doneElLength + remElLength);
 
     @pre
       (elementCount == #eCount) * (fieldsPerElement == #fCount) * (buffer == #buffer) * (readPos == #readPos) *
-      Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
-      ArrayBuffer(#ab, #data) *
+      Uint8Array (#buffer; #ab, #viewOffset, #viewSize) *
+      ArrayBuffer(#ab; #data) *
       (#view == l-sub(#data, #viewOffset, #viewSize)) *
-      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
+      Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
 
-      scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals ()
+      scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+      JSInternals (;)
 
     @post
       (#definition == "Complete") *
-      Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
-      ArrayBuffer(#ab, #data) *
-      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
-      scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals () *
+      Uint8Array (#buffer; #ab, #viewOffset, #viewSize) *
+      ArrayBuffer(#ab; #data) *
+      Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
+      scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+      JSInternals (;) *
 
-      JSObject(ret) *
-        DataProp(ret, "elements", #elements) *
-            ArrayOfArraysOfUInt8Arrays(#elements, #eList) *
-        DataProp(ret, "readPos", #ret_readPos) *
+      JSObject(ret;) *
+        DataProp(ret, "elements"; #elements) *
+            ArrayOfArraysOfUInt8Arrays(#elements; #eList) *
+        DataProp(ret, "readPos"; #ret_readPos) *
             (#ret_readPos == #readPos + #esLength);
 
       (#definition == "Incomplete") *
-      Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
-      ArrayBuffer(#ab, #data) *
-      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
+      Uint8Array (#buffer; #ab, #viewOffset, #viewSize) *
+      ArrayBuffer(#ab; #data) *
+      Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
 
-      scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals () *
+      scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+      JSInternals (;) *
 
       (ret == false)
 */
@@ -88,60 +88,60 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
   var elements = [];
 
   /* @invariant
-      scope(buffer: #buffer) * Uint8Array (#buffer, #ab, #viewOffset, #viewSize) * ArrayBuffer(#ab, #data) *
-      scope(dataView: #dataView) * DataView(#dataView, #ab, #viewOffset, #viewSize) *
+      scope(buffer: #buffer) * Uint8Array (#buffer; #ab, #viewOffset, #viewSize) * ArrayBuffer(#ab; #data) *
+      scope(dataView: #dataView) * DataView(#dataView; #ab, #viewOffset, #viewSize) *
       scope(elements : #doneEls) * scope(readPos : #outerLoopReadPos) *
       scope(elementCount : #eLeft) * scope(fieldsPerElement: #fCount) *
       scope(element: _) * scope(fieldCount: _) * scope(fieldBinary: _) * scope(length: _) *
-      JSInternals() *
+      JSInternals(;) *
 
-      CElements(#view, #readPos, #eCount - #eLeft, #fCount, #doneElsList, #doneElsLength) *
-      Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength) *
+      CElements(#view, #readPos, #eCount - #eLeft, #fCount; #doneElsList, #doneElsLength) *
+      Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength) *
       (#eList == l+ (#doneElsList, #remElsList)) *
       (#esLength == #doneElsLength + #remElsLength) *
       (#readPos + #doneElsLength == #outerLoopReadPos) *
-      ArrayOfArraysOfUInt8Arrays(#doneEls, #doneElsList)
+      ArrayOfArraysOfUInt8Arrays(#doneEls; #doneElsList)
       [bind : #doneEls, #outerLoopReadPos, #eLeft, #remElsList, #remElsLength, #doneElsList, #doneElsLength] */
   while (elementCount--) {
     /* @tactic
-        unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
+        unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength);
         if (#definition = "Complete") then {
-            unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength) [bind: (#fList := #element) and (#eLength := #eLength)]
+            unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount; #remElsList, #remElsLength) [bind: (#fList := #element) and (#eLength := #eLength)]
         } else {
-            unfold IElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength) [bind: (#fList := #fList) and (#eLength := #eLength)]
+            unfold IElements(#view, #outerLoopReadPos, #eLeft, #fCount; #remElsList, #remElsLength) [bind: (#fList := #fList) and (#eLength := #eLength)]
         } */
     var element = []
     var fieldCount = fieldsPerElement
 
     /* @invariant
-        scope(buffer: #buffer) * Uint8Array (#buffer, #ab, #viewOffset, #viewSize) * ArrayBuffer(#ab, #data) *
-        scope(dataView: #dataView) * DataView(#dataView, #ab, #viewOffset, #viewSize) *
+        scope(buffer: #buffer) * Uint8Array (#buffer; #ab, #viewOffset, #viewSize) * ArrayBuffer(#ab; #data) *
+        scope(dataView: #dataView) * DataView(#dataView; #ab, #viewOffset, #viewSize) *
         scope(element : #doneEl) * scope(readPos : #innerLoopReadPos) * scope(fieldCount : #fLeft) *
         scope(fieldBinary: _) * scope(length: _) *
-        JSInternals() *
+        JSInternals(;) *
 
-        CElement(#view, #outerLoopReadPos, #fCount - #fLeft, #doneElList, #doneElLength) *
+        CElement(#view, #outerLoopReadPos, #fCount - #fLeft; #doneElList, #doneElLength) *
         (#fList == l+ (#doneElList, #remElList)) *
-        innerLoopInvariantFacts(#definition, #remElsList, #view, #innerLoopReadPos, #fLeft, #remElList, #eLength, #remElsLength, #doneElLength, #remElLength) *
+        innerLoopInvariantFacts(#definition, #remElsList, #view, #innerLoopReadPos, #fLeft, #remElList, #eLength, #remElsLength, #doneElLength; #remElLength) *
         (#outerLoopReadPos + #doneElLength == #innerLoopReadPos) *
-        ArrayOfUInt8Arrays(#doneEl, #doneElList, #fCount - #fLeft)
+        ArrayOfUInt8Arrays(#doneEl; #doneElList, #fCount - #fLeft)
         [bind: #doneEl, #innerLoopReadPos, #fLeft, #remElList, #remElLength, #doneElList, #doneElLength] */
     while (fieldCount--) {
       /* @tactic
           if (#definition = "Complete") then {
-              unfold CElement(#view, #innerLoopReadPos, #fLeft, #remElList, #remElLength)
+              unfold CElement(#view, #innerLoopReadPos, #fLeft; #remElList, #remElLength)
           } else {
               if (#remElsList = {{ }}) then {
-                  unfold IElement(#view, #innerLoopReadPos, #fLeft, #remElList, #remElLength)
+                  unfold IElement(#view, #innerLoopReadPos, #fLeft; #remElList, #remElLength)
               } else {
-                  unfold CElement(#view, #innerLoopReadPos, #fLeft, #remElList, #remElLength)
+                  unfold CElement(#view, #innerLoopReadPos, #fLeft; #remElList, #remElLength)
               }
           } */
       if (readPos + 2 > dataView.byteLength)
         /* @tactic
             apply PrependCElementI(#view, #outerLoopReadPos, (#fCount - #fLeft), #doneElList, #doneElLength, #fLeft, #remElList, #remElLength);
-            assert IElement(#view, #outerLoopReadPos, #fCount, #fList, #remElsLength);
-            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
+            assert IElement(#view, #outerLoopReadPos, #fCount; #fList, #remElsLength);
+            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength);
             apply PrependCElementsE(#definition, #view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #eLeft, #remElsList, #remElsLength)
         */
         return false
@@ -152,8 +152,8 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
       if (readPos + length > dataView.byteLength)
         /* @tactic
             apply PrependCElementI(#view, #outerLoopReadPos, (#fCount - #fLeft), #doneElList, #doneElLength, #fLeft, #remElList, #remElLength);
-            assert IElement(#view, #outerLoopReadPos, #fCount, #fList, #remElsLength);
-            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
+            assert IElement(#view, #outerLoopReadPos, #fCount; #fList, #remElsLength);
+            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength);
             apply PrependCElementsE(#definition, #view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #eLeft, #remElsList, #remElsLength)
         */
         return false
@@ -171,17 +171,17 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
     }
 
     /* @tactic
-        unfold CElement(#view, #innerLoopReadPos, #fLeft, #remElList, #remElLength);
+        unfold CElement(#view, #innerLoopReadPos, #fLeft; #remElList, #remElLength);
         apply CElementsAppend(#view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #doneElList, #doneElLength) */
     elements.push(element);
   }
 
   /* @tactic
-      unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
+      unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength);
       if (#definition = "Complete") then {
-          unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength)
+          unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount; #remElsList, #remElsLength)
       } else {
-          unfold IElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength)
+          unfold IElements(#view, #outerLoopReadPos, #eLeft, #fCount; #remElsList, #remElsLength)
       } */
   return { elements, readPos }
 }
@@ -200,31 +200,31 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
     @onlyspec EncryptedDataKey (edk)
     [[
         (edk == #edk) *
-        JSObject(#edk) *
-        DataProp(#edk, "providerId", #pId) * types(#pId : Str) *
-        DataProp(#edk, "providerInfo", #pInfo) * types(#pInfo : Str) *
-        DataProp(#edk, "encryptedDataKey", #aEDK) *
-            Uint8Array (#aEDK, #abEDK, 0, #viewSizeEDK) *
-            ArrayBuffer(#abEDK, #encryptedDataKey) *
+        JSObject(#edk;) *
+        DataProp(#edk, "providerId"; #pId) * types(#pId : Str) *
+        DataProp(#edk, "providerInfo"; #pInfo) * types(#pInfo : Str) *
+        DataProp(#edk, "encryptedDataKey"; #aEDK) *
+            Uint8Array (#aEDK; #abEDK, 0, #viewSizeEDK) *
+            ArrayBuffer(#abEDK; #encryptedDataKey) *
             (#viewSizeEDK == l-len #encryptedDataKey) *
-        DataProp(#edk, "rawInfo", #aRInfo) *
-            Uint8Array (#aRInfo, #abRInfo, 0, #viewSizeRInfo) *
-            ArrayBuffer(#abRInfo, #rawInfo) *
+        DataProp(#edk, "rawInfo"; #aRInfo) *
+            Uint8Array (#aRInfo; #abRInfo, 0, #viewSizeRInfo) *
+            ArrayBuffer(#abRInfo; #rawInfo) *
             (#viewSizeRInfo == l-len #rawInfo) *
-        JSObjWithProto (this, $l_edk_proto)
+        JSObjWithProto (this; $l_edk_proto)
     ]]
     [[
-        JSObject(#edk) *
-        DataProp(#edk, "providerId", #pId) *
-        DataProp(#edk, "providerInfo", #pInfo) *
-        DataProp(#edk, "encryptedDataKey", #aEDK) *
-            Uint8Array (#aEDK, #abEDK, 0, #viewSizeEDK) *
-            ArrayBuffer(#abEDK, #encryptedDataKey) *
-        DataProp(#edk, "rawInfo", #aRInfo) *
-            Uint8Array (#aRInfo, #abRInfo, 0, #viewSizeRInfo) *
-            ArrayBuffer(#abRInfo, #rawInfo) *
+        JSObject(#edk;) *
+        DataProp(#edk, "providerId"; #pId) *
+        DataProp(#edk, "providerInfo"; #pInfo) *
+        DataProp(#edk, "encryptedDataKey"; #aEDK) *
+            Uint8Array (#aEDK; #abEDK, 0, #viewSizeEDK) *
+            ArrayBuffer(#abEDK; #encryptedDataKey) *
+        DataProp(#edk, "rawInfo"; #aRInfo) *
+            Uint8Array (#aRInfo; #abRInfo, 0, #viewSizeRInfo) *
+            ArrayBuffer(#abRInfo; #rawInfo) *
 
-        EncryptedDataKey(this, #pId, #pInfo, #encryptedDataKey, #rawInfo) *
+        EncryptedDataKey(this; #pId, #pInfo, #encryptedDataKey, #rawInfo) *
         (ret == this)
     ]]
     normal
@@ -245,13 +245,13 @@ var EncryptedDataKey = function (edk) { };
    @onlyspec toUtf8 (buffer)
        [[
            (buffer == #buffer) *
-           Uint8Array (#buffer, #ab, 0, #length) *
-           ArrayBuffer(#ab, #element)
+           Uint8Array (#buffer; #ab, 0, #length) *
+           ArrayBuffer(#ab; #element)
        ]]
        [[
-           Uint8Array (#buffer, #ab, 0, #length) *
-           ArrayBuffer(#ab, #element) *
-           toUtf8(#element, ret)
+           Uint8Array (#buffer; #ab, 0, #length) *
+           ArrayBuffer(#ab; #element) *
+           toUtf8(#element; ret)
        ]]
        normal
 */
@@ -268,60 +268,60 @@ var toUtf8 = function (buffer) { };
 /**
 
     @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List;) :
-        (definition == "Complete") * Unique(lst1),
-        (definition == "Broken") * Duplicated(lst2, lst3);
+        (definition == "Complete") * Unique(lst1;),
+        (definition == "Broken") * Duplicated(lst2, lst3;);
 
     @id decodeEncryptionContext
 
     @pre (this == undefined) * (encodedEncryptionContext == #eEC) *
-         Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
+         Uint8Array(#eEC; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
          (#EC == l-sub(#data, #byteOffset, #byteLength)) *
          (#definition == "Complete") *
-         RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
+         RawEncryptionContext(#EC; #definition, #ECKs, #errorMessage) *
 
-         scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-         scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-         JSInternals()
+         scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+         scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+         JSInternals(;)
 
-    @post Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
-          RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
+    @post Uint8Array(#eEC; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
+          RawEncryptionContext(#EC; #definition, #ECKs, #errorMessage) *
 
-          DecodedEncryptionContext(ret, #ECKs) *
+          DecodedEncryptionContext(ret, #ECKs;) *
 
-          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-          scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-          JSInternals ()
+          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+          JSInternals (;)
 
     @pre (this == undefined) * (encodedEncryptionContext == #eEC) *
-         Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
+         Uint8Array(#eEC; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
          (#EC == l-sub(#data, #byteOffset, #byteLength)) *
          (#definition == "Broken") *
-         RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
+         RawEncryptionContext(#EC; #definition, #ECKs, #errorMessage) *
 
-         scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-         scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-         JSInternals()
+         scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+         scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+         JSInternals(;)
 
     @posterr
-          Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
-          RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
+          Uint8Array(#eEC; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
+          RawEncryptionContext(#EC; #definition, #ECKs, #errorMessage) *
 
-          ErrorObjectWithMessage(ret, #errorMessage) *
+          ErrorObjectWithMessage(ret; #errorMessage) *
 
-          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-          scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-          JSInternals ()
+          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+          JSInternals (;)
 */
 function decodeEncryptionContext(encodedEncryptionContext) {
   /* @tactic
       if (#definition = "Complete") then {
-        unfold CRawEncryptionContext(#EC, #ECKs)
+        unfold CRawEncryptionContext(#EC; #ECKs)
       } else {
-        unfold BRawEncryptionContext(#EC, #errorMessage, #ECKs)
+        unfold BRawEncryptionContext(#EC; #errorMessage, #ECKs)
       }
    */
 
@@ -362,43 +362,43 @@ function decodeEncryptionContext(encodedEncryptionContext) {
     @tactic
         assert (
             (#EC == l+ ({{ #b0, #b1 }}, #rest)) *
-            Elements(#EC, 2, ((256 * #b0) + #b1), 2, "Complete", #ECKs, l-len #rest)
+            Elements(#EC, 2, ((256 * #b0) + #b1), 2; "Complete", #ECKs, l-len #rest)
         ) [bind: #b0, #b1, #rest];
-        unfold Elements(#EC, 2, ((256 * #b0) + #b1), 2, "Complete", #ECKs, l-len #rest);
+        unfold Elements(#EC, 2, ((256 * #b0) + #b1), 2; "Complete", #ECKs, l-len #rest);
         assert (
             scope(pairsCount: #pairsCount) * (#pairsCount == l-len #ECKs) *
-            scope(elements: #elements) * ArrayOfArraysOfUInt8Arrays(#elements, #ECKs) *
-            scope(encryptionContext: #dECObj) * JSObjWithProto(#dECObj, null) * empty_fields(#dECObj : -{ }-) *
-            toUtf8PairMap(#ECKs, #utf8ECKs) * FirstProj(#ECKs, #rProps) * UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps)
+            scope(elements: #elements) * ArrayOfArraysOfUInt8Arrays(#elements; #ECKs) *
+            scope(encryptionContext: #dECObj) * JSObjWithProto(#dECObj; null) * empty_fields(#dECObj : -{ }-) *
+            toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) * UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;)
         ) [bind: #pairsCount, #elements, #dECObj, #utf8ECKs, #rProps]
 
     @invariant
         scope(pairsCount: #pairsCount) * scope(elements: #elements) * scope(encryptionContext: #dECObj) *
-        scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-        scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
+        scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+        scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
         scope(key: _) * scope(value: _) *
-        toUtf8PairMap(#ECKs, #utf8ECKs) * FirstProj(#ECKs, #rProps) *
-        CElements(#EC, 2., ((256. * #b0) + #b1), 2., #ECKs, (l-len #rest)) *
-        UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps) *
-        JSInternals() *
+        toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) *
+        CElements(#EC, 2., ((256. * #b0) + #b1), 2.; #ECKs, (l-len #rest)) *
+        UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;) *
+        JSInternals(;) *
 
         scope(count: #count) * (#count <=# #pairsCount) *
-        ArrayStructure(#elements, #pairsCount) *
-        ArrayOfArraysOfUInt8ArraysContents(#elements, 0, #count, #done) *
-        ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left) *
+        ArrayStructure(#elements, #pairsCount;) *
+        ArrayOfArraysOfUInt8ArraysContents(#elements, 0, #count; #done) *
+        ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left) *
         (#ECKs == l+ (#done, #left)) *
-        FirstProj(#done, #doneRProps) * Unique(#doneRProps) *
-        FirstProj(#left, #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps) *
-        toUtf8PairMap(#done, #utf8Done) *
-        JSObjWithProto(#dECObj, null) * ObjectTable(#dECObj, #utf8Done)
+        FirstProj(#done; #doneRProps) * Unique(#doneRProps;) *
+        FirstProj(#left; #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;) *
+        toUtf8PairMap(#done; #utf8Done) *
+        JSObjWithProto(#dECObj; null) * ObjectTable(#dECObj, #utf8Done;)
         [bind: #count, #done, #left, #doneRProps, #leftRProps, #utf8Done] */
   for (var count = 0; count < pairsCount; count++) {
     /*
         @tactic
-            unfold ArrayStructure(#elements, #pairsCount);
-            unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps);
-            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
-            unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
+            unfold ArrayStructure(#elements, #pairsCount;);
+            unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;);
+            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;);
+            unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
             apply CElementsElementLength(#EC, 2., ((256. * #b0) + #b1), 2., #ECKs, #done, #ECK, #rest_left);
             assert (#ECK == {{ #new_prop, #new_value }})
     */
@@ -411,13 +411,13 @@ function decodeEncryptionContext(encodedEncryptionContext) {
      */
     /*
         @tactic
-            assert (toUtf8(#new_prop, #utf8NProp)) [bind: #utf8NProp];
-            assert (toUtf8(#new_value, #utf8NVal)) [bind: #utf8NVal];
-            unfold ObjectTable(#dECObj, #utf8Done) [bind: (#doneProps := #pList) and (#donePropsSet := #pSet)];
+            assert (toUtf8(#new_prop; #utf8NProp)) [bind: #utf8NProp];
+            assert (toUtf8(#new_value; #utf8NVal)) [bind: #utf8NVal];
+            unfold ObjectTable(#dECObj, #utf8Done;) [bind: (#doneProps := #pList) and (#donePropsSet := #pSet)];
             apply FirstProjConcatSplit(#ECKs, #done, #left);
             apply ProduceListToSet(#doneRProps); apply ProduceListToSet(#leftRProps);
-            assert (ListToSet(#doneRProps, #doneRPropsSet)) [bind: #doneRPropsSet];
-            unfold FirstProj(#left, #leftRProps);
+            assert (ListToSet(#doneRProps; #doneRPropsSet)) [bind: #doneRPropsSet];
+            unfold FirstProj(#left; #leftRProps);
             apply HeadInSet(#leftRProps);
             if (#definition = "Complete") then {
                 apply UniqueConcatSplitNotInSuffix(#rProps, #doneRProps, #leftRProps, #new_prop);
@@ -426,7 +426,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
                 apply ObjectTableAbsentProperty(#dECObj, #utf8Done, #utf8NProp)
             } else {
                 apply FirstProjToUtf8MapPairCompat(#done);
-                unfold Duplicated(#doneRProps, #leftRProps) [bind: (#doneRPropsSet2 := #preSet)];
+                unfold Duplicated(#doneRProps, #leftRProps;) [bind: (#doneRPropsSet2 := #preSet)];
                 apply ListToSetFunction(#doneRProps, #doneRPropsSet, #doneRProps, #doneRPropsSet2);
                 if (#new_prop -e- #doneRPropsSet) then {
                     apply InListToUtf8(#new_prop, #doneRProps);
@@ -453,7 +453,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
             apply ListToSetAddElement(#doneProps, #donePropsSet, #utf8NProp);
             apply UniqueAppendElement(#doneRProps, #new_prop);
             if (#definition = "Complete") then {
-                unfold Unique(#leftRProps)
+                unfold Unique(#leftRProps;)
             }
     */
     0 === 0;
@@ -461,12 +461,12 @@ function decodeEncryptionContext(encodedEncryptionContext) {
 
   /*
     @tactic
-        unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left);
+        unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left);
         apply toUtf8PairMapInjective(#ECKs, #utf8ECKs, #done, #utf8Done);
         if (#definition = "Broken") then {
-            unfold FirstProj(#left, #leftRProps);
-            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
-            unfold Duplicated(#doneRProps, #leftRProps)
+            unfold FirstProj(#left; #leftRProps);
+            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;);
+            unfold Duplicated(#doneRProps, #leftRProps;)
         };
         use_subst [object_table : (#PVPairs: #utf8ECKs) ]
   */
@@ -486,70 +486,70 @@ function decodeEncryptionContext(encodedEncryptionContext) {
     @id deserializeEncryptedDataKeys
 
     @pre (this == undefined) * (buffer == #buffer) * (startPos == #startPos) *
-         Uint8Array(#buffer, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
+         Uint8Array(#buffer; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
          (#view == l-sub(#data, #byteOffset, #byteLength)) *
          ((#definition == "Complete") \/ (#definition == "Incomplete")) *
-         RawEncryptedDataKeys(#view, #startPos, #definition, #EDKs, #EDKsLength, #errorMessage) *
+         RawEncryptedDataKeys(#view, #startPos; #definition, #EDKs, #EDKsLength, #errorMessage) *
 
-         scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-         scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-         JSInternals()
+         scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+         scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+         JSInternals(;)
 
-    @post Uint8Array(#buffer, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
+    @post Uint8Array(#buffer; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
           (#view == l-sub(#data, #byteOffset, #byteLength)) *
-          RawEncryptedDataKeys(#view, #startPos, #definition, #EDKs, #EDKsLength, #errorMessage) *
+          RawEncryptedDataKeys(#view, #startPos; #definition, #EDKs, #EDKsLength, #errorMessage) *
 
           (#definition == "Complete") *
-          JSObject(ret) *
-            DataProp(ret, "encryptedDataKeys", #dEDKs) *
-                DeserialisedEncryptedDataKeys(#dEDKs, #EDKs) *
-            DataProp(ret, "readPos", #startPos + #EDKsLength) *
+          JSObject(ret;) *
+            DataProp(ret, "encryptedDataKeys"; #dEDKs) *
+                DeserialisedEncryptedDataKeys(#dEDKs; #EDKs) *
+            DataProp(ret, "readPos"; #startPos + #EDKsLength) *
 
-          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-          scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-          JSInternals ();
+          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+          JSInternals (;);
 
-          Uint8Array(#buffer, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
+          Uint8Array(#buffer; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
           (#view == l-sub(#data, #byteOffset, #byteLength)) *
-          RawEncryptedDataKeys(#view, #startPos, #definition, #EDKs, #EDKsLength, #errorMessage) *
+          RawEncryptedDataKeys(#view, #startPos; #definition, #EDKs, #EDKsLength, #errorMessage) *
 
           (#definition == "Incomplete") * (ret == false) *
 
-          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-          scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-          JSInternals ()
+          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+          JSInternals (;)
 
     @pre (this == undefined) * (buffer == #buffer) * (startPos == #startPos) *
-         Uint8Array(#buffer, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
+         Uint8Array(#buffer; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
          (#view == l-sub(#data, #byteOffset, #byteLength)) *
          (#definition == "Broken") *
-         RawEncryptedDataKeys(#view, #startPos, #definition, #EDKs, #EDKsLength, #errorMessage) *
+         RawEncryptedDataKeys(#view, #startPos; #definition, #EDKs, #EDKsLength, #errorMessage) *
 
-         scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-         JSInternals()
+         scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+         JSInternals(;)
 
     @posterr
-          Uint8Array(#buffer, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
-          RawEncryptedDataKeys(#view, #startPos, #definition, #EDKs, #EDKsLength, #errorMessage) *
+          Uint8Array(#buffer; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
+          RawEncryptedDataKeys(#view, #startPos; #definition, #EDKs, #EDKsLength, #errorMessage) *
 
-          ErrorObjectWithMessage(ret, #errorMessage) *
+          ErrorObjectWithMessage(ret; #errorMessage) *
 
-          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-          JSInternals ()
+          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+          JSInternals (;)
 */
 function deserializeEncryptedDataKeys(buffer, startPos) {
   /* @tactic
-      unfold RawEncryptedDataKeys(#view, #startPos, #definition, #EDKs, #EDKsLength, #errorMessage);
+      unfold RawEncryptedDataKeys(#view, #startPos; #definition, #EDKs, #EDKsLength, #errorMessage);
       if (#definition = "Complete") then {
-        unfold CRawEncryptedDataKeys(#view, #startPos, #EDKs, #EDKsLength)
+        unfold CRawEncryptedDataKeys(#view, #startPos; #EDKs, #EDKsLength)
       } else {
           if (#definition = "Incomplete") then {
-            unfold IRawEncryptedDataKeys(#view, #startPos)
+            unfold IRawEncryptedDataKeys(#view, #startPos;)
           } else {
-            unfold BRawEncryptedDataKeys(#view, #startPos, #errorMessage)
+            unfold BRawEncryptedDataKeys(#view, #startPos; #errorMessage)
           }
       } */
 
@@ -595,18 +595,18 @@ function deserializeEncryptedDataKeys(buffer, startPos) {
         @id aux_deserializeEncryptedDataKey
 
         @pre (element == #element) *
-             ArrayOfUInt8Arrays (#element, {{ #rawId, #rawInfo, #encryptedDataKey }}, 3) *
-             scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-             scope(EncryptedDataKey: #EncryptedDataKey) * JSFunctionObject(#EncryptedDataKey, "EncryptedDataKey", #e_sc, #e_len, $l_edk_proto) *
-             GlobalObject()
+             ArrayOfUInt8Arrays (#element; {{ #rawId, #rawInfo, #encryptedDataKey }}, 3) *
+             scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+             scope(EncryptedDataKey: #EncryptedDataKey) * JSFunctionObject(#EncryptedDataKey; "EncryptedDataKey", #e_sc, #e_len, $l_edk_proto) *
+             GlobalObject(;)
 
-        @post ArrayOfUInt8Arrays (#element, {{ #rawId, #rawInfo, #encryptedDataKey }}, 3) *
-              scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-              scope(EncryptedDataKey: #EncryptedDataKey) * JSFunctionObject(#EncryptedDataKey, "EncryptedDataKey", #e_sc, #e_len, $l_edk_proto) *
-              GlobalObject() *
+        @post ArrayOfUInt8Arrays (#element; {{ #rawId, #rawInfo, #encryptedDataKey }}, 3) *
+              scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+              scope(EncryptedDataKey: #EncryptedDataKey) * JSFunctionObject(#EncryptedDataKey; "EncryptedDataKey", #e_sc, #e_len, $l_edk_proto) *
+              GlobalObject(;) *
 
-              toUtf8(#rawId, #pId) * toUtf8(#rawInfo, #pInfo) *
-              EncryptedDataKey(ret, #pId, #pInfo, #encryptedDataKey, #rawInfo)
+              toUtf8(#rawId; #pId) * toUtf8(#rawInfo; #pInfo) *
+              EncryptedDataKey(ret; #pId, #pInfo, #encryptedDataKey, #rawInfo)
     */
     element => {
       /* Implement the array deconstructor */
@@ -647,11 +647,11 @@ var AlgorithmSuiteIdentifier;
 /*
     @onlyspec SdkSuite (suiteId)
         [[
-            JSObject(this) * ((this, "ivLength") -> none) * ((this, "tagLength") -> none) *
-            CAlgorithmSuite(suiteId, #stringId, #ivLength, #tagLength)
+            JSObject(this;) * ((this, "ivLength") -> none) * ((this, "tagLength") -> none) *
+            CAlgorithmSuite(suiteId; #stringId, #ivLength, #tagLength)
         ]]
         [[
-            AlgorithmSuiteObject(this, #ivLength, #tagLength) *
+            AlgorithmSuiteObject(this; #ivLength, #tagLength) *
             (ret == this)
         ]]
         normal
@@ -670,47 +670,47 @@ var SdkSuite = function (suiteId) { };
     @id deserializeMessageHeader
 
     @pre (messageBuffer == #messageBuffer) *
-         Uint8Array(#messageBuffer, #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer, #data) *
+         Uint8Array(#messageBuffer; #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer; #data) *
          (#view == l-sub(#data, #byteOffset, #byteLength)) *
          (#byteOffset + #byteLength <=# l-len #data) *
          ((#definition == "Complete") \/ (#definition == "Incomplete")) *
-         Header(#view,
+         Header(#view;
                 #definition, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
                        #part_two, #ECKs,
                        #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag,
                 #errorMessage) *
 
-         scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-         scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject) *
-         scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject, "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
-         scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject, "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
-         scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-         scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject, "SdkSuite", #s_sc, #s_len, $lobj_proto) *
-         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-         JSInternals ()
+         scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+         scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject;) *
+         scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject; "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
+         scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject; "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
+         scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+         scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject; "SdkSuite", #s_sc, #s_len, $lobj_proto) *
+         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+         JSInternals (;)
 
-    @post Uint8Array(#messageBuffer, #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer, #data) *
-          Header(#view,
+    @post Uint8Array(#messageBuffer; #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer; #data) *
+          Header(#view;
                  #definition, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
                         #part_two, #ECKs,
                         #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag,
                  #errorMessage) *
 
           (#definition == "Complete") *
-          HeaderInfo(ret, #ECKs, #version, #type, #suiteId, #messageId, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #rawHeaderData, #headerIv, #headerAuthTag) *
+          HeaderInfo(ret, #ECKs; #version, #type, #suiteId, #messageId, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #rawHeaderData, #headerIv, #headerAuthTag) *
           (#rawHeaderData == l-sub(#view, 0, #headerLength)) *
 
-          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-          scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject) *
-          scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject, "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
-          scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject, "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
-          scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-          scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject, "SdkSuite", #s_sc, #s_len, $lobj_proto) *
-          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-          JSInternals();
+          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+          scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject;) *
+          scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject; "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
+          scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject; "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
+          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+          scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject; "SdkSuite", #s_sc, #s_len, $lobj_proto) *
+          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+          JSInternals(;);
 
-          Uint8Array(#messageBuffer, #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer, #data) *
-          Header(#view,
+          Uint8Array(#messageBuffer; #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer; #data) *
+          Header(#view;
                  #definition, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
                         #part_two, #ECKs,
                         #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag,
@@ -718,52 +718,52 @@ var SdkSuite = function (suiteId) { };
 
           (definition == "Incomplete") * (ret == false) *
 
-          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-          scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject) *
-          scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject, "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
-          scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject, "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
-          scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-          scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject, "SdkSuite", #s_sc, #s_len, $lobj_proto) *
-          JSInternals()
+          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+          scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject;) *
+          scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject; "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
+          scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject; "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
+          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+          scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject; "SdkSuite", #s_sc, #s_len, $lobj_proto) *
+          JSInternals(;)
 
     @pre (messageBuffer == #messageBuffer) *
-         Uint8Array(#messageBuffer, #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer, #data) *
+         Uint8Array(#messageBuffer; #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer; #data) *
          (#view == l-sub(#data, #byteOffset, #byteLength)) *
          (#byteOffset + #byteLength <=# l-len #data) *
          (#definition == "Broken") *
-         Header(#view,
+         Header(#view;
                 #definition, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
                        #part_two, #ECKs,
                        #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag,
                 #errorMessage) *
 
-         scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-         scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject) *
-         scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject, "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
-         scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject, "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
-         scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-         scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject, "SdkSuite", #s_sc, #s_len, $lobj_proto) *
-         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-         JSInternals ()
+         scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+         scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject;) *
+         scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject; "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
+         scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject; "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
+         scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+         scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject; "SdkSuite", #s_sc, #s_len, $lobj_proto) *
+         scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+         JSInternals (;)
 
     @posterr
-          Uint8Array(#messageBuffer, #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer, #data) *
-          Header(#view,
+          Uint8Array(#messageBuffer; #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer; #data) *
+          Header(#view;
                  #definition, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
                         #part_two, #ECKs,
                         #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag,
                  #errorMessage) *
 
-          ErrorObjectWithMessage(ret, #errorMessage) *
+          ErrorObjectWithMessage(ret; #errorMessage) *
 
-          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
-          scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject) *
-          scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject, "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
-          scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject, "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
-          scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
-          scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject, "SdkSuite", #s_sc, #s_len, $lobj_proto) *
-          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
-          JSInternals()
+          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
+          scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject;) *
+          scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject; "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
+          scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject; "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
+          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
+          scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject; "SdkSuite", #s_sc, #s_len, $lobj_proto) *
+          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
+          JSInternals(;)
 */
 function deserializeMessageHeader(messageBuffer) {
   /* Uint8Array is a view on top of the underlying ArrayBuffer.
@@ -778,15 +778,15 @@ function deserializeMessageHeader(messageBuffer) {
     messageBuffer.byteLength
   )
 
-  /* @tactic unfold Header(#view, #definition, #part_one, #version, #type, #suiteId, #messageId, #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag, #errorMessage) */
+  /* @tactic unfold Header(#view; #definition, #part_one, #version, #type, #suiteId, #messageId, #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag, #errorMessage) */
   /* @tactic
       if (#definition = "Complete") then {
-        unfold CHeader(#view, #part_one, #version, #type, #suiteId, #messageId, #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag)
+        unfold CHeader(#view; #part_one, #version, #type, #suiteId, #messageId, #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag)
           [bind: (#stringId := #stringId) and (#tagLength := #tagLength)]
       } else { if (#definition = "Incomplete") then {
-          unfold IHeader(#view, #part_one, #version, #type, #suiteId, #messageId, #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag)
+          unfold IHeader(#view; #part_one, #version, #type, #suiteId, #messageId, #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag)
         } else {
-          unfold BHeader(#view, #part_one, #version, #type, #suiteId, #messageId, #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag, #errorMessage)
+          unfold BHeader(#view; #part_one, #version, #type, #suiteId, #messageId, #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag, #errorMessage)
         }
       } */
 

--- a/Gillian-JS/Examples/Amazon/deserialize_factory.js
+++ b/Gillian-JS/Examples/Amazon/deserialize_factory.js
@@ -48,7 +48,7 @@ function needs(condition, errorMessage) {
       Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
 
       scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals (;)
+      JSInternals ()
 
     @post
       (#definition == "Complete") *
@@ -56,9 +56,9 @@ function needs(condition, errorMessage) {
       ArrayBuffer(#ab; #data) *
       Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
       scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals (;) *
+      JSInternals () *
 
-      JSObject(ret;) *
+      JSObject(ret) *
         DataProp(ret, "elements"; #elements) *
             ArrayOfArraysOfUInt8Arrays(#elements; #eList) *
         DataProp(ret, "readPos"; #ret_readPos) *
@@ -70,7 +70,7 @@ function needs(condition, errorMessage) {
       Elements(#view, #readPos, #eCount, #fCount; #definition, #eList, #esLength) *
 
       scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-      JSInternals (;) *
+      JSInternals () *
 
       (ret == false)
 */
@@ -93,7 +93,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
       scope(elements : #doneEls) * scope(readPos : #outerLoopReadPos) *
       scope(elementCount : #eLeft) * scope(fieldsPerElement: #fCount) *
       scope(element: _) * scope(fieldCount: _) * scope(fieldBinary: _) * scope(length: _) *
-      JSInternals(;) *
+      JSInternals() *
 
       CElements(#view, #readPos, #eCount - #eLeft, #fCount; #doneElsList, #doneElsLength) *
       Elements(#view, #outerLoopReadPos, #eLeft, #fCount; #definition, #remElsList, #remElsLength) *
@@ -118,7 +118,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
         scope(dataView: #dataView) * DataView(#dataView; #ab, #viewOffset, #viewSize) *
         scope(element : #doneEl) * scope(readPos : #innerLoopReadPos) * scope(fieldCount : #fLeft) *
         scope(fieldBinary: _) * scope(length: _) *
-        JSInternals(;) *
+        JSInternals() *
 
         CElement(#view, #outerLoopReadPos, #fCount - #fLeft; #doneElList, #doneElLength) *
         (#fList == l+ (#doneElList, #remElList)) *
@@ -200,7 +200,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
     @onlyspec EncryptedDataKey (edk)
     [[
         (edk == #edk) *
-        JSObject(#edk;) *
+        JSObject(#edk) *
         DataProp(#edk, "providerId"; #pId) * types(#pId : Str) *
         DataProp(#edk, "providerInfo"; #pInfo) * types(#pInfo : Str) *
         DataProp(#edk, "encryptedDataKey"; #aEDK) *
@@ -214,7 +214,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
         JSObjWithProto (this; $l_edk_proto)
     ]]
     [[
-        JSObject(#edk;) *
+        JSObject(#edk) *
         DataProp(#edk, "providerId"; #pId) *
         DataProp(#edk, "providerInfo"; #pInfo) *
         DataProp(#edk, "encryptedDataKey"; #aEDK) *
@@ -267,9 +267,9 @@ var toUtf8 = function (buffer) { };
 
 /**
 
-    @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List;) :
-        (definition == "Complete") * Unique(lst1;),
-        (definition == "Broken") * Duplicated(lst2, lst3;);
+    @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List) :
+        (definition == "Complete") * Unique(lst1),
+        (definition == "Broken") * Duplicated(lst2, lst3);
 
     @id decodeEncryptionContext
 
@@ -282,17 +282,17 @@ var toUtf8 = function (buffer) { };
          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
-         JSInternals(;)
+         JSInternals()
 
     @post Uint8Array(#eEC; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
           RawEncryptionContext(#EC; #definition, #ECKs, #errorMessage) *
 
-          DecodedEncryptionContext(ret, #ECKs;) *
+          DecodedEncryptionContext(ret, #ECKs) *
 
           scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
           scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
           scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
-          JSInternals (;)
+          JSInternals ()
 
     @pre (this == undefined) * (encodedEncryptionContext == #eEC) *
          Uint8Array(#eEC; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
@@ -303,7 +303,7 @@ var toUtf8 = function (buffer) { };
          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
-         JSInternals(;)
+         JSInternals()
 
     @posterr
           Uint8Array(#eEC; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
@@ -314,7 +314,7 @@ var toUtf8 = function (buffer) { };
           scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
           scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
           scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
-          JSInternals (;)
+          JSInternals ()
 */
 function decodeEncryptionContext(encodedEncryptionContext) {
   /* @tactic
@@ -369,7 +369,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
             scope(pairsCount: #pairsCount) * (#pairsCount == l-len #ECKs) *
             scope(elements: #elements) * ArrayOfArraysOfUInt8Arrays(#elements; #ECKs) *
             scope(encryptionContext: #dECObj) * JSObjWithProto(#dECObj; null) * empty_fields(#dECObj : -{ }-) *
-            toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) * UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;)
+            toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) * UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps)
         ) [bind: #pairsCount, #elements, #dECObj, #utf8ECKs, #rProps]
 
     @invariant
@@ -379,25 +379,25 @@ function decodeEncryptionContext(encodedEncryptionContext) {
         scope(key: _) * scope(value: _) *
         toUtf8PairMap(#ECKs; #utf8ECKs) * FirstProj(#ECKs; #rProps) *
         CElements(#EC, 2., ((256. * #b0) + #b1), 2.; #ECKs, (l-len #rest)) *
-        UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;) *
-        JSInternals(;) *
+        UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps) *
+        JSInternals() *
 
         scope(count: #count) * (#count <=# #pairsCount) *
-        ArrayStructure(#elements, #pairsCount;) *
+        ArrayStructure(#elements, #pairsCount) *
         ArrayOfArraysOfUInt8ArraysContents(#elements, 0, #count; #done) *
         ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left) *
         (#ECKs == l+ (#done, #left)) *
-        FirstProj(#done; #doneRProps) * Unique(#doneRProps;) *
-        FirstProj(#left; #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;) *
+        FirstProj(#done; #doneRProps) * Unique(#doneRProps) *
+        FirstProj(#left; #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps) *
         toUtf8PairMap(#done; #utf8Done) *
-        JSObjWithProto(#dECObj; null) * ObjectTable(#dECObj, #utf8Done;)
+        JSObjWithProto(#dECObj; null) * ObjectTable(#dECObj, #utf8Done)
         [bind: #count, #done, #left, #doneRProps, #leftRProps, #utf8Done] */
   for (var count = 0; count < pairsCount; count++) {
     /*
         @tactic
-            unfold ArrayStructure(#elements, #pairsCount;);
-            unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps;);
-            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;);
+            unfold ArrayStructure(#elements, #pairsCount);
+            unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps);
+            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
             unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count; #left) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
             apply CElementsElementLength(#EC, 2., ((256. * #b0) + #b1), 2., #ECKs, #done, #ECK, #rest_left);
             assert (#ECK == {{ #new_prop, #new_value }})
@@ -413,7 +413,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
         @tactic
             assert (toUtf8(#new_prop; #utf8NProp)) [bind: #utf8NProp];
             assert (toUtf8(#new_value; #utf8NVal)) [bind: #utf8NVal];
-            unfold ObjectTable(#dECObj, #utf8Done;) [bind: (#doneProps := #pList) and (#donePropsSet := #pSet)];
+            unfold ObjectTable(#dECObj, #utf8Done) [bind: (#doneProps := #pList) and (#donePropsSet := #pSet)];
             apply FirstProjConcatSplit(#ECKs, #done, #left);
             apply ProduceListToSet(#doneRProps); apply ProduceListToSet(#leftRProps);
             assert (ListToSet(#doneRProps; #doneRPropsSet)) [bind: #doneRPropsSet];
@@ -426,7 +426,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
                 apply ObjectTableAbsentProperty(#dECObj, #utf8Done, #utf8NProp)
             } else {
                 apply FirstProjToUtf8MapPairCompat(#done);
-                unfold Duplicated(#doneRProps, #leftRProps;) [bind: (#doneRPropsSet2 := #preSet)];
+                unfold Duplicated(#doneRProps, #leftRProps) [bind: (#doneRPropsSet2 := #preSet)];
                 apply ListToSetFunction(#doneRProps, #doneRPropsSet, #doneRProps, #doneRPropsSet2);
                 if (#new_prop -e- #doneRPropsSet) then {
                     apply InListToUtf8(#new_prop, #doneRProps);
@@ -453,7 +453,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
             apply ListToSetAddElement(#doneProps, #donePropsSet, #utf8NProp);
             apply UniqueAppendElement(#doneRProps, #new_prop);
             if (#definition = "Complete") then {
-                unfold Unique(#leftRProps;)
+                unfold Unique(#leftRProps)
             }
     */
     0 === 0;
@@ -465,8 +465,8 @@ function decodeEncryptionContext(encodedEncryptionContext) {
         apply toUtf8PairMapInjective(#ECKs, #utf8ECKs, #done, #utf8Done);
         if (#definition = "Broken") then {
             unfold FirstProj(#left; #leftRProps);
-            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps;);
-            unfold Duplicated(#doneRProps, #leftRProps;)
+            unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
+            unfold Duplicated(#doneRProps, #leftRProps)
         };
         use_subst [object_table : (#PVPairs: #utf8ECKs) ]
   */
@@ -494,14 +494,14 @@ function decodeEncryptionContext(encodedEncryptionContext) {
          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
-         JSInternals(;)
+         JSInternals()
 
     @post Uint8Array(#buffer; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
           (#view == l-sub(#data, #byteOffset, #byteLength)) *
           RawEncryptedDataKeys(#view, #startPos; #definition, #EDKs, #EDKsLength, #errorMessage) *
 
           (#definition == "Complete") *
-          JSObject(ret;) *
+          JSObject(ret) *
             DataProp(ret, "encryptedDataKeys"; #dEDKs) *
                 DeserialisedEncryptedDataKeys(#dEDKs; #EDKs) *
             DataProp(ret, "readPos"; #startPos + #EDKsLength) *
@@ -509,7 +509,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
           scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
           scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
           scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
-          JSInternals (;);
+          JSInternals ();
 
           Uint8Array(#buffer; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
           (#view == l-sub(#data, #byteOffset, #byteLength)) *
@@ -520,7 +520,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
           scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
           scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
           scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
-          JSInternals (;)
+          JSInternals ()
 
     @pre (this == undefined) * (buffer == #buffer) * (startPos == #startPos) *
          Uint8Array(#buffer; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
@@ -529,7 +529,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
          RawEncryptedDataKeys(#view, #startPos; #definition, #EDKs, #EDKsLength, #errorMessage) *
 
          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-         JSInternals(;)
+         JSInternals()
 
     @posterr
           Uint8Array(#buffer; #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer; #data) *
@@ -538,7 +538,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
           ErrorObjectWithMessage(ret; #errorMessage) *
 
           scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-          JSInternals (;)
+          JSInternals ()
 */
 function deserializeEncryptedDataKeys(buffer, startPos) {
   /* @tactic
@@ -547,7 +547,7 @@ function deserializeEncryptedDataKeys(buffer, startPos) {
         unfold CRawEncryptedDataKeys(#view, #startPos; #EDKs, #EDKsLength)
       } else {
           if (#definition = "Incomplete") then {
-            unfold IRawEncryptedDataKeys(#view, #startPos;)
+            unfold IRawEncryptedDataKeys(#view, #startPos)
           } else {
             unfold BRawEncryptedDataKeys(#view, #startPos; #errorMessage)
           }
@@ -598,12 +598,12 @@ function deserializeEncryptedDataKeys(buffer, startPos) {
              ArrayOfUInt8Arrays (#element; {{ #rawId, #rawInfo, #encryptedDataKey }}, 3) *
              scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
              scope(EncryptedDataKey: #EncryptedDataKey) * JSFunctionObject(#EncryptedDataKey; "EncryptedDataKey", #e_sc, #e_len, $l_edk_proto) *
-             GlobalObject(;)
+             GlobalObject()
 
         @post ArrayOfUInt8Arrays (#element; {{ #rawId, #rawInfo, #encryptedDataKey }}, 3) *
               scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
               scope(EncryptedDataKey: #EncryptedDataKey) * JSFunctionObject(#EncryptedDataKey; "EncryptedDataKey", #e_sc, #e_len, $l_edk_proto) *
-              GlobalObject(;) *
+              GlobalObject() *
 
               toUtf8(#rawId; #pId) * toUtf8(#rawInfo; #pInfo) *
               EncryptedDataKey(ret; #pId, #pInfo, #encryptedDataKey, #rawInfo)
@@ -647,7 +647,7 @@ var AlgorithmSuiteIdentifier;
 /*
     @onlyspec SdkSuite (suiteId)
         [[
-            JSObject(this;) * ((this, "ivLength") -> none) * ((this, "tagLength") -> none) *
+            JSObject(this) * ((this, "ivLength") -> none) * ((this, "tagLength") -> none) *
             CAlgorithmSuite(suiteId; #stringId, #ivLength, #tagLength)
         ]]
         [[
@@ -681,13 +681,13 @@ var SdkSuite = function (suiteId) { };
                 #errorMessage) *
 
          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-         scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject;) *
+         scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject) *
          scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject; "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
          scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject; "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
          scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject; "SdkSuite", #s_sc, #s_len, $lobj_proto) *
          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
-         JSInternals (;)
+         JSInternals ()
 
     @post Uint8Array(#messageBuffer; #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer; #data) *
           Header(#view;
@@ -701,13 +701,13 @@ var SdkSuite = function (suiteId) { };
           (#rawHeaderData == l-sub(#view, 0, #headerLength)) *
 
           scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-          scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject;) *
+          scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject) *
           scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject; "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
           scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject; "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
           scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
           scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject; "SdkSuite", #s_sc, #s_len, $lobj_proto) *
           scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
-          JSInternals(;);
+          JSInternals();
 
           Uint8Array(#messageBuffer; #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer; #data) *
           Header(#view;
@@ -719,12 +719,12 @@ var SdkSuite = function (suiteId) { };
           (definition == "Incomplete") * (ret == false) *
 
           scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-          scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject;) *
+          scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject) *
           scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject; "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
           scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject; "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
           scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
           scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject; "SdkSuite", #s_sc, #s_len, $lobj_proto) *
-          JSInternals(;)
+          JSInternals()
 
     @pre (messageBuffer == #messageBuffer) *
          Uint8Array(#messageBuffer; #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer; #data) *
@@ -738,13 +738,13 @@ var SdkSuite = function (suiteId) { };
                 #errorMessage) *
 
          scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-         scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject;) *
+         scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject) *
          scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject; "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
          scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject; "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
          scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
          scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject; "SdkSuite", #s_sc, #s_len, $lobj_proto) *
          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
-         JSInternals (;)
+         JSInternals ()
 
     @posterr
           Uint8Array(#messageBuffer; #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer; #data) *
@@ -757,13 +757,13 @@ var SdkSuite = function (suiteId) { };
           ErrorObjectWithMessage(ret; #errorMessage) *
 
           scope(needs : #needs) * JSFunctionObject(#needs; "needs", #n_sc, #n_len, #n_proto) *
-          scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject;) *
+          scope(AlgorithmSuiteIdentifier : #ASIObject) * AlgorithmSuiteIdentifierObject(#ASIObject) *
           scope(decodeEncryptionContext : #DECObject) * JSFunctionObject(#DECObject; "decodeEncryptionContext", #dc_sc, #dc_len, #dc_proto) *
           scope(deserializeEncryptedDataKeys : #DEDKObject) * JSFunctionObject(#DEDKObject; "deserializeEncryptedDataKeys", #ds_sc, #ds_len, #ds_proto) *
           scope(readElements : #readElements) * JSFunctionObject(#readElements; "readElements", #rE_sc, #rE_len, #rE_proto) *
           scope(SdkSuite : #SdkObject) * JSFunctionObject(#SdkObject; "SdkSuite", #s_sc, #s_len, $lobj_proto) *
           scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8; "toUtf8", #t_sc, #t_len, #t_proto) *
-          JSInternals(;)
+          JSInternals()
 */
 function deserializeMessageHeader(messageBuffer) {
   /* Uint8Array is a view on top of the underlying ArrayBuffer.

--- a/Gillian-JS/Examples/Amazon/deserialize_factory.js
+++ b/Gillian-JS/Examples/Amazon/deserialize_factory.js
@@ -35,7 +35,7 @@ function needs(condition, errorMessage) {
 /**
     @id readElements
 
-    @pred nounfold innerLoopInvariantFacts(+definition, +remElsList, +view, +innerLoopReadPos, +fLeft, +remElList, +eLength, +remElsLength, +doneElLength, remElLength) :
+    @pred nounfold innerLoopInvariantFacts(definition, remElsList, view, innerLoopReadPos, fLeft, remElList, eLength, remElsLength, doneElLength; remElLength) :
       (definition == "Complete") * CElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (eLength == doneElLength + remElLength),
       (definition == "Incomplete") * (remElsList == {{ }}) * IElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (remElsLength == doneElLength + remElLength),
       (definition == "Incomplete") * (! (remElsList == {{ }})) * CElement(view, innerLoopReadPos, fLeft, remElList, remElLength) * (eLength == doneElLength + remElLength);
@@ -267,7 +267,7 @@ var toUtf8 = function (buffer) { };
 
 /**
 
-    @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List) :
+    @pred nounfold UniqueOrDuplicated(definition:Str, lst1:List, lst2:List, lst3:List;) :
         (definition == "Complete") * Unique(lst1),
         (definition == "Broken") * Duplicated(lst2, lst3);
 

--- a/Gillian-JS/Examples/Amazon/deserialize_factory.js
+++ b/Gillian-JS/Examples/Amazon/deserialize_factory.js
@@ -45,7 +45,7 @@ function needs(condition, errorMessage) {
       Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
       ArrayBuffer(#ab, #data) *
       (#view == l-sub(#data, #viewOffset, #viewSize)) *
-      Elements(#definition, #view, #readPos, #eCount, #fCount, #eList, #esLength) *
+      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
 
       scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
       JSInternals ()
@@ -54,7 +54,7 @@ function needs(condition, errorMessage) {
       (#definition == "Complete") *
       Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
       ArrayBuffer(#ab, #data) *
-      Elements(#definition, #view, #readPos, #eCount, #fCount, #eList, #esLength) *
+      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
       scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
       JSInternals () *
 
@@ -67,7 +67,7 @@ function needs(condition, errorMessage) {
       (#definition == "Incomplete") *
       Uint8Array (#buffer, #ab, #viewOffset, #viewSize) *
       ArrayBuffer(#ab, #data) *
-      Elements(#definition, #view, #readPos, #eCount, #fCount, #eList, #esLength) *
+      Elements(#view, #readPos, #eCount, #fCount, #definition, #eList, #esLength) *
 
       scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
       JSInternals () *
@@ -96,7 +96,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
       JSInternals() *
 
       CElements(#view, #readPos, #eCount - #eLeft, #fCount, #doneElsList, #doneElsLength) *
-      Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength) *
+      Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength) *
       (#eList == l+ (#doneElsList, #remElsList)) *
       (#esLength == #doneElsLength + #remElsLength) *
       (#readPos + #doneElsLength == #outerLoopReadPos) *
@@ -104,7 +104,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
       [bind : #doneEls, #outerLoopReadPos, #eLeft, #remElsList, #remElsLength, #doneElsList, #doneElsLength] */
   while (elementCount--) {
     /* @tactic
-        unfold Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength);
+        unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
         if (#definition = "Complete") then {
             unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength) [bind: (#fList := #element) and (#eLength := #eLength)]
         } else {
@@ -141,7 +141,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
         /* @tactic
             apply PrependCElementI(#view, #outerLoopReadPos, (#fCount - #fLeft), #doneElList, #doneElLength, #fLeft, #remElList, #remElLength);
             assert IElement(#view, #outerLoopReadPos, #fCount, #fList, #remElsLength);
-            assert Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength);
+            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
             apply PrependCElementsE(#definition, #view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #eLeft, #remElsList, #remElsLength)
         */
         return false
@@ -153,7 +153,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
         /* @tactic
             apply PrependCElementI(#view, #outerLoopReadPos, (#fCount - #fLeft), #doneElList, #doneElLength, #fLeft, #remElList, #remElLength);
             assert IElement(#view, #outerLoopReadPos, #fCount, #fList, #remElsLength);
-            assert Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength);
+            assert Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
             apply PrependCElementsE(#definition, #view, #readPos, (#eCount - #eLeft), #fCount, #doneElsList, #doneElsLength, #eLeft, #remElsList, #remElsLength)
         */
         return false
@@ -177,7 +177,7 @@ function readElements(elementCount, fieldsPerElement, buffer, readPos) {
   }
 
   /* @tactic
-      unfold Elements(#definition, #view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength);
+      unfold Elements(#view, #outerLoopReadPos, #eLeft, #fCount, #definition, #remElsList, #remElsLength);
       if (#definition = "Complete") then {
           unfold CElements(#view, #outerLoopReadPos, #eLeft, #fCount, #remElsList, #remElsLength)
       } else {
@@ -277,7 +277,7 @@ var toUtf8 = function (buffer) { };
          Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
          (#EC == l-sub(#data, #byteOffset, #byteLength)) *
          (#definition == "Complete") *
-         RawEncryptionContext(#definition, #EC, #ECKs, #errorMessage) *
+         RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
 
          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
          scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
@@ -285,7 +285,7 @@ var toUtf8 = function (buffer) { };
          JSInternals()
 
     @post Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
-          RawEncryptionContext(#definition, #EC, #ECKs, #errorMessage) *
+          RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
 
           DecodedEncryptionContext(ret, #ECKs) *
 
@@ -298,7 +298,7 @@ var toUtf8 = function (buffer) { };
          Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
          (#EC == l-sub(#data, #byteOffset, #byteLength)) *
          (#definition == "Broken") *
-         RawEncryptionContext(#definition, #EC, #ECKs, #errorMessage) *
+         RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
 
          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
          scope(readElements : #readElements) * JSFunctionObject(#readElements, "readElements", #rE_sc, #rE_len, #rE_proto) *
@@ -307,7 +307,7 @@ var toUtf8 = function (buffer) { };
 
     @posterr
           Uint8Array(#eEC, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
-          RawEncryptionContext(#definition, #EC, #ECKs, #errorMessage) *
+          RawEncryptionContext(#EC, #definition, #ECKs, #errorMessage) *
 
           ErrorObjectWithMessage(ret, #errorMessage) *
 
@@ -321,7 +321,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
       if (#definition = "Complete") then {
         unfold CRawEncryptionContext(#EC, #ECKs)
       } else {
-        unfold BRawEncryptionContext(#errorMessage, #EC, #ECKs)
+        unfold BRawEncryptionContext(#EC, #errorMessage, #ECKs)
       }
    */
 
@@ -362,9 +362,9 @@ function decodeEncryptionContext(encodedEncryptionContext) {
     @tactic
         assert (
             (#EC == l+ ({{ #b0, #b1 }}, #rest)) *
-            Elements("Complete", #EC, 2, ((256 * #b0) + #b1), 2, #ECKs, l-len #rest)
+            Elements(#EC, 2, ((256 * #b0) + #b1), 2, "Complete", #ECKs, l-len #rest)
         ) [bind: #b0, #b1, #rest];
-        unfold Elements("Complete", #EC, 2, ((256 * #b0) + #b1), 2, #ECKs, l-len #rest);
+        unfold Elements(#EC, 2, ((256 * #b0) + #b1), 2, "Complete", #ECKs, l-len #rest);
         assert (
             scope(pairsCount: #pairsCount) * (#pairsCount == l-len #ECKs) *
             scope(elements: #elements) * ArrayOfArraysOfUInt8Arrays(#elements, #ECKs) *
@@ -384,8 +384,8 @@ function decodeEncryptionContext(encodedEncryptionContext) {
 
         scope(count: #count) * (#count <=# #pairsCount) *
         ArrayStructure(#elements, #pairsCount) *
-        ArrayOfArraysOfUInt8ArraysContents(#elements, #done, 0, #count) *
-        ArrayOfArraysOfUInt8ArraysContents(#elements, #left, #count, #pairsCount - #count) *
+        ArrayOfArraysOfUInt8ArraysContents(#elements, 0, #count, #done) *
+        ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left) *
         (#ECKs == l+ (#done, #left)) *
         FirstProj(#done, #doneRProps) * Unique(#doneRProps) *
         FirstProj(#left, #leftRProps) * UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps) *
@@ -398,7 +398,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
             unfold ArrayStructure(#elements, #pairsCount);
             unfold UniqueOrDuplicated(#definition, #rProps, {{ }}, #rProps);
             unfold UniqueOrDuplicated(#definition, #leftRProps, #doneRProps, #leftRProps);
-            unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #left, #count, #pairsCount - #count) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
+            unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left) [bind: (#ECK := #elementContents) and (#rest_left := #rest)];
             apply CElementsElementLength(#EC, 2., ((256. * #b0) + #b1), 2., #ECKs, #done, #ECK, #rest_left);
             assert (#ECK == {{ #new_prop, #new_value }})
     */
@@ -461,7 +461,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
 
   /*
     @tactic
-        unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #left, #count, #pairsCount - #count);
+        unfold ArrayOfArraysOfUInt8ArraysContents(#elements, #count, #pairsCount - #count, #left);
         apply toUtf8PairMapInjective(#ECKs, #utf8ECKs, #done, #utf8Done);
         if (#definition = "Broken") then {
             unfold FirstProj(#left, #leftRProps);
@@ -489,7 +489,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
          Uint8Array(#buffer, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
          (#view == l-sub(#data, #byteOffset, #byteLength)) *
          ((#definition == "Complete") \/ (#definition == "Incomplete")) *
-         RawEncryptedDataKeys(#definition, #view, #startPos, #EDKs, #EDKsLength, #errorMessage) *
+         RawEncryptedDataKeys(#view, #startPos, #definition, #EDKs, #EDKsLength, #errorMessage) *
 
          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
          scope(toUtf8: #toUtf8) * JSFunctionObject(#toUtf8, "toUtf8", #t_sc, #t_len, #t_proto) *
@@ -498,7 +498,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
 
     @post Uint8Array(#buffer, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
           (#view == l-sub(#data, #byteOffset, #byteLength)) *
-          RawEncryptedDataKeys(#definition, #view, #startPos, #EDKs, #EDKsLength, #errorMessage) *
+          RawEncryptedDataKeys(#view, #startPos, #definition, #EDKs, #EDKsLength, #errorMessage) *
 
           (#definition == "Complete") *
           JSObject(ret) *
@@ -513,7 +513,7 @@ function decodeEncryptionContext(encodedEncryptionContext) {
 
           Uint8Array(#buffer, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
           (#view == l-sub(#data, #byteOffset, #byteLength)) *
-          RawEncryptedDataKeys(#definition, #view, #startPos, #EDKs, #EDKsLength, #errorMessage) *
+          RawEncryptedDataKeys(#view, #startPos, #definition, #EDKs, #EDKsLength, #errorMessage) *
 
           (#definition == "Incomplete") * (ret == false) *
 
@@ -526,14 +526,14 @@ function decodeEncryptionContext(encodedEncryptionContext) {
          Uint8Array(#buffer, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
          (#view == l-sub(#data, #byteOffset, #byteLength)) *
          (#definition == "Broken") *
-         RawEncryptedDataKeys(#definition, #view, #startPos, #EDKs, #EDKsLength, #errorMessage) *
+         RawEncryptedDataKeys(#view, #startPos, #definition, #EDKs, #EDKsLength, #errorMessage) *
 
          scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
          JSInternals()
 
     @posterr
           Uint8Array(#buffer, #aBuffer, #byteOffset, #byteLength) * ArrayBuffer(#aBuffer, #data) *
-          RawEncryptedDataKeys(#definition, #view, #startPos, #EDKs, #EDKsLength, #errorMessage) *
+          RawEncryptedDataKeys(#view, #startPos, #definition, #EDKs, #EDKsLength, #errorMessage) *
 
           ErrorObjectWithMessage(ret, #errorMessage) *
 
@@ -542,14 +542,14 @@ function decodeEncryptionContext(encodedEncryptionContext) {
 */
 function deserializeEncryptedDataKeys(buffer, startPos) {
   /* @tactic
-      unfold RawEncryptedDataKeys(#definition, #view, #startPos, #EDKs, #EDKsLength, #errorMessage);
+      unfold RawEncryptedDataKeys(#view, #startPos, #definition, #EDKs, #EDKsLength, #errorMessage);
       if (#definition = "Complete") then {
         unfold CRawEncryptedDataKeys(#view, #startPos, #EDKs, #EDKsLength)
       } else {
           if (#definition = "Incomplete") then {
             unfold IRawEncryptedDataKeys(#view, #startPos)
           } else {
-            unfold BRawEncryptedDataKeys(#errorMessage, #view, #startPos)
+            unfold BRawEncryptedDataKeys(#view, #startPos, #errorMessage)
           }
       } */
 
@@ -674,8 +674,8 @@ var SdkSuite = function (suiteId) { };
          (#view == l-sub(#data, #byteOffset, #byteLength)) *
          (#byteOffset + #byteLength <=# l-len #data) *
          ((#definition == "Complete") \/ (#definition == "Incomplete")) *
-         Header(#definition,
-                #view, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
+         Header(#view,
+                #definition, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
                        #part_two, #ECKs,
                        #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag,
                 #errorMessage) *
@@ -690,14 +690,14 @@ var SdkSuite = function (suiteId) { };
          JSInternals ()
 
     @post Uint8Array(#messageBuffer, #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer, #data) *
-          Header(#definition,
-                 #view, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
+          Header(#view,
+                 #definition, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
                         #part_two, #ECKs,
                         #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag,
                  #errorMessage) *
 
           (#definition == "Complete") *
-          HeaderInfo(ret, #version, #type, #suiteId, #messageId, #ECKs, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #rawHeaderData, #headerIv, #headerAuthTag) *
+          HeaderInfo(ret, #ECKs, #version, #type, #suiteId, #messageId, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #rawHeaderData, #headerIv, #headerAuthTag) *
           (#rawHeaderData == l-sub(#view, 0, #headerLength)) *
 
           scope(needs : #needs) * JSFunctionObject(#needs, "needs", #n_sc, #n_len, #n_proto) *
@@ -710,8 +710,8 @@ var SdkSuite = function (suiteId) { };
           JSInternals();
 
           Uint8Array(#messageBuffer, #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer, #data) *
-          Header(#definition,
-                 #view, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
+          Header(#view,
+                 #definition, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
                         #part_two, #ECKs,
                         #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag,
                  #errorMessage) *
@@ -731,8 +731,8 @@ var SdkSuite = function (suiteId) { };
          (#view == l-sub(#data, #byteOffset, #byteLength)) *
          (#byteOffset + #byteLength <=# l-len #data) *
          (#definition == "Broken") *
-         Header(#definition,
-                #view, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
+         Header(#view,
+                #definition, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
                        #part_two, #ECKs,
                        #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag,
                 #errorMessage) *
@@ -748,8 +748,8 @@ var SdkSuite = function (suiteId) { };
 
     @posterr
           Uint8Array(#messageBuffer, #buffer, #byteOffset, #byteLength) * ArrayBuffer(#buffer, #data) *
-          Header(#definition,
-                 #view, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
+          Header(#view,
+                 #definition, #part_one, #version, #type, #suiteId, #messageId, #ECLength,
                         #part_two, #ECKs,
                         #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag,
                  #errorMessage) *
@@ -778,7 +778,7 @@ function deserializeMessageHeader(messageBuffer) {
     messageBuffer.byteLength
   )
 
-  /* @tactic unfold Header(#definition, #view, #part_one, #version, #type, #suiteId, #messageId, #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag, #errorMessage) */
+  /* @tactic unfold Header(#view, #definition, #part_one, #version, #type, #suiteId, #messageId, #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag, #errorMessage) */
   /* @tactic
       if (#definition = "Complete") then {
         unfold CHeader(#view, #part_one, #version, #type, #suiteId, #messageId, #ECLength, #part_two, #ECKs, #part_three, #EDKs, #contentType, #headerIvLength, #frameLength, #headerLength, #headerIv, #headerAuthTag)

--- a/Gillian-JS/Examples/JaVerT/BST.js
+++ b/Gillian-JS/Examples/JaVerT/BST.js
@@ -1,15 +1,15 @@
 "use strict";
 
 /**
-	@pred nounfold NullableObject(o) :
+	@pred nounfold NullableObject(o;) :
 		types (o : Obj),
 		types (o : Null);
 
-	@pred Node(+n : Obj, val : Num, left, right) :
+	@pred Node(n : Obj; val : Num, left, right) :
 		JSObject(n) *
 		DataProp(n, "value", val) * DataProp(n, "left",  left) * DataProp(n, "right", right);
 
-	@pred BST(+n, K : Set) :
+	@pred BST(n; K : Set) :
 		(n == null) * (K == -{ }-),
 
 		Node(n, #val, #left, #right) * BST(#left, #KL) * BST(#right, #KR) *

--- a/Gillian-JS/Examples/JaVerT/BST.js
+++ b/Gillian-JS/Examples/JaVerT/BST.js
@@ -6,13 +6,13 @@
 		types (o : Null);
 
 	@pred Node(n : Obj; val : Num, left, right) :
-		JSObject(n) *
-		DataProp(n, "value", val) * DataProp(n, "left",  left) * DataProp(n, "right", right);
+		JSObject(n;) *
+		DataProp(n, "value"; val) * DataProp(n, "left";  left) * DataProp(n, "right"; right);
 
 	@pred BST(n; K : Set) :
 		(n == null) * (K == -{ }-),
 
-		Node(n, #val, #left, #right) * BST(#left, #KL) * BST(#right, #KR) *
+		Node(n; #val, #left, #right) * BST(#left; #KL) * BST(#right; #KR) *
 		(K == -u- (#KL, -{ #val }-, #KR)) *
 		(forall #x : Num. ((! (#x --e-- #KL)) \/ (#x <# #val))) *
 		(forall #x : Num. ((! (#x --e-- #KR)) \/ (#val <# #x))) *
@@ -26,7 +26,7 @@
 		(v == #v) * types (#v : Num)
 
 	@post
-		Node(ret, #v, null, null)
+		Node(ret; #v, null, null)
 */
 function make_node(v)
 {
@@ -43,16 +43,16 @@ function make_node(v)
 
     @pre
         (v == #v) * (t == #t) *
-		GlobalObject() * ObjectPrototype($lobj_proto) *
-		BST(#t, #K) * types (#v : Num) *
-		scope(make_node : #makeNode) * JSFunctionObject(#makeNode, "makeNode", _, _, _) *
-		scope(insert : #insert) * JSFunctionObject(#insert, "insert", _, _, _)
+		GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+		BST(#t; #K) * types (#v : Num) *
+		scope(make_node : #makeNode) * JSFunctionObject(#makeNode; "makeNode", _, _, _) *
+		scope(insert : #insert) * JSFunctionObject(#insert; "insert", _, _, _)
 
 	@post
-		GlobalObject() * ObjectPrototype($lobj_proto) *
-		BST(ret, -u- (#K, -{ #v }-)) * types (ret : Obj) *
-		scope(make_node : #makeNode) * JSFunctionObject(#makeNode, "makeNode", _, _, _) *
-		scope(insert : #insert) * JSFunctionObject(#insert, "insert", _, _, _)
+		GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+		BST(ret; -u- (#K, -{ #v }-)) * types (ret : Obj) *
+		scope(make_node : #makeNode) * JSFunctionObject(#makeNode; "makeNode", _, _, _) *
+		scope(insert : #insert) * JSFunctionObject(#insert; "insert", _, _, _)
 */
 function insert(v, t)
 {
@@ -74,14 +74,14 @@ function insert(v, t)
 	@id find
 
 	@pre
-		(t == #t) * BST(#t, #K) * (v == #v) * types (#v : Num) *
-		scope(find : #find) * JSFunctionObject(#find, "find", _, _, _) *
-		GlobalObject() * ObjectPrototype($lobj_proto)
+		(t == #t) * BST(#t; #K) * (v == #v) * types (#v : Num) *
+		scope(find : #find) * JSFunctionObject(#find; "find", _, _, _) *
+		GlobalObject(;) * ObjectPrototype($lobj_proto;)
 
 	@post
-		BST(#t, #K) * (ret == (#v -e- #K)) *
-		scope(find : #find) * JSFunctionObject(#find, "find", _, _, _) *
-		GlobalObject() * ObjectPrototype($lobj_proto)
+		BST(#t; #K) * (ret == (#v -e- #K)) *
+		scope(find : #find) * JSFunctionObject(#find; "find", _, _, _) *
+		GlobalObject(;) * ObjectPrototype($lobj_proto;)
 */
 function find (v, t)
 {
@@ -105,15 +105,15 @@ function find (v, t)
 	@id findMin
 
 	@pre
-		GlobalObject() * ObjectPrototype($lobj_proto) *
-		(t == #t) * BST(#t, #K) * types(#t : Obj) *
-		scope(find_min : #findMin) * JSFunctionObject(#findMin, "findMin", _, _, _)
+		GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+		(t == #t) * BST(#t; #K) * types(#t : Obj) *
+		scope(find_min : #findMin) * JSFunctionObject(#findMin; "findMin", _, _, _)
 
 	@post
-		GlobalObject() * ObjectPrototype($lobj_proto) *
-		BST(#t, #K) * (ret --e-- #K) * types(ret : Num) *
+		GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+		BST(#t; #K) * (ret --e-- #K) * types(ret : Num) *
 		(forall #x : Num. ((! (#x --e-- #K)) \/ (ret <=# #x))) *
-		scope(find_min : #findMin) * JSFunctionObject(#findMin, "findMin", _, _, _)
+		scope(find_min : #findMin) * JSFunctionObject(#findMin; "findMin", _, _, _)
 */
 function find_min(t)
 {
@@ -131,17 +131,17 @@ function find_min(t)
 	@id remove
 
 	@pre
-		GlobalObject() * ObjectPrototype($lobj_proto) *
-		(t == #t) * BST(#t, #K) *
+		GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+		(t == #t) * BST(#t; #K) *
 		(v == #v) * types (#v : Num) *
-		scope(remove : #remove) * JSFunctionObject(#remove, "remove", _, _, _) *
-		scope(find_min : #findMin) * JSFunctionObject(#findMin, "findMin", _, _, _)
+		scope(remove : #remove) * JSFunctionObject(#remove; "remove", _, _, _) *
+		scope(find_min : #findMin) * JSFunctionObject(#findMin; "findMin", _, _, _)
 
 	@post
-		GlobalObject() * ObjectPrototype($lobj_proto) *
-		BST(ret, #K_new) * (#K_new == #K -d- -{ #v }-) * NullableObject(ret) *
-		scope(remove : #remove) * JSFunctionObject(#remove, "remove", _, _, _) *
-		scope(find_min : #findMin) * JSFunctionObject(#findMin, "findMin", _, _, _)
+		GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+		BST(ret; #K_new) * (#K_new == #K -d- -{ #v }-) * NullableObject(ret;) *
+		scope(remove : #remove) * JSFunctionObject(#remove; "remove", _, _, _) *
+		scope(find_min : #findMin) * JSFunctionObject(#findMin; "findMin", _, _, _)
 */
 function remove(v, t)
 {

--- a/Gillian-JS/Examples/JaVerT/BST.js
+++ b/Gillian-JS/Examples/JaVerT/BST.js
@@ -1,12 +1,12 @@
 "use strict";
 
 /**
-	@pred nounfold NullableObject(o;) :
+	@pred nounfold NullableObject(o) :
 		types (o : Obj),
 		types (o : Null);
 
 	@pred Node(n : Obj; val : Num, left, right) :
-		JSObject(n;) *
+		JSObject(n) *
 		DataProp(n, "value"; val) * DataProp(n, "left";  left) * DataProp(n, "right"; right);
 
 	@pred BST(n; K : Set) :
@@ -43,13 +43,13 @@ function make_node(v)
 
     @pre
         (v == #v) * (t == #t) *
-		GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+		GlobalObject() * ObjectPrototype($lobj_proto) *
 		BST(#t; #K) * types (#v : Num) *
 		scope(make_node : #makeNode) * JSFunctionObject(#makeNode; "makeNode", _, _, _) *
 		scope(insert : #insert) * JSFunctionObject(#insert; "insert", _, _, _)
 
 	@post
-		GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+		GlobalObject() * ObjectPrototype($lobj_proto) *
 		BST(ret; -u- (#K, -{ #v }-)) * types (ret : Obj) *
 		scope(make_node : #makeNode) * JSFunctionObject(#makeNode; "makeNode", _, _, _) *
 		scope(insert : #insert) * JSFunctionObject(#insert; "insert", _, _, _)
@@ -76,12 +76,12 @@ function insert(v, t)
 	@pre
 		(t == #t) * BST(#t; #K) * (v == #v) * types (#v : Num) *
 		scope(find : #find) * JSFunctionObject(#find; "find", _, _, _) *
-		GlobalObject(;) * ObjectPrototype($lobj_proto;)
+		GlobalObject() * ObjectPrototype($lobj_proto)
 
 	@post
 		BST(#t; #K) * (ret == (#v -e- #K)) *
 		scope(find : #find) * JSFunctionObject(#find; "find", _, _, _) *
-		GlobalObject(;) * ObjectPrototype($lobj_proto;)
+		GlobalObject() * ObjectPrototype($lobj_proto)
 */
 function find (v, t)
 {
@@ -105,12 +105,12 @@ function find (v, t)
 	@id findMin
 
 	@pre
-		GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+		GlobalObject() * ObjectPrototype($lobj_proto) *
 		(t == #t) * BST(#t; #K) * types(#t : Obj) *
 		scope(find_min : #findMin) * JSFunctionObject(#findMin; "findMin", _, _, _)
 
 	@post
-		GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+		GlobalObject() * ObjectPrototype($lobj_proto) *
 		BST(#t; #K) * (ret --e-- #K) * types(ret : Num) *
 		(forall #x : Num. ((! (#x --e-- #K)) \/ (ret <=# #x))) *
 		scope(find_min : #findMin) * JSFunctionObject(#findMin; "findMin", _, _, _)
@@ -131,15 +131,15 @@ function find_min(t)
 	@id remove
 
 	@pre
-		GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+		GlobalObject() * ObjectPrototype($lobj_proto) *
 		(t == #t) * BST(#t; #K) *
 		(v == #v) * types (#v : Num) *
 		scope(remove : #remove) * JSFunctionObject(#remove; "remove", _, _, _) *
 		scope(find_min : #findMin) * JSFunctionObject(#findMin; "findMin", _, _, _)
 
 	@post
-		GlobalObject(;) * ObjectPrototype($lobj_proto;) *
-		BST(ret; #K_new) * (#K_new == #K -d- -{ #v }-) * NullableObject(ret;) *
+		GlobalObject() * ObjectPrototype($lobj_proto) *
+		BST(ret; #K_new) * (#K_new == #K -d- -{ #v }-) * NullableObject(ret) *
 		scope(remove : #remove) * JSFunctionObject(#remove; "remove", _, _, _) *
 		scope(find_min : #findMin) * JSFunctionObject(#findMin; "findMin", _, _, _)
 */

--- a/Gillian-JS/Examples/JaVerT/DLL.js
+++ b/Gillian-JS/Examples/JaVerT/DLL.js
@@ -2,7 +2,7 @@
 
 /* 
   @pred Node(x:Obj; val, prev, next) : 
-    JSObject(x;) * DataProp(x, "val"; val) * DataProp(x, "prev"; prev) * DataProp(x, "next"; next);
+    JSObject(x) * DataProp(x, "val"; val) * DataProp(x, "prev"; prev) * DataProp(x, "next"; next);
 
   @pred DLL(x; alpha:List) :
     (x == null) * (alpha == {{ }}),
@@ -12,10 +12,10 @@
 /** 
   @id listCopy 
 
-  @pre  GlobalObject(;) * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) *
+  @pre  GlobalObject() * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) *
         (lst == #lst) * DLL(#lst; #alpha)
 
-  @post GlobalObject(;) * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) * 
+  @post GlobalObject() * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) * 
         DLL(#lst; #alpha) * DLL(ret; #alpha)
 */
 function listCopy (lst) { 
@@ -29,10 +29,10 @@ function listCopy (lst) {
 /** 
   @id listConcat 
 
-  @pre  GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+  @pre  GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
         (la == #la) * DLL(#la; #alpha) * (lb == #lb) * DLL(#lb; #beta)
 
-  @post GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) * 
+  @post GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) * 
         DLL(ret; l+ (#alpha, #beta))
 */
 function listConcat(la, lb) {
@@ -48,10 +48,10 @@ function listConcat(la, lb) {
 /** 
   @id listAppend 
 
-  @pre  GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+  @pre  GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
         (lst == #lst) * DLL(#lst; #alpha) * (v == #v)
 
-  @post GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) * 
+  @post GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) * 
         DLL(ret; l+ (#alpha, {{ #v }} ))
 */
 function listAppend(lst, v) {

--- a/Gillian-JS/Examples/JaVerT/DLL.js
+++ b/Gillian-JS/Examples/JaVerT/DLL.js
@@ -2,21 +2,21 @@
 
 /* 
   @pred Node(x:Obj; val, prev, next) : 
-    JSObject(x) * DataProp(x, "val", val) * DataProp(x, "prev", prev) * DataProp(x, "next", next);
+    JSObject(x;) * DataProp(x, "val"; val) * DataProp(x, "prev"; prev) * DataProp(x, "next"; next);
 
   @pred DLL(x; alpha:List) :
     (x == null) * (alpha == {{ }}),
-    Node(x, #val, #prev, #next) * DLL(#next, #beta) * (alpha == #val :: #beta);
+    Node(x; #val, #prev, #next) * DLL(#next; #beta) * (alpha == #val :: #beta);
 */
 
 /** 
   @id listCopy 
 
-  @pre  GlobalObject() * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy, "listCopy", _, _, _) *
-        (lst == #lst) * DLL(#lst, #alpha)
+  @pre  GlobalObject(;) * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) *
+        (lst == #lst) * DLL(#lst; #alpha)
 
-  @post GlobalObject() * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy, "listCopy", _, _, _) * 
-        DLL(#lst, #alpha) * DLL(ret, #alpha)
+  @post GlobalObject(;) * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) * 
+        DLL(#lst; #alpha) * DLL(ret; #alpha)
 */
 function listCopy (lst) { 
   if (lst === null) {
@@ -29,11 +29,11 @@ function listCopy (lst) {
 /** 
   @id listConcat 
 
-  @pre  GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat, "listConcat", _, _, _) *
-        (la == #la) * DLL(#la, #alpha) * (lb == #lb) * DLL(#lb, #beta)
+  @pre  GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+        (la == #la) * DLL(#la; #alpha) * (lb == #lb) * DLL(#lb; #beta)
 
-  @post GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat, "listConcat", _, _, _) * 
-        DLL(ret, l+ (#alpha, #beta))
+  @post GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) * 
+        DLL(ret; l+ (#alpha, #beta))
 */
 function listConcat(la, lb) {
   if (la === null) return lb; 
@@ -48,11 +48,11 @@ function listConcat(la, lb) {
 /** 
   @id listAppend 
 
-  @pre  GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat, "listConcat", _, _, _) *
-        (lst == #lst) * DLL(#lst, #alpha) * (v == #v)
+  @pre  GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+        (lst == #lst) * DLL(#lst; #alpha) * (v == #v)
 
-  @post GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat, "listConcat", _, _, _) * 
-        DLL(ret, l+ (#alpha, {{ #v }} ))
+  @post GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) * 
+        DLL(ret; l+ (#alpha, {{ #v }} ))
 */
 function listAppend(lst, v) {
   var newNode = { val: v, prev : null, next : null };

--- a/Gillian-JS/Examples/JaVerT/DLL.js
+++ b/Gillian-JS/Examples/JaVerT/DLL.js
@@ -1,10 +1,10 @@
 "use strict";
 
 /* 
-  @pred Node(+x:Obj, val, prev, next) : 
+  @pred Node(x:Obj; val, prev, next) : 
     JSObject(x) * DataProp(x, "val", val) * DataProp(x, "prev", prev) * DataProp(x, "next", next);
 
-  @pred DLL(+x, alpha:List) :
+  @pred DLL(x; alpha:List) :
     (x == null) * (alpha == {{ }}),
     Node(x, #val, #prev, #next) * DLL(#next, #beta) * (alpha == #val :: #beta);
 */

--- a/Gillian-JS/Examples/JaVerT/ExprEval.js
+++ b/Gillian-JS/Examples/JaVerT/ExprEval.js
@@ -1,81 +1,81 @@
 /**
     @pred Map (m; mp, kvs, keys) :
-      JSObjWithProto(m, mp) *
-      DataProp(m, "_contents", #c) * JSObject(#c) *
+      JSObjWithProto(m; mp) *
+      DataProp(m, "_contents"; #c) * JSObject(#c;) *
       ((m, "get") -> none) * ((m, "put") -> none) * ((m, "validKey") -> none) *
-      ((#c, "hasOwnProperty") -> none) * KVPairs(#c, kvs, keys) * empty_fields(#c : -u- (keys, -{ "hasOwnProperty" }-));
+      ((#c, "hasOwnProperty") -> none) * KVPairs(#c; kvs, keys) * empty_fields(#c : -u- (keys, -{ "hasOwnProperty" }-));
 
     @pred KVPairs (o; kvs : Set, keys : Set) :
       [def1]  (kvs == -{ }-) * (keys == -{ }-),
       [def2: #key]
               (kvs == -u- (-{ {{ #key, #value }} }-, #rkvs)) * (keys == -u- (-{ #key }-, #rkeys)) * (! (#key --e-- #rkeys)) *
-              ValidKey(#key) * DataProp(o, #key, #value) * KVPairs(o, #rkvs, #rkeys) *
+              ValidKey(#key;) * DataProp(o, #key; #value) * KVPairs(o; #rkvs, #rkeys) *
               types (#rkvs: Set, #rkeys: Set);
 
     @pred MapProto(mp;) :
-      JSObject(mp) *
-      DataProp(mp, "get", #get_loc) * JSFunctionObject(#get_loc, "mapGet", _, _, _) *
-      DataProp(mp, "put", #put_loc) * JSFunctionObject(#put_loc, "mapPut", _, _, _) *
-      DataProp(mp, "validKey", #vK_loc) * JSFunctionObject(#vK_loc, "isValidKey", _, _, _) *
+      JSObject(mp;) *
+      DataProp(mp, "get"; #get_loc) * JSFunctionObject(#get_loc; "mapGet", _, _, _) *
+      DataProp(mp, "put"; #put_loc) * JSFunctionObject(#put_loc; "mapPut", _, _, _) *
+      DataProp(mp, "validKey"; #vK_loc) * JSFunctionObject(#vK_loc; "isValidKey", _, _, _) *
       ((mp, "_contents") -> none);
 
     @onlyspec map()
       [[
-        initialHeapPostWeak() *
-        JSObjWithProto(this, #mp) *
+        initialHeapPostWeak(;) *
+        JSObjWithProto(this; #mp) *
         ((this, "_contents") -> none) *
         ((this, "get") -> none) *
         ((this, "put") -> none) *
         ((this, "validKey") -> none) *
-        MapProto(#mp)
+        MapProto(#mp;)
       ]]
       [[
-        initialHeapPostWeak() *
-        Map(this, #mp, #kvs, #keys) * (#kvs == -{ }-) * (#keys == -{ }-) *
-        MapProto(#mp) * (ret == this)
+        initialHeapPostWeak(;) *
+        Map(this; #mp, #kvs, #keys) * (#kvs == -{ }-) * (#keys == -{ }-) *
+        MapProto(#mp;) * (ret == this)
       ]]
       normal
 
     @onlyspec mapGet(k)
       <invalid_key>
-      [[ (k == #k) * Map(this, #mp, #kvs, #keys) * MapProto(#mp) * InvalidKey(#k) * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject() ]]
-      [[ Map(this, #mp, #kvs, #keys) * MapProto(#mp) * ErrorObjectWithMessage(ret, "Invalid Key") * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject() ]]
+      [[ (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * InvalidKey(#k;) * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;) ]]
+      [[ Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ErrorObjectWithMessage(ret; "Invalid Key") * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;) ]]
       error;
 
       <inexistent_key>
-      [[ (k == #k) * Map(this, #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (! (#k --e-- #keys)) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
-      [[ Map(this, #mp, #kvs, #keys) * MapProto(#mp) * (ret == null) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
+      [[ (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (! (#k --e-- #keys)) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
+      [[ Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * (ret == null) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
       normal;
 
       <existent_key: #v>
-      [[ (k == #k) * Map(this, #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (#k --e-- #keys) * ({{ #k, #v }} --e-- #kvs) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
-      [[ Map(this, #mp, #kvs, #keys) * MapProto(#mp) * (ret == #v) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
+      [[ (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (#k --e-- #keys) * ({{ #k, #v }} --e-- #kvs) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
+      [[ Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * (ret == #v) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
       normal
 
     @onlyspec isValidKey(key)
-      [[ ((key == #key) * ValidKey(#key)) ]]
+      [[ ((key == #key) * ValidKey(#key;)) ]]
       [[ (ret == true) ]]
       normal;
 
-      [[ ((key == #key) * InvalidKey(#key)) ]]
+      [[ ((key == #key) * InvalidKey(#key;)) ]]
       [[ (ret == false) ]]
       normal
 
     @onlyspec mapPut(k, v)
       <invalid_key>
-      [[ (k == #k) * (v == #v) * Map(this, #mp, #kvs, #keys) * MapProto(#mp) * InvalidKey(#k) * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject() ]]
-      [[ Map(this, #mp, #kvs, #keys) * MapProto(#mp) * ErrorObjectWithMessage(ret, "Invalid Key") * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject() ]]
+      [[ (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * InvalidKey(#k;) * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;) ]]
+      [[ Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ErrorObjectWithMessage(ret; "Invalid Key") * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;) ]]
       error;
 
       <inexistent_key>
-      [[ (k == #k) * (v == #v) * Map(this, #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (! (#k --e-- #keys)) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
-      [[ Map(this, #mp, -u- (-{ {{ #k, #v }} }-, #kvs), -u- (-{ #k }-, #keys)) * MapProto(#mp) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
+      [[ (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (! (#k --e-- #keys)) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
+      [[ Map(this; #mp, -u- (-{ {{ #k, #v }} }-, #kvs), -u- (-{ #k }-, #keys)) * MapProto(#mp;) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
       normal;
 
       <existent_key: #rkvs, #w>
-      [[ (k == #k) * (v == #v) * Map(this, #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (#k --e-- #keys) *
-       (#kvs == -u- (-{ {{ #k, #w }} }-, #rkvs)) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
-      [[ Map(this, #mp, -u- (-{ {{ #k, #v }} }-, #rkvs), #keys) * MapProto(#mp) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
+      [[ (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (#k --e-- #keys) *
+       (#kvs == -u- (-{ {{ #k, #w }} }-, #rkvs)) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
+      [[ Map(this; #mp, -u- (-{ {{ #k, #v }} }-, #rkvs), #keys) * MapProto(#mp;) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
       normal
 */
 
@@ -151,50 +151,50 @@ function evalBinop (op, l1, l2) {
     types(v : Bool);
 
   @pred ExpressionStruct(e:Obj; cat:Str) :
-    JSObject(e) * DataProp(e, "type", "expr") * DataProp(e, "category", cat);
+    JSObject(e;) * DataProp(e, "type"; "expr") * DataProp(e, "category"; cat);
 
   @pred ExpressionWithValue(e:Obj, bindings:Set, vars:Set; v) :
-    ExpressionStruct(e, "lit") * DataProp(e, "val", v) * types(v : Num),
-    ExpressionStruct(e, "lit") * DataProp(e, "val", v) * types(v : Bool),
+    ExpressionStruct(e; "lit") * DataProp(e, "val"; v) * types(v : Num),
+    ExpressionStruct(e; "lit") * DataProp(e, "val"; v) * types(v : Bool),
 
-    [var: #v] ExpressionStruct(e, "var") * DataProp(e, "name",  #var_name) * (v == #v) *
-      ValidKey(#var_name) * ({{ #var_name, #v }} --e-- bindings) * (#var_name --e-- vars) * ValidVal(#v),
+    [var: #v] ExpressionStruct(e; "var") * DataProp(e, "name";  #var_name) * (v == #v) *
+      ValidKey(#var_name;) * ({{ #var_name, #v }} --e-- bindings) * (#var_name --e-- vars) * ValidVal(#v;),
 
-    ExpressionStruct(e, "unop") * DataProp(e, "op",  "-") * DataProp(e, "arg", #arg) *
-      ExpressionWithValue(#arg, bindings, vars, #varg) * types(#varg : Num) * (v == -#varg),
-    ExpressionStruct(e, "unop") * DataProp(e, "op",  "not") * DataProp(e, "arg", #arg) *
-      ExpressionWithValue(#arg, bindings, vars, #varg) * types(#varg : Bool) * (v == not #varg),
+    ExpressionStruct(e; "unop") * DataProp(e, "op";  "-") * DataProp(e, "arg"; #arg) *
+      ExpressionWithValue(#arg, bindings, vars; #varg) * types(#varg : Num) * (v == -#varg),
+    ExpressionStruct(e; "unop") * DataProp(e, "op";  "not") * DataProp(e, "arg"; #arg) *
+      ExpressionWithValue(#arg, bindings, vars; #varg) * types(#varg : Bool) * (v == not #varg),
 
-    ExpressionStruct(e, "binop") * DataProp(e, "op",  "+") * DataProp(e, "left", #left) * DataProp(e, "right", #right) *
-      ExpressionWithValue(#left, bindings, vars, #vleft) * ExpressionWithValue(#right, bindings, vars, #vright) *
+    ExpressionStruct(e; "binop") * DataProp(e, "op";  "+") * DataProp(e, "left"; #left) * DataProp(e, "right"; #right) *
+      ExpressionWithValue(#left, bindings, vars; #vleft) * ExpressionWithValue(#right, bindings, vars; #vright) *
       types(#vleft : Num) * types(#vright : Num) * (v == #vleft + #vright),
-    ExpressionStruct(e, "binop") * DataProp(e, "op",  "-") * DataProp(e, "left", #left) * DataProp(e, "right", #right) *
-      ExpressionWithValue(#left, bindings, vars, #vleft) * ExpressionWithValue(#right, bindings, vars, #vright) *
+    ExpressionStruct(e; "binop") * DataProp(e, "op";  "-") * DataProp(e, "left"; #left) * DataProp(e, "right"; #right) *
+      ExpressionWithValue(#left, bindings, vars; #vleft) * ExpressionWithValue(#right, bindings, vars; #vright) *
       types(#vleft : Num) * types(#vright : Num) * (v == #vleft - #vright),
-    ExpressionStruct(e, "binop") * DataProp(e, "op",  "and") * DataProp(e, "left", #left) * DataProp(e, "right", #right) *
-      ExpressionWithValue(#left, bindings, vars, #vleft) * ExpressionWithValue(#right, bindings, vars, #vright) *
+    ExpressionStruct(e; "binop") * DataProp(e, "op";  "and") * DataProp(e, "left"; #left) * DataProp(e, "right"; #right) *
+      ExpressionWithValue(#left, bindings, vars; #vleft) * ExpressionWithValue(#right, bindings, vars; #vright) *
       types(#vleft : Bool) * types(#vright : Bool) * (v == #vleft and #vright),
-    ExpressionStruct(e, "binop") * DataProp(e, "op",  "or") * DataProp(e, "left", #left) * DataProp(e, "right", #right) *
-      ExpressionWithValue(#left, bindings, vars, #vleft) * ExpressionWithValue(#right, bindings, vars, #vright) *
+    ExpressionStruct(e; "binop") * DataProp(e, "op";  "or") * DataProp(e, "left"; #left) * DataProp(e, "right"; #right) *
+      ExpressionWithValue(#left, bindings, vars; #vleft) * ExpressionWithValue(#right, bindings, vars; #vright) *
       types(#vleft : Bool) * types(#vright : Bool) * (v == #vleft or #vright);
 */
 
 /*
   @id evalExpr
 
-  @pre  GlobalObject() * ObjectPrototype($lobj_proto) *
-        scope(evalExpr  : #evalExpr)  * JSFunctionObject(#evalExpr,  "evalExpr",  _, _, _) *
-        scope(evalUnop  : #evalUnop)  * JSFunctionObject(#evalUnop,  "evalUnop",  _, _, _) *
-        scope(evalBinop : #evalBinop) * JSFunctionObject(#evalBinop, "evalBinop", _, _, _) *
-        ((store == #store) * (e == #e) * ExpressionWithValue(#e, #bnds, #vars, #v)) *
-        Map(#store, #mp, #bnds, #vars) * MapProto(#mp)
+  @pre  GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+        scope(evalExpr  : #evalExpr)  * JSFunctionObject(#evalExpr;  "evalExpr",  _, _, _) *
+        scope(evalUnop  : #evalUnop)  * JSFunctionObject(#evalUnop;  "evalUnop",  _, _, _) *
+        scope(evalBinop : #evalBinop) * JSFunctionObject(#evalBinop; "evalBinop", _, _, _) *
+        ((store == #store) * (e == #e) * ExpressionWithValue(#e, #bnds, #vars; #v)) *
+        Map(#store; #mp, #bnds, #vars) * MapProto(#mp;)
 
-  @post (GlobalObject() * ObjectPrototype($lobj_proto) *
-        scope(evalExpr : #evalExpr) * JSFunctionObject(#evalExpr, "evalExpr", _, _, _) *
-        scope(evalUnop : #evalUnop) * JSFunctionObject(#evalUnop, "evalUnop", _, _, _) *
-        scope(evalBinop : #evalBinop) * JSFunctionObject(#evalBinop, "evalBinop", _, _, _) *
-        ExpressionWithValue(#e, #bnds, #vars, #v) * (ret == #v) *
-        Map(#store, #mp, #bnds, #vars) * MapProto(#mp))
+  @post (GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+        scope(evalExpr : #evalExpr) * JSFunctionObject(#evalExpr; "evalExpr", _, _, _) *
+        scope(evalUnop : #evalUnop) * JSFunctionObject(#evalUnop; "evalUnop", _, _, _) *
+        scope(evalBinop : #evalBinop) * JSFunctionObject(#evalBinop; "evalBinop", _, _, _) *
+        ExpressionWithValue(#e, #bnds, #vars; #v) * (ret == #v) *
+        Map(#store; #mp, #bnds, #vars) * MapProto(#mp;))
 */
 function evalExpr (store, e) {
   switch (e.category) {

--- a/Gillian-JS/Examples/JaVerT/ExprEval.js
+++ b/Gillian-JS/Examples/JaVerT/ExprEval.js
@@ -1,18 +1,18 @@
 /**
-    @pred Map (+m, mp, kvs, keys) :
+    @pred Map (m; mp, kvs, keys) :
       JSObjWithProto(m, mp) *
       DataProp(m, "_contents", #c) * JSObject(#c) *
       ((m, "get") -> none) * ((m, "put") -> none) * ((m, "validKey") -> none) *
       ((#c, "hasOwnProperty") -> none) * KVPairs(#c, kvs, keys) * empty_fields(#c : -u- (keys, -{ "hasOwnProperty" }-));
 
-    @pred KVPairs (+o, kvs : Set, keys : Set) :
+    @pred KVPairs (o; kvs : Set, keys : Set) :
       [def1]  (kvs == -{ }-) * (keys == -{ }-),
       [def2: #key]
               (kvs == -u- (-{ {{ #key, #value }} }-, #rkvs)) * (keys == -u- (-{ #key }-, #rkeys)) * (! (#key --e-- #rkeys)) *
               ValidKey(#key) * DataProp(o, #key, #value) * KVPairs(o, #rkvs, #rkeys) *
               types (#rkvs: Set, #rkeys: Set);
 
-    @pred MapProto(mp) :
+    @pred MapProto(mp;) :
       JSObject(mp) *
       DataProp(mp, "get", #get_loc) * JSFunctionObject(#get_loc, "mapGet", _, _, _) *
       DataProp(mp, "put", #put_loc) * JSFunctionObject(#put_loc, "mapPut", _, _, _) *
@@ -80,10 +80,10 @@
 */
 
 /**
-  @pred ValidKey(key) :
+  @pred ValidKey(key;) :
     types(key : Str) * (! (key == "hasOwnProperty"));
 
-  @pred InvalidKey(key) :
+  @pred InvalidKey(key;) :
     types (key : Undefined),
     types (key : Null),
     types (key : Bool),
@@ -146,14 +146,14 @@ function evalBinop (op, l1, l2) {
 }
 
 /*
-  @pred ValidVal(v) :
+  @pred ValidVal(v;) :
     types(v : Str),
     types(v : Bool);
 
-  @pred ExpressionStruct(+e:Obj, cat:Str) :
+  @pred ExpressionStruct(e:Obj; cat:Str) :
     JSObject(e) * DataProp(e, "type", "expr") * DataProp(e, "category", cat);
 
-  @pred ExpressionWithValue(+e:Obj, +bindings:Set, +vars:Set, v) :
+  @pred ExpressionWithValue(e:Obj, bindings:Set, vars:Set; v) :
     ExpressionStruct(e, "lit") * DataProp(e, "val", v) * types(v : Num),
     ExpressionStruct(e, "lit") * DataProp(e, "val", v) * types(v : Bool),
 

--- a/Gillian-JS/Examples/JaVerT/ExprEval.js
+++ b/Gillian-JS/Examples/JaVerT/ExprEval.js
@@ -153,7 +153,7 @@ function evalBinop (op, l1, l2) {
   @pred ExpressionStruct(+e:Obj, cat:Str) :
     JSObject(e) * DataProp(e, "type", "expr") * DataProp(e, "category", cat);
 
-  @pred ExpressionWithValue(+e:Obj, v, +bindings:Set, +vars:Set) :
+  @pred ExpressionWithValue(+e:Obj, +bindings:Set, +vars:Set, v) :
     ExpressionStruct(e, "lit") * DataProp(e, "val", v) * types(v : Num),
     ExpressionStruct(e, "lit") * DataProp(e, "val", v) * types(v : Bool),
 
@@ -161,21 +161,21 @@ function evalBinop (op, l1, l2) {
       ValidKey(#var_name) * ({{ #var_name, #v }} --e-- bindings) * (#var_name --e-- vars) * ValidVal(#v),
 
     ExpressionStruct(e, "unop") * DataProp(e, "op",  "-") * DataProp(e, "arg", #arg) *
-      ExpressionWithValue(#arg, #varg, bindings, vars) * types(#varg : Num) * (v == -#varg),
+      ExpressionWithValue(#arg, bindings, vars, #varg) * types(#varg : Num) * (v == -#varg),
     ExpressionStruct(e, "unop") * DataProp(e, "op",  "not") * DataProp(e, "arg", #arg) *
-      ExpressionWithValue(#arg, #varg, bindings, vars) * types(#varg : Bool) * (v == not #varg),
+      ExpressionWithValue(#arg, bindings, vars, #varg) * types(#varg : Bool) * (v == not #varg),
 
     ExpressionStruct(e, "binop") * DataProp(e, "op",  "+") * DataProp(e, "left", #left) * DataProp(e, "right", #right) *
-      ExpressionWithValue(#left, #vleft, bindings, vars) * ExpressionWithValue(#right, #vright, bindings, vars) *
+      ExpressionWithValue(#left, bindings, vars, #vleft) * ExpressionWithValue(#right, bindings, vars, #vright) *
       types(#vleft : Num) * types(#vright : Num) * (v == #vleft + #vright),
     ExpressionStruct(e, "binop") * DataProp(e, "op",  "-") * DataProp(e, "left", #left) * DataProp(e, "right", #right) *
-      ExpressionWithValue(#left, #vleft, bindings, vars) * ExpressionWithValue(#right, #vright, bindings, vars) *
+      ExpressionWithValue(#left, bindings, vars, #vleft) * ExpressionWithValue(#right, bindings, vars, #vright) *
       types(#vleft : Num) * types(#vright : Num) * (v == #vleft - #vright),
     ExpressionStruct(e, "binop") * DataProp(e, "op",  "and") * DataProp(e, "left", #left) * DataProp(e, "right", #right) *
-      ExpressionWithValue(#left, #vleft, bindings, vars) * ExpressionWithValue(#right, #vright, bindings, vars) *
+      ExpressionWithValue(#left, bindings, vars, #vleft) * ExpressionWithValue(#right, bindings, vars, #vright) *
       types(#vleft : Bool) * types(#vright : Bool) * (v == #vleft and #vright),
     ExpressionStruct(e, "binop") * DataProp(e, "op",  "or") * DataProp(e, "left", #left) * DataProp(e, "right", #right) *
-      ExpressionWithValue(#left, #vleft, bindings, vars) * ExpressionWithValue(#right, #vright, bindings, vars) *
+      ExpressionWithValue(#left, bindings, vars, #vleft) * ExpressionWithValue(#right, bindings, vars, #vright) *
       types(#vleft : Bool) * types(#vright : Bool) * (v == #vleft or #vright);
 */
 
@@ -186,14 +186,14 @@ function evalBinop (op, l1, l2) {
         scope(evalExpr  : #evalExpr)  * JSFunctionObject(#evalExpr,  "evalExpr",  _, _, _) *
         scope(evalUnop  : #evalUnop)  * JSFunctionObject(#evalUnop,  "evalUnop",  _, _, _) *
         scope(evalBinop : #evalBinop) * JSFunctionObject(#evalBinop, "evalBinop", _, _, _) *
-        ((store == #store) * (e == #e) * ExpressionWithValue(#e, #v, #bnds, #vars)) *
+        ((store == #store) * (e == #e) * ExpressionWithValue(#e, #bnds, #vars, #v)) *
         Map(#store, #mp, #bnds, #vars) * MapProto(#mp)
 
   @post (GlobalObject() * ObjectPrototype($lobj_proto) *
         scope(evalExpr : #evalExpr) * JSFunctionObject(#evalExpr, "evalExpr", _, _, _) *
         scope(evalUnop : #evalUnop) * JSFunctionObject(#evalUnop, "evalUnop", _, _, _) *
         scope(evalBinop : #evalBinop) * JSFunctionObject(#evalBinop, "evalBinop", _, _, _) *
-        ExpressionWithValue(#e, #v, #bnds, #vars) * (ret == #v) *
+        ExpressionWithValue(#e, #bnds, #vars, #v) * (ret == #v) *
         Map(#store, #mp, #bnds, #vars) * MapProto(#mp))
 */
 function evalExpr (store, e) {

--- a/Gillian-JS/Examples/JaVerT/ExprEval.js
+++ b/Gillian-JS/Examples/JaVerT/ExprEval.js
@@ -1,7 +1,7 @@
 /**
     @pred Map (m; mp, kvs, keys) :
       JSObjWithProto(m; mp) *
-      DataProp(m, "_contents"; #c) * JSObject(#c;) *
+      DataProp(m, "_contents"; #c) * JSObject(#c) *
       ((m, "get") -> none) * ((m, "put") -> none) * ((m, "validKey") -> none) *
       ((#c, "hasOwnProperty") -> none) * KVPairs(#c; kvs, keys) * empty_fields(#c : -u- (keys, -{ "hasOwnProperty" }-));
 
@@ -9,11 +9,11 @@
       [def1]  (kvs == -{ }-) * (keys == -{ }-),
       [def2: #key]
               (kvs == -u- (-{ {{ #key, #value }} }-, #rkvs)) * (keys == -u- (-{ #key }-, #rkeys)) * (! (#key --e-- #rkeys)) *
-              ValidKey(#key;) * DataProp(o, #key; #value) * KVPairs(o; #rkvs, #rkeys) *
+              ValidKey(#key) * DataProp(o, #key; #value) * KVPairs(o; #rkvs, #rkeys) *
               types (#rkvs: Set, #rkeys: Set);
 
-    @pred MapProto(mp;) :
-      JSObject(mp;) *
+    @pred MapProto(mp) :
+      JSObject(mp) *
       DataProp(mp, "get"; #get_loc) * JSFunctionObject(#get_loc; "mapGet", _, _, _) *
       DataProp(mp, "put"; #put_loc) * JSFunctionObject(#put_loc; "mapPut", _, _, _) *
       DataProp(mp, "validKey"; #vK_loc) * JSFunctionObject(#vK_loc; "isValidKey", _, _, _) *
@@ -21,69 +21,69 @@
 
     @onlyspec map()
       [[
-        initialHeapPostWeak(;) *
+        initialHeapPostWeak() *
         JSObjWithProto(this; #mp) *
         ((this, "_contents") -> none) *
         ((this, "get") -> none) *
         ((this, "put") -> none) *
         ((this, "validKey") -> none) *
-        MapProto(#mp;)
+        MapProto(#mp)
       ]]
       [[
-        initialHeapPostWeak(;) *
+        initialHeapPostWeak() *
         Map(this; #mp, #kvs, #keys) * (#kvs == -{ }-) * (#keys == -{ }-) *
-        MapProto(#mp;) * (ret == this)
+        MapProto(#mp) * (ret == this)
       ]]
       normal
 
     @onlyspec mapGet(k)
       <invalid_key>
-      [[ (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * InvalidKey(#k;) * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;) ]]
-      [[ Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ErrorObjectWithMessage(ret; "Invalid Key") * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;) ]]
+      [[ (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp) * InvalidKey(#k) * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject() ]]
+      [[ Map(this; #mp, #kvs, #keys) * MapProto(#mp) * ErrorObjectWithMessage(ret; "Invalid Key") * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject() ]]
       error;
 
       <inexistent_key>
-      [[ (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (! (#k --e-- #keys)) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
-      [[ Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * (ret == null) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
+      [[ (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (! (#k --e-- #keys)) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
+      [[ Map(this; #mp, #kvs, #keys) * MapProto(#mp) * (ret == null) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
       normal;
 
       <existent_key: #v>
-      [[ (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (#k --e-- #keys) * ({{ #k, #v }} --e-- #kvs) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
-      [[ Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * (ret == #v) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
+      [[ (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (#k --e-- #keys) * ({{ #k, #v }} --e-- #kvs) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
+      [[ Map(this; #mp, #kvs, #keys) * MapProto(#mp) * (ret == #v) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
       normal
 
     @onlyspec isValidKey(key)
-      [[ ((key == #key) * ValidKey(#key;)) ]]
+      [[ ((key == #key) * ValidKey(#key)) ]]
       [[ (ret == true) ]]
       normal;
 
-      [[ ((key == #key) * InvalidKey(#key;)) ]]
+      [[ ((key == #key) * InvalidKey(#key)) ]]
       [[ (ret == false) ]]
       normal
 
     @onlyspec mapPut(k, v)
       <invalid_key>
-      [[ (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * InvalidKey(#k;) * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;) ]]
-      [[ Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ErrorObjectWithMessage(ret; "Invalid Key") * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;) ]]
+      [[ (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp) * InvalidKey(#k) * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject() ]]
+      [[ Map(this; #mp, #kvs, #keys) * MapProto(#mp) * ErrorObjectWithMessage(ret; "Invalid Key") * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject() ]]
       error;
 
       <inexistent_key>
-      [[ (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (! (#k --e-- #keys)) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
-      [[ Map(this; #mp, -u- (-{ {{ #k, #v }} }-, #kvs), -u- (-{ #k }-, #keys)) * MapProto(#mp;) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
+      [[ (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (! (#k --e-- #keys)) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
+      [[ Map(this; #mp, -u- (-{ {{ #k, #v }} }-, #kvs), -u- (-{ #k }-, #keys)) * MapProto(#mp) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
       normal;
 
       <existent_key: #rkvs, #w>
-      [[ (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (#k --e-- #keys) *
-       (#kvs == -u- (-{ {{ #k, #w }} }-, #rkvs)) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
-      [[ Map(this; #mp, -u- (-{ {{ #k, #v }} }-, #rkvs), #keys) * MapProto(#mp;) * GlobalObject(;) * ObjectPrototype($lobj_proto;) ]]
+      [[ (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (#k --e-- #keys) *
+       (#kvs == -u- (-{ {{ #k, #w }} }-, #rkvs)) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
+      [[ Map(this; #mp, -u- (-{ {{ #k, #v }} }-, #rkvs), #keys) * MapProto(#mp) * GlobalObject() * ObjectPrototype($lobj_proto) ]]
       normal
 */
 
 /**
-  @pred ValidKey(key;) :
+  @pred ValidKey(key) :
     types(key : Str) * (! (key == "hasOwnProperty"));
 
-  @pred InvalidKey(key;) :
+  @pred InvalidKey(key) :
     types (key : Undefined),
     types (key : Null),
     types (key : Bool),
@@ -146,19 +146,19 @@ function evalBinop (op, l1, l2) {
 }
 
 /*
-  @pred ValidVal(v;) :
+  @pred ValidVal(v) :
     types(v : Str),
     types(v : Bool);
 
   @pred ExpressionStruct(e:Obj; cat:Str) :
-    JSObject(e;) * DataProp(e, "type"; "expr") * DataProp(e, "category"; cat);
+    JSObject(e) * DataProp(e, "type"; "expr") * DataProp(e, "category"; cat);
 
   @pred ExpressionWithValue(e:Obj, bindings:Set, vars:Set; v) :
     ExpressionStruct(e; "lit") * DataProp(e, "val"; v) * types(v : Num),
     ExpressionStruct(e; "lit") * DataProp(e, "val"; v) * types(v : Bool),
 
     [var: #v] ExpressionStruct(e; "var") * DataProp(e, "name";  #var_name) * (v == #v) *
-      ValidKey(#var_name;) * ({{ #var_name, #v }} --e-- bindings) * (#var_name --e-- vars) * ValidVal(#v;),
+      ValidKey(#var_name) * ({{ #var_name, #v }} --e-- bindings) * (#var_name --e-- vars) * ValidVal(#v),
 
     ExpressionStruct(e; "unop") * DataProp(e, "op";  "-") * DataProp(e, "arg"; #arg) *
       ExpressionWithValue(#arg, bindings, vars; #varg) * types(#varg : Num) * (v == -#varg),
@@ -182,19 +182,19 @@ function evalBinop (op, l1, l2) {
 /*
   @id evalExpr
 
-  @pre  GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+  @pre  GlobalObject() * ObjectPrototype($lobj_proto) *
         scope(evalExpr  : #evalExpr)  * JSFunctionObject(#evalExpr;  "evalExpr",  _, _, _) *
         scope(evalUnop  : #evalUnop)  * JSFunctionObject(#evalUnop;  "evalUnop",  _, _, _) *
         scope(evalBinop : #evalBinop) * JSFunctionObject(#evalBinop; "evalBinop", _, _, _) *
         ((store == #store) * (e == #e) * ExpressionWithValue(#e, #bnds, #vars; #v)) *
-        Map(#store; #mp, #bnds, #vars) * MapProto(#mp;)
+        Map(#store; #mp, #bnds, #vars) * MapProto(#mp)
 
-  @post (GlobalObject(;) * ObjectPrototype($lobj_proto;) *
+  @post (GlobalObject() * ObjectPrototype($lobj_proto) *
         scope(evalExpr : #evalExpr) * JSFunctionObject(#evalExpr; "evalExpr", _, _, _) *
         scope(evalUnop : #evalUnop) * JSFunctionObject(#evalUnop; "evalUnop", _, _, _) *
         scope(evalBinop : #evalBinop) * JSFunctionObject(#evalBinop; "evalBinop", _, _, _) *
         ExpressionWithValue(#e, #bnds, #vars; #v) * (ret == #v) *
-        Map(#store; #mp, #bnds, #vars) * MapProto(#mp;))
+        Map(#store; #mp, #bnds, #vars) * MapProto(#mp))
 */
 function evalExpr (store, e) {
   switch (e.category) {

--- a/Gillian-JS/Examples/JaVerT/IDGen.js
+++ b/Gillian-JS/Examples/JaVerT/IDGen.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
-@pred idGenerator(+ig, +sc_ig, c_val : Num, prefix : Str) :
+@pred idGenerator(ig, sc_ig; c_val : Num, prefix : Str) :
    JSObject(ig) * 
    DataProp(ig, "getId", #gni) * JSFunctionObject(#gni, "getId", #gni_sc, _, _) *
    DataProp(ig, "reset", #ri)  * JSFunctionObject(#ri, "reset", #ri_sc, _, _) *

--- a/Gillian-JS/Examples/JaVerT/IDGen.js
+++ b/Gillian-JS/Examples/JaVerT/IDGen.js
@@ -2,7 +2,7 @@
 
 /**
 @pred idGenerator(ig, sc_ig; c_val : Num, prefix : Str) :
-   JSObject(ig;) * 
+   JSObject(ig) * 
    DataProp(ig, "getId"; #gni) * JSFunctionObject(#gni; "getId", #gni_sc, _, _) *
    DataProp(ig, "reset"; #ri)  * JSFunctionObject(#ri; "reset", #ri_sc, _, _) *
    closure(count: c_val, prefix: prefix; getId: #gni_sc, reset: #ri_sc, makeIdGen: sc_ig);

--- a/Gillian-JS/Examples/JaVerT/IDGen.js
+++ b/Gillian-JS/Examples/JaVerT/IDGen.js
@@ -2,9 +2,9 @@
 
 /**
 @pred idGenerator(ig, sc_ig; c_val : Num, prefix : Str) :
-   JSObject(ig) * 
-   DataProp(ig, "getId", #gni) * JSFunctionObject(#gni, "getId", #gni_sc, _, _) *
-   DataProp(ig, "reset", #ri)  * JSFunctionObject(#ri, "reset", #ri_sc, _, _) *
+   JSObject(ig;) * 
+   DataProp(ig, "getId"; #gni) * JSFunctionObject(#gni; "getId", #gni_sc, _, _) *
+   DataProp(ig, "reset"; #ri)  * JSFunctionObject(#ri; "reset", #ri_sc, _, _) *
    closure(count: c_val, prefix: prefix; getId: #gni_sc, reset: #ri_sc, makeIdGen: sc_ig);
 */
 
@@ -14,9 +14,9 @@
 	   scope(makeIdGen: #mig) *
 	   scope(ig1: #ig1) *
 	   scope(ig2: #ig2) *
-	   JSFunctionObject(#mig, "makeIdGen", _, _, _) *
-	   idGenerator(#ig1, _, 1, "foo") *
-	   idGenerator(#ig2, _, 0, "bar") * 
+	   JSFunctionObject(#mig; "makeIdGen", _, _, _) *
+	   idGenerator(#ig1, _; 1, "foo") *
+	   idGenerator(#ig2, _; 0, "bar") * 
 	   scope(id1: #id1) *
 	   (#id1 == "foo_id_0"))
 */
@@ -24,7 +24,7 @@
 /**
 	@id   makeIdGen
 	@pre  ((prefix == #prefix) * types(#prefix: Str))
-	@post (idGenerator(ret, $$scope, 0, #prefix))
+	@post (idGenerator(ret, $$scope; 0, #prefix))
 */
 var makeIdGen = function (prefix) { 
 
@@ -32,8 +32,8 @@ var makeIdGen = function (prefix) {
 
 	/**
 		@id   getId
-		@pre  (this == #ig) * o_chains(getId: $$scope, makeIdGen: #sc_ig) * idGenerator(#ig, #sc_ig, #c, #prefix)
-		@post idGenerator(#ig, #sc_ig, #c + 1, #prefix) * (ret == #prefix ++ "_id_" ++ num_to_string(#c))
+		@pre  (this == #ig) * o_chains(getId: $$scope, makeIdGen: #sc_ig) * idGenerator(#ig, #sc_ig; #c, #prefix)
+		@post idGenerator(#ig, #sc_ig; #c + 1, #prefix) * (ret == #prefix ++ "_id_" ++ num_to_string(#c))
 		
 	*/
 	var getId = function () { 
@@ -42,8 +42,8 @@ var makeIdGen = function (prefix) {
 
 	/**
 		@id   reset
-		@pre  (this == #ig) * o_chains(reset: $$scope, makeIdGen: #sc_ig) * idGenerator(#ig, #sc_ig, #c, #prefix)
-		@post idGenerator(#ig, #sc_ig, 0, #prefix)
+		@pre  (this == #ig) * o_chains(reset: $$scope, makeIdGen: #sc_ig) * idGenerator(#ig, #sc_ig; #c, #prefix)
+		@post idGenerator(#ig, #sc_ig; 0, #prefix)
 	*/
 	var reset = function () { 
 		count = 0 

--- a/Gillian-JS/Examples/JaVerT/KVMap.js
+++ b/Gillian-JS/Examples/JaVerT/KVMap.js
@@ -1,10 +1,10 @@
 "use strict";
 
 /*
-		@pred ValidKey(k;) : 
+		@pred ValidKey(k) : 
 				types(k : Str) * (! (k == "hasOwnProperty"));
 
-		@pred InvalidKey(ik;) :
+		@pred InvalidKey(ik) :
 				types (ik : Undefined),
 				types (ik : Null),
 				types (ik : Bool),
@@ -13,7 +13,7 @@
 
 		@pred Map (m; mp, kvs, keys) :
 				JSObjWithProto(m; mp) *
-				DataProp(m, "_contents"; #c) * JSObject(#c;) *
+				DataProp(m, "_contents"; #c) * JSObject(#c) *
 				((m, "get") -> none) * ((m, "put") -> none) * ((m, "validKey") -> none) *
 				((#c, "hasOwnProperty") -> none) * KVPairs(#c; kvs, keys) * empty_fields(#c : -u- (keys, -{ "hasOwnProperty" }-));
 
@@ -22,11 +22,11 @@
 		[def2: #k, #v] 
 					 (kvs == -u- (-{ {{ #k, #v }} }-, #rkvs)) * (keys == -u- (-{ #k }-, #rkeys)) *
 					 (! (#k --e-- #rkeys)) * 
-					 ValidKey(#k;) * DataProp(o, #k; #v) * KVPairs(o; #rkvs, #rkeys) *
+					 ValidKey(#k) * DataProp(o, #k; #v) * KVPairs(o; #rkvs, #rkeys) *
 					 types (#rkvs: Set, #rkeys: Set);
 
-		@pred MapProto(mp;) :
-				JSObject(mp;) *
+		@pred MapProto(mp) :
+				JSObject(mp) *
 				DataProp(mp, "get"; #gl) * JSFunctionObject(#gl; "mapGet", _, _, _) *
 				DataProp(mp, "put"; #pl) * JSFunctionObject(#pl; "mapPut", _, _, _) *
 				DataProp(mp, "validKey"; #vKl) * JSFunctionObject(#vKl; "isValidKey", _, _, _) *
@@ -38,19 +38,19 @@
 		@id  map
 
 		@pre (
-			initialHeapPostWeak(;) * 
+			initialHeapPostWeak() * 
 			JSObjWithProto(this; #mp) *
 				((this, "_contents") -> none) *
 				((this, "get") -> none) *
 				((this, "put") -> none) *
 				((this, "validKey") -> none) *
-				MapProto(#mp;)
+				MapProto(#mp)
 		)
 	  
 		@post (
-			initialHeapPostWeak(;) * 
+			initialHeapPostWeak() * 
 			Map(this; #mp, #kvs, #keys) * (#kvs == -{ }-) * (#keys == -{ }-) * 
-			MapProto(#mp;) * (ret == this)
+			MapProto(#mp) * (ret == this)
 		)
 */
 function Map() {
@@ -61,10 +61,10 @@ function Map() {
 /**
 	@id isValidKey
 	
-	@pre  ((key == #key) * ValidKey(#key;))
+	@pre  ((key == #key) * ValidKey(#key))
 	@post (ret == true)
 		
-	@pre ((key == #key) * InvalidKey(#key;))
+	@pre ((key == #key) * InvalidKey(#key))
 	@post (ret == false)
 */
 Map.prototype.validKey = function (key) {
@@ -74,15 +74,15 @@ Map.prototype.validKey = function (key) {
 /**
 	@id mapGet
 	
-	@pre     (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * InvalidKey(#k;) * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;)
-	@posterr Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ErrorObjectWithMessage(ret; "Invalid Key") * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;)
+	@pre     (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp) * InvalidKey(#k) * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject()
+	@posterr Map(this; #mp, #kvs, #keys) * MapProto(#mp) * ErrorObjectWithMessage(ret; "Invalid Key") * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject()
 
-	@pre  (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (! (#k --e-- #keys)) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
-	@post Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * (ret == null) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
+	@pre  (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (! (#k --e-- #keys)) * GlobalObject() * ObjectPrototype($lobj_proto)
+	@post Map(this; #mp, #kvs, #keys) * MapProto(#mp) * (ret == null) * GlobalObject() * ObjectPrototype($lobj_proto)
 	
 	@pre [existent_key: #v] 
-				 (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (#k --e-- #keys) * ({{ #k, #v }} --e-- #kvs) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
-	@post Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * (ret == #v) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
+				 (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (#k --e-- #keys) * ({{ #k, #v }} --e-- #kvs) * GlobalObject() * ObjectPrototype($lobj_proto)
+	@post Map(this; #mp, #kvs, #keys) * MapProto(#mp) * (ret == #v) * GlobalObject() * ObjectPrototype($lobj_proto)
 */
 Map.prototype.get = function (k) {
 	/* @tactic assert ( DataProp(this, "_contents"; #c) ) [bind: #c] */
@@ -100,17 +100,17 @@ Map.prototype.get = function (k) {
 /**
 	@id mapPut
 	
-	@pre     (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * InvalidKey(#k;) * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;)
-	@posterr Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ErrorObjectWithMessage(ret; "Invalid Key") * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;)
+	@pre     (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp) * InvalidKey(#k) * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject()
+	@posterr Map(this; #mp, #kvs, #keys) * MapProto(#mp) * ErrorObjectWithMessage(ret; "Invalid Key") * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject()
 
-	@pre  (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (! (#k --e-- #keys)) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
-		@post Map(this; #mp, -u- (-{ {{ #k, #v }} }-, #kvs), -u- (-{ #k }-, #keys)) * MapProto(#mp;) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
+	@pre  (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (! (#k --e-- #keys)) * GlobalObject() * ObjectPrototype($lobj_proto)
+		@post Map(this; #mp, -u- (-{ {{ #k, #v }} }-, #kvs), -u- (-{ #k }-, #keys)) * MapProto(#mp) * GlobalObject() * ObjectPrototype($lobj_proto)
 
 	  
 	@pre  [existent_key: #w, #rkvs]
-					(k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (#k --e-- #keys) * 
-				(#kvs == -u- (-{ {{ #k, #w }} }-, #rkvs)) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
-	@post Map(this; #mp, -u- (-{ {{ #k, #v }} }-, #rkvs), #keys) * MapProto(#mp;) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
+					(k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (#k --e-- #keys) * 
+				(#kvs == -u- (-{ {{ #k, #w }} }-, #rkvs)) * GlobalObject() * ObjectPrototype($lobj_proto)
+	@post Map(this; #mp, -u- (-{ {{ #k, #v }} }-, #rkvs), #keys) * MapProto(#mp) * GlobalObject() * ObjectPrototype($lobj_proto)
 */
 Map.prototype.put = function (k, v) {
 	/* @tactic assert( DataProp(this, "_contents"; #c) * scope (v : #v) ) [bind: #c] */

--- a/Gillian-JS/Examples/JaVerT/KVMap.js
+++ b/Gillian-JS/Examples/JaVerT/KVMap.js
@@ -12,24 +12,24 @@
 				types (ik : Str) * (ik == "hasOwnProperty");
 
 		@pred Map (m; mp, kvs, keys) :
-				JSObjWithProto(m, mp) *
-				DataProp(m, "_contents", #c) * JSObject(#c) *
+				JSObjWithProto(m; mp) *
+				DataProp(m, "_contents"; #c) * JSObject(#c;) *
 				((m, "get") -> none) * ((m, "put") -> none) * ((m, "validKey") -> none) *
-				((#c, "hasOwnProperty") -> none) * KVPairs(#c, kvs, keys) * empty_fields(#c : -u- (keys, -{ "hasOwnProperty" }-));
+				((#c, "hasOwnProperty") -> none) * KVPairs(#c; kvs, keys) * empty_fields(#c : -u- (keys, -{ "hasOwnProperty" }-));
 
 		@pred KVPairs (o; kvs : Set, keys : Set) :
 		[def1] (kvs == -{ }-) * (keys == -{ }-),
 		[def2: #k, #v] 
 					 (kvs == -u- (-{ {{ #k, #v }} }-, #rkvs)) * (keys == -u- (-{ #k }-, #rkeys)) *
 					 (! (#k --e-- #rkeys)) * 
-					 ValidKey(#k) * DataProp(o, #k, #v) * KVPairs(o, #rkvs, #rkeys) *
+					 ValidKey(#k;) * DataProp(o, #k; #v) * KVPairs(o; #rkvs, #rkeys) *
 					 types (#rkvs: Set, #rkeys: Set);
 
 		@pred MapProto(mp;) :
-				JSObject(mp) *
-				DataProp(mp, "get", #gl) * JSFunctionObject(#gl, "mapGet", _, _, _) *
-				DataProp(mp, "put", #pl) * JSFunctionObject(#pl, "mapPut", _, _, _) *
-				DataProp(mp, "validKey", #vKl) * JSFunctionObject(#vKl, "isValidKey", _, _, _) *
+				JSObject(mp;) *
+				DataProp(mp, "get"; #gl) * JSFunctionObject(#gl; "mapGet", _, _, _) *
+				DataProp(mp, "put"; #pl) * JSFunctionObject(#pl; "mapPut", _, _, _) *
+				DataProp(mp, "validKey"; #vKl) * JSFunctionObject(#vKl; "isValidKey", _, _, _) *
 				((mp, "_contents") -> none);
 */
 
@@ -38,19 +38,19 @@
 		@id  map
 
 		@pre (
-			initialHeapPostWeak() * 
-			JSObjWithProto(this, #mp) *
+			initialHeapPostWeak(;) * 
+			JSObjWithProto(this; #mp) *
 				((this, "_contents") -> none) *
 				((this, "get") -> none) *
 				((this, "put") -> none) *
 				((this, "validKey") -> none) *
-				MapProto(#mp)
+				MapProto(#mp;)
 		)
 	  
 		@post (
-			initialHeapPostWeak() * 
-			Map(this, #mp, #kvs, #keys) * (#kvs == -{ }-) * (#keys == -{ }-) * 
-			MapProto(#mp) * (ret == this)
+			initialHeapPostWeak(;) * 
+			Map(this; #mp, #kvs, #keys) * (#kvs == -{ }-) * (#keys == -{ }-) * 
+			MapProto(#mp;) * (ret == this)
 		)
 */
 function Map() {
@@ -61,10 +61,10 @@ function Map() {
 /**
 	@id isValidKey
 	
-	@pre  ((key == #key) * ValidKey(#key))
+	@pre  ((key == #key) * ValidKey(#key;))
 	@post (ret == true)
 		
-	@pre ((key == #key) * InvalidKey(#key))
+	@pre ((key == #key) * InvalidKey(#key;))
 	@post (ret == false)
 */
 Map.prototype.validKey = function (key) {
@@ -74,23 +74,23 @@ Map.prototype.validKey = function (key) {
 /**
 	@id mapGet
 	
-	@pre     (k == #k) * Map(this, #mp, #kvs, #keys) * MapProto(#mp) * InvalidKey(#k) * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject()
-	@posterr Map(this, #mp, #kvs, #keys) * MapProto(#mp) * ErrorObjectWithMessage(ret, "Invalid Key") * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject()
+	@pre     (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * InvalidKey(#k;) * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;)
+	@posterr Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ErrorObjectWithMessage(ret; "Invalid Key") * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;)
 
-	@pre  (k == #k) * Map(this, #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (! (#k --e-- #keys)) * GlobalObject() * ObjectPrototype($lobj_proto)
-	@post Map(this, #mp, #kvs, #keys) * MapProto(#mp) * (ret == null) * GlobalObject() * ObjectPrototype($lobj_proto)
+	@pre  (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (! (#k --e-- #keys)) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
+	@post Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * (ret == null) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
 	
 	@pre [existent_key: #v] 
-				 (k == #k) * Map(this, #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (#k --e-- #keys) * ({{ #k, #v }} --e-- #kvs) * GlobalObject() * ObjectPrototype($lobj_proto)
-	@post Map(this, #mp, #kvs, #keys) * MapProto(#mp) * (ret == #v) * GlobalObject() * ObjectPrototype($lobj_proto)
+				 (k == #k) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (#k --e-- #keys) * ({{ #k, #v }} --e-- #kvs) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
+	@post Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * (ret == #v) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
 */
 Map.prototype.get = function (k) {
-	/* @tactic assert ( DataProp(this, "_contents", #c) ) [bind: #c] */
+	/* @tactic assert ( DataProp(this, "_contents"; #c) ) [bind: #c] */
 	if (this.validKey(k)) {
-		/* @tactic if (#k -e- #keys) then { unfold KVPairs(#c, #kvs, #keys) [bind: (#k := #k) and (#v := #v)] } */
+		/* @tactic if (#k -e- #keys) then { unfold KVPairs(#c; #kvs, #keys) [bind: (#k := #k) and (#v := #v)] } */
 		if (this._contents.hasOwnProperty(k)) {
 			var result = this._contents[k];
-			/* @tactic fold KVPairs(#c, #kvs, #keys) [def2 with (#k := #k)] */
+			/* @tactic fold KVPairs(#c; #kvs, #keys) [def2 with (#k := #k)] */
 			return result
 		} else { return null }
 	} else
@@ -100,26 +100,26 @@ Map.prototype.get = function (k) {
 /**
 	@id mapPut
 	
-	@pre     (k == #k) * (v == #v) * Map(this, #mp, #kvs, #keys) * MapProto(#mp) * InvalidKey(#k) * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject()
-	@posterr Map(this, #mp, #kvs, #keys) * MapProto(#mp) * ErrorObjectWithMessage(ret, "Invalid Key") * GlobalObject() * ObjectPrototype($lobj_proto) * BI_ErrorObject()
+	@pre     (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * InvalidKey(#k;) * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;)
+	@posterr Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ErrorObjectWithMessage(ret; "Invalid Key") * GlobalObject(;) * ObjectPrototype($lobj_proto;) * BI_ErrorObject(;)
 
-	@pre  (k == #k) * (v == #v) * Map(this, #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (! (#k --e-- #keys)) * GlobalObject() * ObjectPrototype($lobj_proto)
-		@post Map(this, #mp, -u- (-{ {{ #k, #v }} }-, #kvs), -u- (-{ #k }-, #keys)) * MapProto(#mp) * GlobalObject() * ObjectPrototype($lobj_proto)
+	@pre  (k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (! (#k --e-- #keys)) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
+		@post Map(this; #mp, -u- (-{ {{ #k, #v }} }-, #kvs), -u- (-{ #k }-, #keys)) * MapProto(#mp;) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
 
 	  
 	@pre  [existent_key: #w, #rkvs]
-					(k == #k) * (v == #v) * Map(this, #mp, #kvs, #keys) * MapProto(#mp) * ValidKey(#k) * (#k --e-- #keys) * 
-				(#kvs == -u- (-{ {{ #k, #w }} }-, #rkvs)) * GlobalObject() * ObjectPrototype($lobj_proto)
-	@post Map(this, #mp, -u- (-{ {{ #k, #v }} }-, #rkvs), #keys) * MapProto(#mp) * GlobalObject() * ObjectPrototype($lobj_proto)
+					(k == #k) * (v == #v) * Map(this; #mp, #kvs, #keys) * MapProto(#mp;) * ValidKey(#k;) * (#k --e-- #keys) * 
+				(#kvs == -u- (-{ {{ #k, #w }} }-, #rkvs)) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
+	@post Map(this; #mp, -u- (-{ {{ #k, #v }} }-, #rkvs), #keys) * MapProto(#mp;) * GlobalObject(;) * ObjectPrototype($lobj_proto;)
 */
 Map.prototype.put = function (k, v) {
-	/* @tactic assert( DataProp(this, "_contents", #c) * scope (v : #v) ) [bind: #c] */
+	/* @tactic assert( DataProp(this, "_contents"; #c) * scope (v : #v) ) [bind: #c] */
 	if (this.validKey(k)) {
-		/* @tactic if (#k -e- #keys) then { unfold KVPairs(#c, #kvs, #keys) [bind: (#k := #k) and (#v := #w) and (#rkvs := #rkvs)] } */
+		/* @tactic if (#k -e- #keys) then { unfold KVPairs(#c; #kvs, #keys) [bind: (#k := #k) and (#v := #w) and (#rkvs := #rkvs)] } */
 		this._contents[k] = v;
 		/* @tactic if (#k -e- #keys) 
-			then { fold KVPairs(#c, -u- (-{ {{ #k, #v }} }-, #rkvs), #keys) [def2 with (#k := #k) and (#v := #v) and (#rkvs := #rkvs) and (#rkeys := (#keys -d- -{ #k }-))] } 
-			else { fold KVPairs(#c, -u- (-{ {{ #k, #v }} }-, #kvs), -u- ( -{ #k }-, #keys)) [def2 with (#k := #k) and (#v := #v) and (#rkvs := #kvs)] } */
+			then { fold KVPairs(#c; -u- (-{ {{ #k, #v }} }-, #rkvs), #keys) [def2 with (#k := #k) and (#v := #v) and (#rkvs := #rkvs) and (#rkeys := (#keys -d- -{ #k }-))] } 
+			else { fold KVPairs(#c; -u- (-{ {{ #k, #v }} }-, #kvs), -u- ( -{ #k }-, #keys)) [def2 with (#k := #k) and (#v := #v) and (#rkvs := #kvs)] } */
 		return v;
 	} else
 		throw new Error("Invalid Key")

--- a/Gillian-JS/Examples/JaVerT/KVMap.js
+++ b/Gillian-JS/Examples/JaVerT/KVMap.js
@@ -1,23 +1,23 @@
 "use strict";
 
 /*
-		@pred ValidKey(k) : 
+		@pred ValidKey(k;) : 
 				types(k : Str) * (! (k == "hasOwnProperty"));
 
-		@pred InvalidKey(ik) :
+		@pred InvalidKey(ik;) :
 				types (ik : Undefined),
 				types (ik : Null),
 				types (ik : Bool),
 				types (ik : Num),
 				types (ik : Str) * (ik == "hasOwnProperty");
 
-		@pred Map (+m, mp, kvs, keys) :
+		@pred Map (m; mp, kvs, keys) :
 				JSObjWithProto(m, mp) *
 				DataProp(m, "_contents", #c) * JSObject(#c) *
 				((m, "get") -> none) * ((m, "put") -> none) * ((m, "validKey") -> none) *
 				((#c, "hasOwnProperty") -> none) * KVPairs(#c, kvs, keys) * empty_fields(#c : -u- (keys, -{ "hasOwnProperty" }-));
 
-		@pred KVPairs (+o, kvs : Set, keys : Set) :
+		@pred KVPairs (o; kvs : Set, keys : Set) :
 		[def1] (kvs == -{ }-) * (keys == -{ }-),
 		[def2: #k, #v] 
 					 (kvs == -u- (-{ {{ #k, #v }} }-, #rkvs)) * (keys == -u- (-{ #k }-, #rkeys)) *
@@ -25,7 +25,7 @@
 					 ValidKey(#k) * DataProp(o, #k, #v) * KVPairs(o, #rkvs, #rkeys) *
 					 types (#rkvs: Set, #rkeys: Set);
 
-		@pred MapProto(mp) :
+		@pred MapProto(mp;) :
 				JSObject(mp) *
 				DataProp(mp, "get", #gl) * JSFunctionObject(#gl, "mapGet", _, _, _) *
 				DataProp(mp, "put", #pl) * JSFunctionObject(#pl, "mapPut", _, _, _) *

--- a/Gillian-JS/Examples/JaVerT/PriQ.js
+++ b/Gillian-JS/Examples/JaVerT/PriQ.js
@@ -8,8 +8,8 @@
 		DataProp(n, "next"; next) *
 		((n, "insert") -> none);
 
-	@pred NodePrototype(np:Obj;) :
-		JSObject(np;) *
+	@pred NodePrototype(np:Obj) :
+		JSObject(np) *
 		DataProp(np, "insert"; #insert_loc) *
 		JSFunctionObject(#insert_loc; "np_insert", _, _, _) *
 		((np, "pri") -> none) *
@@ -31,13 +31,13 @@
 		((pq, "dequeue") -> none);
 
 	@pred QueuePrototype(qp; np, qfs_sc):
-		JSObject(qp;) *
+		JSObject(qp) *
 		DataProp(qp, "enqueue"; #enqueue_loc) * JSFunctionObject(#enqueue_loc; "enqueue", qfs_sc, _, _) *
 		DataProp(qp, "dequeue"; #dequeue_loc) * JSFunctionObject(#dequeue_loc; "dequeue", qfs_sc, _, _) *
 		((qp, "_head") -> none) *
-		sc_scope(enqueue, Node : #n, qfs_sc) * JSFunctionObject(#n; "Node", #node_sc, _, np) * NodePrototype(np;);
+		sc_scope(enqueue, Node : #n, qfs_sc) * JSFunctionObject(#n; "Node", #node_sc, _, np) * NodePrototype(np);
 
-	@pred PriorityQueueModule(pq, np;) :
+	@pred PriorityQueueModule(pq, np) :
 	  JSFunctionObject(pq; "PriorityQueue", #pq_sc, _, #pqp) *
 	  QueuePrototype(#pqp; np, #qfs_sc) *
 	  o_chains(PriorityQueue: #pq_sc, enqueue: #qfs_sc);
@@ -47,17 +47,17 @@
 	@toprequires emp
 	@topensures (
 		scope(q : #q) * scope(r : #r) *
-		scope(PriorityQueue : #pq_lib) * PriorityQueueModule (#pq_lib, #np;) *
+		scope(PriorityQueue : #pq_lib) * PriorityQueueModule (#pq_lib, #np) *
 		Queue(#q, #np; #pqp, #pri_q, 1) *
-		(ret == #r) * JSObject(#r;) * DataProp(#r, "pri"; _) * DataProp(#r, "val"; _)
+		(ret == #r) * JSObject(#r) * DataProp(#r, "pri"; _) * DataProp(#r, "val"; _)
 	)
 */
 
 /**
 	@id PQLib
 
-	@pre  ObjectPrototype($lobj_proto;)
-  @post ObjectPrototype($lobj_proto;) * PriorityQueueModule (ret, #np;)
+	@pre  ObjectPrototype($lobj_proto)
+  @post ObjectPrototype($lobj_proto) * PriorityQueueModule (ret, #np)
 */
 var PriorityQueue = (function () {
 
@@ -68,13 +68,13 @@ var PriorityQueue = (function () {
 			(pri == #pri) * types(#pri : Num) * (0 <# #pri) * (val == #val) *
 			((this, "pri") -> none) * ((this, "val") -> none) * ((this, "next") -> none) *
 			((this, "insert") -> none) *
-			JSObjWithProto(this; #np) * NodePrototype(#np;) *
-			ObjectPrototype($lobj_proto;)
+			JSObjWithProto(this; #np) * NodePrototype(#np) *
+			ObjectPrototype($lobj_proto)
 		)
 		@post (
 			Node(this; #pri, #val, null, #np) *
-			NodePrototype(#np;) *
-			ObjectPrototype($lobj_proto;) *
+			NodePrototype(#np) *
+			ObjectPrototype($lobj_proto) *
 			(ret == undefined)
 		)
 	*/
@@ -91,12 +91,12 @@ var PriorityQueue = (function () {
 			(nl == #nl) *
 			NodeList(#nl, #np; #pri_nl, #length) *
 			Node(this; #npri, #nval, null, #np) *
-			NodePrototype(#np;) *
+			NodePrototype(#np) *
 			(#pri_nl <# #npri)
 		)
 		@post (
 			NodeList(this, #np; #npri, #length + 1) *
-			NodePrototype(#np;) *
+			NodePrototype(#np) *
 			(ret == this)
 		)
 
@@ -104,12 +104,12 @@ var PriorityQueue = (function () {
 			(nl == #nl) *
 			NodeList(#nl, #np; #pri_nl, #length) *
 			Node(this; #npri, #nval, null, #np) *
-			NodePrototype(#np;) *
+			NodePrototype(#np) *
 			(#npri <=# #pri_nl)
 	  )
 	  @post (
 			NodeList(#nl, #np; #pri_nl, #length + 1) *
-			NodePrototype(#np;) *
+			NodePrototype(#np) *
 			(ret == #nl)
         )
 
@@ -117,17 +117,17 @@ var PriorityQueue = (function () {
 			(nl == #nl) *
 			NodeList(#nl, #np; #pri_nl, #length) *
 			Node(this; #npri, #nval, null, #np) *
-			NodePrototype(#np;)
+			NodePrototype(#np)
 	  )
     @post
       (
         NodeList(this, #np; #npri, #length + 1) *
-        NodePrototype(#np;) *
+        NodePrototype(#np) *
         (ret == this) * (#pri_nl <# #npri)
       );
       (
 			  NodeList(#nl, #np; #pri_nl, #length + 1) *
-			  NodePrototype(#np;) *
+			  NodePrototype(#np) *
         (ret == #nl) * (#npri <=# #pri_nl)
       )
 	*/
@@ -150,7 +150,7 @@ var PriorityQueue = (function () {
 	    @id PriorityQueue
 
 			@pre (
-				ObjectPrototype($lobj_proto;) *
+				ObjectPrototype($lobj_proto) *
         ((this, "_head") -> none) *
         ((this, "enqueue") -> none) *
         ((this, "dequeue") -> none) *
@@ -159,7 +159,7 @@ var PriorityQueue = (function () {
         QueuePrototype(#pqp; #np, #qfs_sc)
 	    )
 	    @post (
-	    	ObjectPrototype($lobj_proto;) *
+	    	ObjectPrototype($lobj_proto) *
 	    	Queue(this, #np; #pqp, 0, 0) *
 	    	QueuePrototype(#pqp; #np, #qfs_sc) *
 	    	(ret == undefined)
@@ -177,12 +177,12 @@ var PriorityQueue = (function () {
 				Queue(this, #np; #pqp, #pri_q, #length) *
 				QueuePrototype(#pqp; #np, #qfs_sc) *
 				o_chains(enqueue: #qfs_sc, PQLib: $$scope) *
-				(#pri <=# #pri_q) * ObjectPrototype($lobj_proto;)
+				(#pri <=# #pri_q) * ObjectPrototype($lobj_proto)
 			)
 			@post (
 				(ret == undefined) *
 				Queue(this, #np; #pqp, #pri_q, #length + 1) *
-				QueuePrototype(#pqp; #np, #qfs_sc) * ObjectPrototype($lobj_proto;)
+				QueuePrototype(#pqp; #np, #qfs_sc) * ObjectPrototype($lobj_proto)
 			)
 
 			@pre (
@@ -190,12 +190,12 @@ var PriorityQueue = (function () {
 				Queue(this, #np; #pqp, #pri_q, #length) *
 				QueuePrototype(#pqp; #np, #qfs_sc) *
 				o_chains(enqueue: #qfs_sc, PQLib: $$scope) *
-				(#pri_q <# #pri) * ObjectPrototype($lobj_proto;)
+				(#pri_q <# #pri) * ObjectPrototype($lobj_proto)
 			)
 			@post (
 				(ret == undefined) *
 				Queue(this, #np; #pqp, #pri, #length + 1) *
-				QueuePrototype(#pqp; #np, #qfs_sc) * ObjectPrototype($lobj_proto;)
+				QueuePrototype(#pqp; #np, #qfs_sc) * ObjectPrototype($lobj_proto)
 			)
 	*/
 	PQ.prototype.enqueue = function(pri, val) {
@@ -216,7 +216,7 @@ var PriorityQueue = (function () {
      @post (
        Queue(this, #np; #pqp, #new_pri_q, #length - 1) *
        QueuePrototype(#pqp; #np, #qfs_sc) *
-       (ret == #r) * JSObject(#r;) *
+       (ret == #r) * JSObject(#r) *
        DataProp(#r, "pri"; #pri_q) * DataProp(#r, "val"; #some_val)
      )
 
@@ -224,13 +224,13 @@ var PriorityQueue = (function () {
        Queue(this, #np; #pqp, #pri_q, #length) * (#length == 0) *
        QueuePrototype(#pqp; #np, #qfs_sc) *
        o_chains(enqueue: #qfs_sc, dequeue: $$scope) *
-       GlobalObject(;) * BI_ErrorObject(;)
+       GlobalObject() * BI_ErrorObject()
      )
      @posterr (
        Queue(this, #np; #pqp, #pri_q, #length) *
        QueuePrototype(#pqp; #np, #qfs_sc) *
        (ret == #e) * ErrorObjectWithMessage(#e; "Queue is empty") *
-       GlobalObject(;) * BI_ErrorObject(;)
+       GlobalObject() * BI_ErrorObject()
      )
 	*/
 	PQ.prototype.dequeue = function () {

--- a/Gillian-JS/Examples/JaVerT/PriQ.js
+++ b/Gillian-JS/Examples/JaVerT/PriQ.js
@@ -1,14 +1,14 @@
 "use strict";
 
 /**
-	@pred Node(+n, pri:Num, val, next, np:Obj) :
+	@pred Node(n; pri:Num, val, next, np:Obj) :
 		JSObjWithProto(n, np)     *
 		DataProp(n, "pri",  pri)  * (0 <# pri) *
 		DataProp(n, "val",  val)  *
 		DataProp(n, "next", next) *
 		((n, "insert") -> none);
 
-	@pred NodePrototype(np:Obj) :
+	@pred NodePrototype(np:Obj;) :
 		JSObject(np) *
 		DataProp(np, "insert", #insert_loc) *
 		JSFunctionObject(#insert_loc, "np_insert", _, _, _) *
@@ -16,28 +16,28 @@
 		((np, "val") -> none) *
 		((np, "next") -> none);
 
-	@pred NodeList(+nl, +np:Obj, max_pri:Num, length:Num) :
+	@pred NodeList(nl, np:Obj; max_pri:Num, length:Num) :
 		(nl == null) * (max_pri == 0) * (length == 0),
 
 		Node(nl, max_pri, #val, #next, np) * (0 <# max_pri) *
 		NodeList(#next, np, #pri, #len_nl) * (#pri <=# max_pri) *
 	    (0 <# length) * (length == #len_nl + 1);
 
-	@pred Queue(+pq, +np, qp, max_pri : Num, length : Num) :
+	@pred Queue(pq, np; qp, max_pri : Num, length : Num) :
 		JSObjWithProto(pq, qp) *
 		DataProp(pq, "_head",  #head) *
 		NodeList(#head, np, max_pri, length) *
 		((pq, "enqueue") -> none) *
 		((pq, "dequeue") -> none);
 
-	@pred QueuePrototype(+qp, np, qfs_sc):
+	@pred QueuePrototype(qp; np, qfs_sc):
 		JSObject(qp) *
 		DataProp(qp, "enqueue", #enqueue_loc) * JSFunctionObject(#enqueue_loc, "enqueue", qfs_sc, _, _) *
 		DataProp(qp, "dequeue", #dequeue_loc) * JSFunctionObject(#dequeue_loc, "dequeue", qfs_sc, _, _) *
 		((qp, "_head") -> none) *
 		sc_scope(enqueue, Node : #n, qfs_sc) * JSFunctionObject(#n, "Node", #node_sc, _, np) * NodePrototype(np);
 
-	@pred PriorityQueueModule(pq, np) :
+	@pred PriorityQueueModule(pq, np;) :
 	  JSFunctionObject(pq, "PriorityQueue", #pq_sc, _, #pqp) *
 	  QueuePrototype(#pqp, np, #qfs_sc) *
 	  o_chains(PriorityQueue: #pq_sc, enqueue: #qfs_sc);

--- a/Gillian-JS/Examples/JaVerT/PriQ.js
+++ b/Gillian-JS/Examples/JaVerT/PriQ.js
@@ -23,7 +23,7 @@
 		NodeList(#next, np, #pri, #len_nl) * (#pri <=# max_pri) *
 	    (0 <# length) * (length == #len_nl + 1);
 
-	@pred Queue(+pq, qp, +np, max_pri : Num, length : Num) :
+	@pred Queue(+pq, +np, qp, max_pri : Num, length : Num) :
 		JSObjWithProto(pq, qp) *
 		DataProp(pq, "_head",  #head) *
 		NodeList(#head, np, max_pri, length) *
@@ -48,7 +48,7 @@
 	@topensures (
 		scope(q : #q) * scope(r : #r) *
 		scope(PriorityQueue : #pq_lib) * PriorityQueueModule (#pq_lib, #np) *
-		Queue(#q, #pqp, #np, #pri_q, 1) *
+		Queue(#q, #np, #pqp, #pri_q, 1) *
 		(ret == #r) * JSObject(#r) * DataProp(#r, "pri", _) * DataProp(#r, "val", _)
 	)
 */
@@ -160,7 +160,7 @@ var PriorityQueue = (function () {
 	    )
 	    @post (
 	    	ObjectPrototype($lobj_proto) *
-	    	Queue(this, #pqp, #np, 0, 0) *
+	    	Queue(this, #np, #pqp, 0, 0) *
 	    	QueuePrototype(#pqp, #np, #qfs_sc) *
 	    	(ret == undefined)
 	    )
@@ -174,27 +174,27 @@ var PriorityQueue = (function () {
 
 			@pre (
 				(pri == #pri) * (0 <# #pri) * (val == #val) *
-				Queue(this, #pqp, #np, #pri_q, #length) *
+				Queue(this, #np, #pqp, #pri_q, #length) *
 				QueuePrototype(#pqp, #np, #qfs_sc) *
 				o_chains(enqueue: #qfs_sc, PQLib: $$scope) *
 				(#pri <=# #pri_q) * ObjectPrototype($lobj_proto)
 			)
 			@post (
 				(ret == undefined) *
-				Queue(this, #pqp, #np, #pri_q, #length + 1) *
+				Queue(this, #np, #pqp, #pri_q, #length + 1) *
 				QueuePrototype(#pqp, #np, #qfs_sc) * ObjectPrototype($lobj_proto)
 			)
 
 			@pre (
 				(pri == #pri) * (0 <# #pri) * (val == #val) *
-				Queue(this, #pqp, #np, #pri_q, #length) *
+				Queue(this, #np, #pqp, #pri_q, #length) *
 				QueuePrototype(#pqp, #np, #qfs_sc) *
 				o_chains(enqueue: #qfs_sc, PQLib: $$scope) *
 				(#pri_q <# #pri) * ObjectPrototype($lobj_proto)
 			)
 			@post (
 				(ret == undefined) *
-				Queue(this, #pqp, #np, #pri, #length + 1) *
+				Queue(this, #np, #pqp, #pri, #length + 1) *
 				QueuePrototype(#pqp, #np, #qfs_sc) * ObjectPrototype($lobj_proto)
 			)
 	*/
@@ -208,26 +208,26 @@ var PriorityQueue = (function () {
 		@id dequeue
 
      @pre (
-       Queue(this, #pqp, #np, #pri_q, #length) *
+       Queue(this, #np, #pqp, #pri_q, #length) *
        QueuePrototype(#pqp, #np, #qfs_sc) *
        o_chains(enqueue: #qfs_sc, dequeue: $$scope) *
        (0 <# #length)
      )
      @post (
-       Queue(this, #pqp, #np, #new_pri_q, #length - 1) *
+       Queue(this, #np, #pqp, #new_pri_q, #length - 1) *
        QueuePrototype(#pqp, #np, #qfs_sc) *
        (ret == #r) * JSObject(#r) *
        DataProp(#r, "pri", #pri_q) * DataProp(#r, "val", #some_val)
      )
 
 	@pre (
-       Queue(this, #pqp, #np, #pri_q, #length) * (#length == 0) *
+       Queue(this, #np, #pqp, #pri_q, #length) * (#length == 0) *
        QueuePrototype(#pqp, #np, #qfs_sc) *
        o_chains(enqueue: #qfs_sc, dequeue: $$scope) *
        GlobalObject() * BI_ErrorObject()
      )
      @posterr (
-       Queue(this, #pqp, #np, #pri_q, #length) *
+       Queue(this, #np, #pqp, #pri_q, #length) *
        QueuePrototype(#pqp, #np, #qfs_sc) *
        (ret == #e) * ErrorObjectWithMessage(#e, "Queue is empty") *
        GlobalObject() * BI_ErrorObject()

--- a/Gillian-JS/Examples/JaVerT/PriQ.js
+++ b/Gillian-JS/Examples/JaVerT/PriQ.js
@@ -2,16 +2,16 @@
 
 /**
 	@pred Node(n; pri:Num, val, next, np:Obj) :
-		JSObjWithProto(n, np)     *
-		DataProp(n, "pri",  pri)  * (0 <# pri) *
-		DataProp(n, "val",  val)  *
-		DataProp(n, "next", next) *
+		JSObjWithProto(n; np)     *
+		DataProp(n, "pri";  pri)  * (0 <# pri) *
+		DataProp(n, "val";  val)  *
+		DataProp(n, "next"; next) *
 		((n, "insert") -> none);
 
 	@pred NodePrototype(np:Obj;) :
-		JSObject(np) *
-		DataProp(np, "insert", #insert_loc) *
-		JSFunctionObject(#insert_loc, "np_insert", _, _, _) *
+		JSObject(np;) *
+		DataProp(np, "insert"; #insert_loc) *
+		JSFunctionObject(#insert_loc; "np_insert", _, _, _) *
 		((np, "pri") -> none) *
 		((np, "val") -> none) *
 		((np, "next") -> none);
@@ -19,27 +19,27 @@
 	@pred NodeList(nl, np:Obj; max_pri:Num, length:Num) :
 		(nl == null) * (max_pri == 0) * (length == 0),
 
-		Node(nl, max_pri, #val, #next, np) * (0 <# max_pri) *
-		NodeList(#next, np, #pri, #len_nl) * (#pri <=# max_pri) *
+		Node(nl; max_pri, #val, #next, np) * (0 <# max_pri) *
+		NodeList(#next, np; #pri, #len_nl) * (#pri <=# max_pri) *
 	    (0 <# length) * (length == #len_nl + 1);
 
 	@pred Queue(pq, np; qp, max_pri : Num, length : Num) :
-		JSObjWithProto(pq, qp) *
-		DataProp(pq, "_head",  #head) *
-		NodeList(#head, np, max_pri, length) *
+		JSObjWithProto(pq; qp) *
+		DataProp(pq, "_head";  #head) *
+		NodeList(#head, np; max_pri, length) *
 		((pq, "enqueue") -> none) *
 		((pq, "dequeue") -> none);
 
 	@pred QueuePrototype(qp; np, qfs_sc):
-		JSObject(qp) *
-		DataProp(qp, "enqueue", #enqueue_loc) * JSFunctionObject(#enqueue_loc, "enqueue", qfs_sc, _, _) *
-		DataProp(qp, "dequeue", #dequeue_loc) * JSFunctionObject(#dequeue_loc, "dequeue", qfs_sc, _, _) *
+		JSObject(qp;) *
+		DataProp(qp, "enqueue"; #enqueue_loc) * JSFunctionObject(#enqueue_loc; "enqueue", qfs_sc, _, _) *
+		DataProp(qp, "dequeue"; #dequeue_loc) * JSFunctionObject(#dequeue_loc; "dequeue", qfs_sc, _, _) *
 		((qp, "_head") -> none) *
-		sc_scope(enqueue, Node : #n, qfs_sc) * JSFunctionObject(#n, "Node", #node_sc, _, np) * NodePrototype(np);
+		sc_scope(enqueue, Node : #n, qfs_sc) * JSFunctionObject(#n; "Node", #node_sc, _, np) * NodePrototype(np;);
 
 	@pred PriorityQueueModule(pq, np;) :
-	  JSFunctionObject(pq, "PriorityQueue", #pq_sc, _, #pqp) *
-	  QueuePrototype(#pqp, np, #qfs_sc) *
+	  JSFunctionObject(pq; "PriorityQueue", #pq_sc, _, #pqp) *
+	  QueuePrototype(#pqp; np, #qfs_sc) *
 	  o_chains(PriorityQueue: #pq_sc, enqueue: #qfs_sc);
 */
 
@@ -47,17 +47,17 @@
 	@toprequires emp
 	@topensures (
 		scope(q : #q) * scope(r : #r) *
-		scope(PriorityQueue : #pq_lib) * PriorityQueueModule (#pq_lib, #np) *
-		Queue(#q, #np, #pqp, #pri_q, 1) *
-		(ret == #r) * JSObject(#r) * DataProp(#r, "pri", _) * DataProp(#r, "val", _)
+		scope(PriorityQueue : #pq_lib) * PriorityQueueModule (#pq_lib, #np;) *
+		Queue(#q, #np; #pqp, #pri_q, 1) *
+		(ret == #r) * JSObject(#r;) * DataProp(#r, "pri"; _) * DataProp(#r, "val"; _)
 	)
 */
 
 /**
 	@id PQLib
 
-	@pre  ObjectPrototype($lobj_proto)
-  @post ObjectPrototype($lobj_proto) * PriorityQueueModule (ret, #np)
+	@pre  ObjectPrototype($lobj_proto;)
+  @post ObjectPrototype($lobj_proto;) * PriorityQueueModule (ret, #np;)
 */
 var PriorityQueue = (function () {
 
@@ -68,13 +68,13 @@ var PriorityQueue = (function () {
 			(pri == #pri) * types(#pri : Num) * (0 <# #pri) * (val == #val) *
 			((this, "pri") -> none) * ((this, "val") -> none) * ((this, "next") -> none) *
 			((this, "insert") -> none) *
-			JSObjWithProto(this, #np) * NodePrototype(#np) *
-			ObjectPrototype($lobj_proto)
+			JSObjWithProto(this; #np) * NodePrototype(#np;) *
+			ObjectPrototype($lobj_proto;)
 		)
 		@post (
-			Node(this, #pri, #val, null, #np) *
-			NodePrototype(#np) *
-			ObjectPrototype($lobj_proto) *
+			Node(this; #pri, #val, null, #np) *
+			NodePrototype(#np;) *
+			ObjectPrototype($lobj_proto;) *
 			(ret == undefined)
 		)
 	*/
@@ -89,45 +89,45 @@ var PriorityQueue = (function () {
 
 		@pre (
 			(nl == #nl) *
-			NodeList(#nl, #np, #pri_nl, #length) *
-			Node(this, #npri, #nval, null, #np) *
-			NodePrototype(#np) *
+			NodeList(#nl, #np; #pri_nl, #length) *
+			Node(this; #npri, #nval, null, #np) *
+			NodePrototype(#np;) *
 			(#pri_nl <# #npri)
 		)
 		@post (
-			NodeList(this, #np, #npri, #length + 1) *
-			NodePrototype(#np) *
+			NodeList(this, #np; #npri, #length + 1) *
+			NodePrototype(#np;) *
 			(ret == this)
 		)
 
 	  @pre (
 			(nl == #nl) *
-			NodeList(#nl, #np, #pri_nl, #length) *
-			Node(this, #npri, #nval, null, #np) *
-			NodePrototype(#np) *
+			NodeList(#nl, #np; #pri_nl, #length) *
+			Node(this; #npri, #nval, null, #np) *
+			NodePrototype(#np;) *
 			(#npri <=# #pri_nl)
 	  )
 	  @post (
-			NodeList(#nl, #np, #pri_nl, #length + 1) *
-			NodePrototype(#np) *
+			NodeList(#nl, #np; #pri_nl, #length + 1) *
+			NodePrototype(#np;) *
 			(ret == #nl)
         )
 
       @pre (
 			(nl == #nl) *
-			NodeList(#nl, #np, #pri_nl, #length) *
-			Node(this, #npri, #nval, null, #np) *
-			NodePrototype(#np)
+			NodeList(#nl, #np; #pri_nl, #length) *
+			Node(this; #npri, #nval, null, #np) *
+			NodePrototype(#np;)
 	  )
     @post
       (
-        NodeList(this, #np, #npri, #length + 1) *
-        NodePrototype(#np) *
+        NodeList(this, #np; #npri, #length + 1) *
+        NodePrototype(#np;) *
         (ret == this) * (#pri_nl <# #npri)
       );
       (
-			  NodeList(#nl, #np, #pri_nl, #length + 1) *
-			  NodePrototype(#np) *
+			  NodeList(#nl, #np; #pri_nl, #length + 1) *
+			  NodePrototype(#np;) *
         (ret == #nl) * (#npri <=# #pri_nl)
       )
 	*/
@@ -150,18 +150,18 @@ var PriorityQueue = (function () {
 	    @id PriorityQueue
 
 			@pre (
-				ObjectPrototype($lobj_proto) *
+				ObjectPrototype($lobj_proto;) *
         ((this, "_head") -> none) *
         ((this, "enqueue") -> none) *
         ((this, "dequeue") -> none) *
-        JSObjWithProto(this, #pqp) *
+        JSObjWithProto(this; #pqp) *
         o_chains(enqueue: #qfs_sc, PQLib: $$scope) *
-        QueuePrototype(#pqp, #np, #qfs_sc)
+        QueuePrototype(#pqp; #np, #qfs_sc)
 	    )
 	    @post (
-	    	ObjectPrototype($lobj_proto) *
-	    	Queue(this, #np, #pqp, 0, 0) *
-	    	QueuePrototype(#pqp, #np, #qfs_sc) *
+	    	ObjectPrototype($lobj_proto;) *
+	    	Queue(this, #np; #pqp, 0, 0) *
+	    	QueuePrototype(#pqp; #np, #qfs_sc) *
 	    	(ret == undefined)
 	    )
 	*/
@@ -174,28 +174,28 @@ var PriorityQueue = (function () {
 
 			@pre (
 				(pri == #pri) * (0 <# #pri) * (val == #val) *
-				Queue(this, #np, #pqp, #pri_q, #length) *
-				QueuePrototype(#pqp, #np, #qfs_sc) *
+				Queue(this, #np; #pqp, #pri_q, #length) *
+				QueuePrototype(#pqp; #np, #qfs_sc) *
 				o_chains(enqueue: #qfs_sc, PQLib: $$scope) *
-				(#pri <=# #pri_q) * ObjectPrototype($lobj_proto)
+				(#pri <=# #pri_q) * ObjectPrototype($lobj_proto;)
 			)
 			@post (
 				(ret == undefined) *
-				Queue(this, #np, #pqp, #pri_q, #length + 1) *
-				QueuePrototype(#pqp, #np, #qfs_sc) * ObjectPrototype($lobj_proto)
+				Queue(this, #np; #pqp, #pri_q, #length + 1) *
+				QueuePrototype(#pqp; #np, #qfs_sc) * ObjectPrototype($lobj_proto;)
 			)
 
 			@pre (
 				(pri == #pri) * (0 <# #pri) * (val == #val) *
-				Queue(this, #np, #pqp, #pri_q, #length) *
-				QueuePrototype(#pqp, #np, #qfs_sc) *
+				Queue(this, #np; #pqp, #pri_q, #length) *
+				QueuePrototype(#pqp; #np, #qfs_sc) *
 				o_chains(enqueue: #qfs_sc, PQLib: $$scope) *
-				(#pri_q <# #pri) * ObjectPrototype($lobj_proto)
+				(#pri_q <# #pri) * ObjectPrototype($lobj_proto;)
 			)
 			@post (
 				(ret == undefined) *
-				Queue(this, #np, #pqp, #pri, #length + 1) *
-				QueuePrototype(#pqp, #np, #qfs_sc) * ObjectPrototype($lobj_proto)
+				Queue(this, #np; #pqp, #pri, #length + 1) *
+				QueuePrototype(#pqp; #np, #qfs_sc) * ObjectPrototype($lobj_proto;)
 			)
 	*/
 	PQ.prototype.enqueue = function(pri, val) {
@@ -208,34 +208,34 @@ var PriorityQueue = (function () {
 		@id dequeue
 
      @pre (
-       Queue(this, #np, #pqp, #pri_q, #length) *
-       QueuePrototype(#pqp, #np, #qfs_sc) *
+       Queue(this, #np; #pqp, #pri_q, #length) *
+       QueuePrototype(#pqp; #np, #qfs_sc) *
        o_chains(enqueue: #qfs_sc, dequeue: $$scope) *
        (0 <# #length)
      )
      @post (
-       Queue(this, #np, #pqp, #new_pri_q, #length - 1) *
-       QueuePrototype(#pqp, #np, #qfs_sc) *
-       (ret == #r) * JSObject(#r) *
-       DataProp(#r, "pri", #pri_q) * DataProp(#r, "val", #some_val)
+       Queue(this, #np; #pqp, #new_pri_q, #length - 1) *
+       QueuePrototype(#pqp; #np, #qfs_sc) *
+       (ret == #r) * JSObject(#r;) *
+       DataProp(#r, "pri"; #pri_q) * DataProp(#r, "val"; #some_val)
      )
 
 	@pre (
-       Queue(this, #np, #pqp, #pri_q, #length) * (#length == 0) *
-       QueuePrototype(#pqp, #np, #qfs_sc) *
+       Queue(this, #np; #pqp, #pri_q, #length) * (#length == 0) *
+       QueuePrototype(#pqp; #np, #qfs_sc) *
        o_chains(enqueue: #qfs_sc, dequeue: $$scope) *
-       GlobalObject() * BI_ErrorObject()
+       GlobalObject(;) * BI_ErrorObject(;)
      )
      @posterr (
-       Queue(this, #np, #pqp, #pri_q, #length) *
-       QueuePrototype(#pqp, #np, #qfs_sc) *
-       (ret == #e) * ErrorObjectWithMessage(#e, "Queue is empty") *
-       GlobalObject() * BI_ErrorObject()
+       Queue(this, #np; #pqp, #pri_q, #length) *
+       QueuePrototype(#pqp; #np, #qfs_sc) *
+       (ret == #e) * ErrorObjectWithMessage(#e; "Queue is empty") *
+       GlobalObject(;) * BI_ErrorObject(;)
      )
 	*/
 	PQ.prototype.dequeue = function () {
-      /* @tactic assert DataProp(this, "_head", #nl) [bind: #nl];
-                 unfold NodeList(#nl, #np, #pri_q, #length) */
+      /* @tactic assert DataProp(this, "_head"; #nl) [bind: #nl];
+                 unfold NodeList(#nl, #np; #pri_q, #length) */
 	  if (this._head === null) {
 	    throw new Error("Queue is empty");
 	  }

--- a/Gillian-JS/Examples/JaVerT/SLL.js
+++ b/Gillian-JS/Examples/JaVerT/SLL.js
@@ -1,10 +1,10 @@
 "use strict";
 
 /*
-  @pred Node(+x:Obj, val, next) :
+  @pred Node(x:Obj; val, next) :
     JSObject(x) * DataProp(x, "val", val) * DataProp(x, "next", next);
 
-  @pred SLL(+x, alpha:List) :
+  @pred SLL(x; alpha:List) :
     (x == null) * (alpha == {{ }}),
     Node(x, #val, #next) * SLL(#next, #beta) * (alpha == #val :: #beta);
 */

--- a/Gillian-JS/Examples/JaVerT/SLL.js
+++ b/Gillian-JS/Examples/JaVerT/SLL.js
@@ -2,7 +2,7 @@
 
 /*
   @pred Node(x:Obj; val, next) :
-    JSObject(x;) * DataProp(x, "val"; val) * DataProp(x, "next"; next);
+    JSObject(x) * DataProp(x, "val"; val) * DataProp(x, "next"; next);
 
   @pred SLL(x; alpha:List) :
     (x == null) * (alpha == {{ }}),
@@ -13,10 +13,10 @@
 /**
   @id listCopy
 
-  @pre  GlobalObject(;) * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) *
+  @pre  GlobalObject() * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) *
         (lst == #lst) * SLL(#lst; #alpha)
 
-  @post GlobalObject(;) * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) *
+  @post GlobalObject() * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) *
         SLL(#lst; #alpha) * SLL(ret; #alpha)
 */
 function listCopy (lst) {
@@ -30,10 +30,10 @@ function listCopy (lst) {
 /**
   @id listConcat
 
-  @pre  GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+  @pre  GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
         (la == #la) * SLL(#la; #alpha) * (lb == #lb) * SLL(#lb; #beta)
 
-  @post GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+  @post GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
         SLL(ret; l+ (#alpha, #beta))
 */
 function listConcat(la, lb) {
@@ -45,10 +45,10 @@ function listConcat(la, lb) {
 /**
   @id listAppend
 
-  @pre  GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+  @pre  GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
         (lst == #lst) * SLL(#lst; #alpha) * (v == #v)
 
-  @post GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+  @post GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
         SLL(ret; l+ (#alpha, {{ #v }} ))
 */
 function listAppend(lst, v) {

--- a/Gillian-JS/Examples/JaVerT/SLL.js
+++ b/Gillian-JS/Examples/JaVerT/SLL.js
@@ -2,22 +2,22 @@
 
 /*
   @pred Node(x:Obj; val, next) :
-    JSObject(x) * DataProp(x, "val", val) * DataProp(x, "next", next);
+    JSObject(x;) * DataProp(x, "val"; val) * DataProp(x, "next"; next);
 
   @pred SLL(x; alpha:List) :
     (x == null) * (alpha == {{ }}),
-    Node(x, #val, #next) * SLL(#next, #beta) * (alpha == #val :: #beta);
+    Node(x; #val, #next) * SLL(#next; #beta) * (alpha == #val :: #beta);
 */
 
 
 /**
   @id listCopy
 
-  @pre  GlobalObject() * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy, "listCopy", _, _, _) *
-        (lst == #lst) * SLL(#lst, #alpha)
+  @pre  GlobalObject(;) * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) *
+        (lst == #lst) * SLL(#lst; #alpha)
 
-  @post GlobalObject() * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy, "listCopy", _, _, _) *
-        SLL(#lst, #alpha) * SLL(ret, #alpha)
+  @post GlobalObject(;) * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) *
+        SLL(#lst; #alpha) * SLL(ret; #alpha)
 */
 function listCopy (lst) {
   if (lst === null) {
@@ -30,11 +30,11 @@ function listCopy (lst) {
 /**
   @id listConcat
 
-  @pre  GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat, "listConcat", _, _, _) *
-        (la == #la) * SLL(#la, #alpha) * (lb == #lb) * SLL(#lb, #beta)
+  @pre  GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+        (la == #la) * SLL(#la; #alpha) * (lb == #lb) * SLL(#lb; #beta)
 
-  @post GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat, "listConcat", _, _, _) *
-        SLL(ret, l+ (#alpha, #beta))
+  @post GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+        SLL(ret; l+ (#alpha, #beta))
 */
 function listConcat(la, lb) {
   if (la === null) return lb;
@@ -45,11 +45,11 @@ function listConcat(la, lb) {
 /**
   @id listAppend
 
-  @pre  GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat, "listConcat", _, _, _) *
-        (lst == #lst) * SLL(#lst, #alpha) * (v == #v)
+  @pre  GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+        (lst == #lst) * SLL(#lst; #alpha) * (v == #v)
 
-  @post GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat, "listConcat", _, _, _) *
-        SLL(ret, l+ (#alpha, {{ #v }} ))
+  @post GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+        SLL(ret; l+ (#alpha, {{ #v }} ))
 */
 function listAppend(lst, v) {
   var newNode = { val: v, next : null };

--- a/Gillian-JS/Examples/JaVerT/Sort.js
+++ b/Gillian-JS/Examples/JaVerT/Sort.js
@@ -2,23 +2,23 @@
 
 /**
 
-  @pred nullableObject(o) :
+  @pred nullableObject(o;) :
     types(o : Obj),
     (o == null);
 
-  @pred Node(+n:Obj, v:Num, t):
+  @pred Node(n:Obj; v:Num, t):
     JSObject(n) *
     DataProp(n, "value", v) *
     DataProp(n, "next", t);
 
-  @pred NDList(+nl, E:Set):
+  @pred NDList(nl; E:Set):
     (nl == null) * (E == -{ }-),
 
     Node(nl, #v, #t) * NDList(#t, #tE) *
     (E == -u- (#tE, -{ #v }-)) *
     (! (#v --e-- #tE));
 
-  @pred SOList(+nl, E:Set):
+  @pred SOList(nl; E:Set):
     (nl == null) * (E == -{ }-),
 
     Node(nl, #v, #t) * SOList(#t, #tE) *

--- a/Gillian-JS/Examples/JaVerT/Sort.js
+++ b/Gillian-JS/Examples/JaVerT/Sort.js
@@ -2,12 +2,12 @@
 
 /**
 
-  @pred nullableObject(o;) :
+  @pred nullableObject(o) :
     types(o : Obj),
     (o == null);
 
   @pred Node(n:Obj; v:Num, t):
-    JSObject(n;) *
+    JSObject(n) *
     DataProp(n, "value"; v) *
     DataProp(n, "next"; t);
 
@@ -29,9 +29,9 @@
 /**
 	@id insert
 
-	@pre (JSObject ($lg;) * (node == #n) * (value == #v) * SOList(#n; #E) * types(#v: Num) *
+	@pre (JSObject ($lg) * (node == #n) * (value == #v) * SOList(#n; #E) * types(#v: Num) *
 		 scope(insert: #insert_fun) * JSFunctionObject(#insert_fun; "insert", #insert_sc, #insert_len, #insert_proto))
-	@post (JSObject ($lg;) * (ret == #ret) * SOList(#ret; -u- (-{ #v }-, #E)) * types(#ret: Obj) *
+	@post (JSObject ($lg) * (ret == #ret) * SOList(#ret; -u- (-{ #v }-, #E)) * types(#ret: Obj) *
 		 scope(insert: #insert_fun) * JSFunctionObject(#insert_fun; "insert", #insert_sc, #insert_len, #insert_proto))
 */
 function insert(node, value) {
@@ -51,10 +51,10 @@ function insert(node, value) {
 /**
 	@id sort
 
-	@pre (JSObject ($lg;) * (head == #h) * NDList(#h; #E) *
+	@pre (JSObject ($lg) * (head == #h) * NDList(#h; #E) *
 		  scope(sort: #sort_fun) * JSFunctionObject(#sort_fun; "sort", #sort_sc, #sort_len, #sort_proto) *
 		  scope(insert: #insert_fun) * JSFunctionObject(#insert_fun; "insert", #insert_sc, #insert_len, #insert_proto))
-	@post (JSObject ($lg;) * SOList(ret; #E) * nullableObject(ret;) *
+	@post (JSObject ($lg) * SOList(ret; #E) * nullableObject(ret) *
 		  scope(sort: #sort_fun) * JSFunctionObject(#sort_fun; "sort", #sort_sc, #sort_len, #sort_proto) *
 		  scope(insert: #insert_fun) * JSFunctionObject(#insert_fun; "insert", #insert_sc, #insert_len, #insert_proto))
 */

--- a/Gillian-JS/Examples/JaVerT/Sort.js
+++ b/Gillian-JS/Examples/JaVerT/Sort.js
@@ -7,21 +7,21 @@
     (o == null);
 
   @pred Node(n:Obj; v:Num, t):
-    JSObject(n) *
-    DataProp(n, "value", v) *
-    DataProp(n, "next", t);
+    JSObject(n;) *
+    DataProp(n, "value"; v) *
+    DataProp(n, "next"; t);
 
   @pred NDList(nl; E:Set):
     (nl == null) * (E == -{ }-),
 
-    Node(nl, #v, #t) * NDList(#t, #tE) *
+    Node(nl; #v, #t) * NDList(#t; #tE) *
     (E == -u- (#tE, -{ #v }-)) *
     (! (#v --e-- #tE));
 
   @pred SOList(nl; E:Set):
     (nl == null) * (E == -{ }-),
 
-    Node(nl, #v, #t) * SOList(#t, #tE) *
+    Node(nl; #v, #t) * SOList(#t; #tE) *
     (E == -u- (#tE, -{ #v }-)) *
     (forall #x:Num. ((! (#x --e-- #tE)) \/ (#v <# #x)));
  */
@@ -29,10 +29,10 @@
 /**
 	@id insert
 
-	@pre (JSObject ($lg) * (node == #n) * (value == #v) * SOList(#n, #E) * types(#v: Num) *
-		 scope(insert: #insert_fun) * JSFunctionObject(#insert_fun, "insert", #insert_sc, #insert_len, #insert_proto))
-	@post (JSObject ($lg) * (ret == #ret) * SOList(#ret, -u- (-{ #v }-, #E)) * types(#ret: Obj) *
-		 scope(insert: #insert_fun) * JSFunctionObject(#insert_fun, "insert", #insert_sc, #insert_len, #insert_proto))
+	@pre (JSObject ($lg;) * (node == #n) * (value == #v) * SOList(#n; #E) * types(#v: Num) *
+		 scope(insert: #insert_fun) * JSFunctionObject(#insert_fun; "insert", #insert_sc, #insert_len, #insert_proto))
+	@post (JSObject ($lg;) * (ret == #ret) * SOList(#ret; -u- (-{ #v }-, #E)) * types(#ret: Obj) *
+		 scope(insert: #insert_fun) * JSFunctionObject(#insert_fun; "insert", #insert_sc, #insert_len, #insert_proto))
 */
 function insert(node, value) {
 
@@ -51,12 +51,12 @@ function insert(node, value) {
 /**
 	@id sort
 
-	@pre (JSObject ($lg) * (head == #h) * NDList(#h, #E) *
-		  scope(sort: #sort_fun) * JSFunctionObject(#sort_fun, "sort", #sort_sc, #sort_len, #sort_proto) *
-		  scope(insert: #insert_fun) * JSFunctionObject(#insert_fun, "insert", #insert_sc, #insert_len, #insert_proto))
-	@post (JSObject ($lg) * SOList(ret, #E) * nullableObject(ret) *
-		  scope(sort: #sort_fun) * JSFunctionObject(#sort_fun, "sort", #sort_sc, #sort_len, #sort_proto) *
-		  scope(insert: #insert_fun) * JSFunctionObject(#insert_fun, "insert", #insert_sc, #insert_len, #insert_proto))
+	@pre (JSObject ($lg;) * (head == #h) * NDList(#h; #E) *
+		  scope(sort: #sort_fun) * JSFunctionObject(#sort_fun; "sort", #sort_sc, #sort_len, #sort_proto) *
+		  scope(insert: #insert_fun) * JSFunctionObject(#insert_fun; "insert", #insert_sc, #insert_len, #insert_proto))
+	@post (JSObject ($lg;) * SOList(ret; #E) * nullableObject(ret;) *
+		  scope(sort: #sort_fun) * JSFunctionObject(#sort_fun; "sort", #sort_sc, #sort_len, #sort_proto) *
+		  scope(insert: #insert_fun) * JSFunctionObject(#insert_fun; "insert", #insert_sc, #insert_len, #insert_proto))
 */
 function sort(head) {
     var result;

--- a/Gillian-JS/Examples/JaVerT/annotated/SLL.js
+++ b/Gillian-JS/Examples/JaVerT/annotated/SLL.js
@@ -1,6 +1,6 @@
 /* 
   @pred Node(x:Obj; val, next) : 
-    JSObject(x;) * DataProp(x, "val"; val) * DataProp(x, "next"; next);
+    JSObject(x) * DataProp(x, "val"; val) * DataProp(x, "next"; next);
 
   @pred SLL(x; alpha:List) :
     (x == null) * (alpha == {{ }}),
@@ -11,10 +11,10 @@
 /** 
   @id listCopy 
 
-  @pre  GlobalObject(;) * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) *
+  @pre  GlobalObject() * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) *
         (lst == #lst) * SLL(#lst; #alpha)
 
-  @post GlobalObject(;) * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) * 
+  @post GlobalObject() * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) * 
         SLL(#lst; #alpha) * SLL(ret; #alpha)
 */
 function listCopy (lst) { 
@@ -29,10 +29,10 @@ function listCopy (lst) {
 /** 
   @id listConcat 
 
-  @pre  GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+  @pre  GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
         (la == #la) * SLL(#la; #alpha) * (lb == #lb) * SLL(#lb; #beta)
 
-  @post GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) * 
+  @post GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) * 
         SLL(ret; l+ (#alpha, #beta))
 */
 function listConcat(la, lb) {
@@ -46,10 +46,10 @@ function listConcat(la, lb) {
 /** 
   @id listAppend 
 
-  @pre  GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+  @pre  GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
         (lst == #lst) * SLL(#lst; #alpha) * (v == #v)
 
-  @post GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) * 
+  @post GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) * 
         SLL(ret; l+ (#alpha, {{ #v }} ))
 */
 function listAppend(lst, v) {

--- a/Gillian-JS/Examples/JaVerT/annotated/SLL.js
+++ b/Gillian-JS/Examples/JaVerT/annotated/SLL.js
@@ -1,24 +1,24 @@
 /* 
   @pred Node(x:Obj; val, next) : 
-    JSObject(x) * DataProp(x, "val", val) * DataProp(x, "next", next);
+    JSObject(x;) * DataProp(x, "val"; val) * DataProp(x, "next"; next);
 
   @pred SLL(x; alpha:List) :
     (x == null) * (alpha == {{ }}),
-    Node(x, #val, #next) * SLL(#next, #beta) * (alpha == #val :: #beta);
+    Node(x; #val, #next) * SLL(#next; #beta) * (alpha == #val :: #beta);
 */
 
 
 /** 
   @id listCopy 
 
-  @pre  GlobalObject() * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy, "listCopy", _, _, _) *
-        (lst == #lst) * SLL(#lst, #alpha)
+  @pre  GlobalObject(;) * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) *
+        (lst == #lst) * SLL(#lst; #alpha)
 
-  @post GlobalObject() * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy, "listCopy", _, _, _) * 
-        SLL(#lst, #alpha) * SLL(ret, #alpha)
+  @post GlobalObject(;) * scope(listCopy: #listCopy) * JSFunctionObject(#listCopy; "listCopy", _, _, _) * 
+        SLL(#lst; #alpha) * SLL(ret; #alpha)
 */
 function listCopy (lst) { 
-  /* @tactic unfold SLL(#lst, #alpha) */
+  /* @tactic unfold SLL(#lst; #alpha) */
   if (lst === null) { 
     return null
   }  else {
@@ -29,16 +29,16 @@ function listCopy (lst) {
 /** 
   @id listConcat 
 
-  @pre  GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat, "listConcat", _, _, _) *
-        (la == #la) * SLL(#la, #alpha) * (lb == #lb) * SLL(#lb, #beta)
+  @pre  GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+        (la == #la) * SLL(#la; #alpha) * (lb == #lb) * SLL(#lb; #beta)
 
-  @post GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat, "listConcat", _, _, _) * 
-        SLL(ret, l+ (#alpha, #beta))
+  @post GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) * 
+        SLL(ret; l+ (#alpha, #beta))
 */
 function listConcat(la, lb) {
   if (la === null) return lb; 
 
-  /* @tactic unfold SLL(#la, #alpha) */
+  /* @tactic unfold SLL(#la; #alpha) */
   la.next = listConcat(la.next, lb);
   return la
 }
@@ -46,11 +46,11 @@ function listConcat(la, lb) {
 /** 
   @id listAppend 
 
-  @pre  GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat, "listConcat", _, _, _) *
-        (lst == #lst) * SLL(#lst, #alpha) * (v == #v)
+  @pre  GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) *
+        (lst == #lst) * SLL(#lst; #alpha) * (v == #v)
 
-  @post GlobalObject() * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat, "listConcat", _, _, _) * 
-        SLL(ret, l+ (#alpha, {{ #v }} ))
+  @post GlobalObject(;) * scope(listConcat: #listConcat) * JSFunctionObject(#listConcat; "listConcat", _, _, _) * 
+        SLL(ret; l+ (#alpha, {{ #v }} ))
 */
 function listAppend(lst, v) {
   var newNode = { val: v, next : null };

--- a/Gillian-JS/Examples/JaVerT/annotated/SLL.js
+++ b/Gillian-JS/Examples/JaVerT/annotated/SLL.js
@@ -1,8 +1,8 @@
 /* 
-  @pred Node(+x:Obj, val, next) : 
+  @pred Node(x:Obj; val, next) : 
     JSObject(x) * DataProp(x, "val", val) * DataProp(x, "next", next);
 
-  @pred SLL(+x, alpha:List) :
+  @pred SLL(x; alpha:List) :
     (x == null) * (alpha == {{ }}),
     Node(x, #val, #next) * SLL(#next, #beta) * (alpha == #val :: #beta);
 */

--- a/Gillian-JS/lib/Compiler/JSIL2GIL.ml
+++ b/Gillian-JS/lib/Compiler/JSIL2GIL.ml
@@ -83,7 +83,7 @@ let rec jsil2gil_asrt (a : Asrt.t) : GAsrt.t =
   | MetaData (e1, e2) -> [ Asrt_utils.metadata ~loc:(fe e1) ~metadata:(fe e2) ]
   | EmptyFields (e1, e2) ->
       [ Asrt_utils.empty_fields ~loc:(fe e1) ~domain:(fe e2) ]
-  | Pred (pn, es) -> [ Pred (pn, List.map fe es) ]
+  | Pred (pn, ins, outs) -> [ Pred (pn, List.map fe ins, List.map fe outs) ]
   | Pure f -> [ Pure (jsil2gil_expr f) ]
   | Types vts -> [ Types (List.map (fun (v, t) -> (fe v, t)) vts) ]
 

--- a/Gillian-JS/lib/Compiler/JSIL2GIL.ml
+++ b/Gillian-JS/lib/Compiler/JSIL2GIL.ml
@@ -169,7 +169,7 @@ let jsil2gil_pred (pred : Pred.t) : GPred.t =
     (* TODO (Alexis): Set depending on module of pred *)
     pred_num_params = pred.num_params;
     pred_params = pred.params;
-    pred_ins = pred.ins;
+    ins_number = pred.ins_number;
     pred_definitions =
       List.map (fun (info, asrt) -> (info, jsil2gil_asrt asrt)) pred.definitions;
     pred_facts = List.map jsil2gil_expr pred.facts;

--- a/Gillian-JS/lib/Compiler/JSIL_PostParser.ml
+++ b/Gillian-JS/lib/Compiler/JSIL_PostParser.ml
@@ -182,15 +182,17 @@ let scope_info_to_assertion
                 let fun_obj_asrt =
                   Asrt.Pred
                     ( "JSFunctionObject",
+                      [ x_val ],
                       [
-                        x_val;
                         Lit (String proc_x.name);
                         proc_x_sc;
                         Lit (Num (float_of_int (List.length proc_x.params)));
                         proc_x_prototype;
                       ] )
                 in
-                let proto_asrt = Asrt.Pred ("JSObject", [ proc_x_prototype ]) in
+                let proto_asrt =
+                  Asrt.Pred ("JSObject", [ proc_x_prototype ], [])
+                in
                 [ fun_obj_asrt; proto_asrt; a_xval ]
           else if SS.mem x args then
             let x_val : Expr.t = LVar (Names.make_svar_name x) in
@@ -205,7 +207,7 @@ let scope_info_to_assertion
   let this_asrt = make_this_assertion () in
 
   if fid <> JS2JSIL_Helpers.main_fid then
-    let init_heap_asrt : Asrt.t = Pred (heap_asrt_name, []) in
+    let init_heap_asrt : Asrt.t = Pred (heap_asrt_name, [], []) in
     Asrt.star
       (glob_constraints @ (this_asrt :: init_heap_asrt :: a_schain :: a_vars))
   else Asrt.star (glob_constraints @ (this_asrt :: a_schain :: a_vars))
@@ -248,15 +250,17 @@ let create_pre_scope_pred
                 let fun_obj_asrt =
                   Asrt.Pred
                     ( "JSFunctionObject",
+                      [ PVar x ],
                       [
-                        PVar x;
                         Lit (String proc_x.name);
                         proc_x_sc;
                         Lit (Num (float_of_int (List.length proc_x.params)));
                         proc_x_prototype;
                       ] )
                 in
-                let proto_asrt = Asrt.Pred ("JSObject", [ proc_x_prototype ]) in
+                let proto_asrt =
+                  Asrt.Pred ("JSObject", [ proc_x_prototype ], [])
+                in
                 ([ x ], [ fun_obj_asrt; proto_asrt; a_x ])
           else ([], [])
         in
@@ -296,15 +300,15 @@ let create_function_predicate
   let fo_asrt =
     Asrt.Pred
       ( "JSFunctionObject",
+        [ PVar x ],
         [
-          PVar x;
           Lit (String fid);
           fid_x_sc;
           Lit (Num (float_of_int (List.length fparams)));
           fid_prototype;
         ] )
   in
-  let proto_asrt = Asrt.Pred ("JSObject", [ fid_prototype ]) in
+  let proto_asrt = Asrt.Pred ("JSObject", [ fid_prototype ], []) in
 
   {
     name = pred_name;
@@ -385,10 +389,12 @@ let create_post_scope_pred
     [ mtdt_er_a; ef_er_a; (* args_a; *) md_md_a; ef_md_a; er_fl_a ]
   in
 
-  let pred_params =
-    List.map (fun x -> Expr.PVar x) (JS2JSIL_Helpers.var_scope :: out_params)
+  (* The pre-scope predicate has a single in-parameter (the scope chain). *)
+  let pre_scope_ins = [ Expr.PVar JS2JSIL_Helpers.var_scope ] in
+  let pre_scope_outs = List.map (fun x -> Expr.PVar x) out_params in
+  let pre_scope_asrt =
+    Asrt.Pred (pre_scope_prefix ^ fid, pre_scope_ins, pre_scope_outs)
   in
-  let pre_scope_asrt = Asrt.Pred (pre_scope_prefix ^ fid, pred_params) in
 
   {
     name = post_scope_prefix ^ fid;

--- a/Gillian-JS/lib/Compiler/JSIL_PostParser.ml
+++ b/Gillian-JS/lib/Compiler/JSIL_PostParser.ml
@@ -272,7 +272,7 @@ let create_pre_scope_pred
     name = pre_scope_prefix ^ fid;
     num_params = List.length p_args + 1;
     params;
-    ins = [ 0 ];
+    ins_number = 1;
     definitions = [ (None, Asrt.star (a_schain :: a_vars)) ];
     facts = [];
     pure = false;
@@ -310,7 +310,7 @@ let create_function_predicate
     name = pred_name;
     num_params = 1;
     params = [ ("x", None) ];
-    ins = [ 0 ];
+    ins_number = 1;
     definitions = [ (None, Asrt.star [ fo_asrt; proto_asrt ]) ];
     facts = [];
     pure = false;
@@ -324,7 +324,7 @@ let create_function_predicate
   name        : string;                                            (** Name of the predicate  *)
   num_params  : int;                                               (** Number of parameters   *)
   params      : (string * Type.t option) list;                     (** Actual parameters      *)
-  ins         : int list;                                          (** Ins                    *)
+  ins_number  : int;                                               (** Number of in-params    *)
   definitions : (((string * (string list)) option) * Asrt.t) list; (** Predicate definitions  *)
   pure        : bool;                                              (** Is the predicate pure  *)
   normalised  : bool;                                              (** If the predicate has been previously normalised *)
@@ -394,7 +394,7 @@ let create_post_scope_pred
     name = post_scope_prefix ^ fid;
     num_params = List.length params;
     params;
-    ins = [ 0; 1 ];
+    ins_number = 2;
     definitions =
       [ (None, Asrt.star (pre_scope_asrt :: (args_asrts @ er_asrts))) ];
     facts = [];

--- a/Gillian-JS/lib/JSIL/Asrt.ml
+++ b/Gillian-JS/lib/JSIL/Asrt.ml
@@ -7,7 +7,7 @@ type t =
   | Star of t * t  (** Separating conjunction *)
   | PointsTo of Expr.t * Expr.t * Expr.t  (** Heap cell assertion *)
   | MetaData of Expr.t * Expr.t  (** MetaData *)
-  | Pred of string * Expr.t list  (** Predicates *)
+  | Pred of string * Expr.t list * Expr.t list  (** Predicates *)
   | EmptyFields of Expr.t * Expr.t  (** emptyFields assertion *)
   | Pure of Expr.t  (** Pure formula *)
   | Types of (Expr.t * Type.t) list  (** Typing assertion *)
@@ -53,8 +53,9 @@ let rec pp fmt (a : t) : unit =
       Fmt.pf fmt "((%a, %a) -> %a)" Expr.pp e1 Expr.pp e2 Expr.pp e3
   | Emp -> Fmt.string fmt "emp"
   (* x(y1, ..., yn) *)
-  | Pred (name, params) ->
-      Fmt.pf fmt "%s(%a)" name (Fmt.list ~sep:(Fmt.any ", ") Expr.pp) params
+  | Pred (name, ins, outs) ->
+      let pp_e_l = Fmt.list ~sep:(Fmt.any ", ") Expr.pp in
+      Fmt.pf fmt "%s(%a; %a)" name pp_e_l ins pp_e_l outs
   (* types(e1:t1, ..., en:tn) *)
   | Types type_list ->
       let pp_pair =

--- a/Gillian-JS/lib/JSIL/Pred.ml
+++ b/Gillian-JS/lib/JSIL/Pred.ml
@@ -8,7 +8,8 @@ type t = {
   name : string;  (** Name of the predicate *)
   num_params : int;  (** Number of parameters *)
   params : (string * Type.t option) list;  (** Actual parameters *)
-  ins : int list;  (** Ins *)
+  ins_number : int;
+      (** Number of in-parameters (the first [ins_number] ones) *)
   definitions : ((string * string list) option * Asrt.t) list;
       (** Predicate definitions *)
   facts : Expr.t list;  (** Facts about the predicate *)
@@ -27,19 +28,21 @@ let init (preds : t list) : (string, t) Hashtbl.t =
   pred_def_tbl
 
 let pp fmt pred =
-  let { name; params; ins; definitions; _ } = pred in
-  let exist_ins = List.length pred.ins <> List.length pred.params in
-  let params_with_info =
-    if exist_ins then
-      List.mapi
-        (fun i (v, t) -> ((if List.mem i ins then "+" else "") ^ v, t))
-        params
-    else params
-  in
+  let { name; params; ins_number; definitions; _ } = pred in
   let pp_param fmt (v, t) =
     match t with
     | None -> Fmt.pf fmt "%s" v
     | Some typ -> Fmt.pf fmt "%s : %s" v (Type.str typ)
+  in
+  (* Prints params as [(in1, ..., ink; out1, ..., outm)] *)
+  let pp_params fmt params =
+    let ins = List.filteri (fun i _ -> i < ins_number) params in
+    let outs = List.filteri (fun i _ -> i >= ins_number) params in
+    Fmt.pf fmt "%a;%a"
+      Fmt.(list ~sep:(any ", ") pp_param)
+      ins
+      Fmt.(list ~sep:(any ", ") pp_param)
+      outs
   in
   let pp_id_ex fmt id_ex =
     match id_ex with
@@ -70,9 +73,7 @@ let pp fmt pred =
         Fmt.pf fmt "@\nfacts: %a;" Fmt.(list ~sep:(any " and ") Expr.pp) facts
   in
   Fmt.pf fmt "@[<v 2>%a%a%apred %s(%a):@\n%a;%a@]" pp_abstract pred.abstract
-    pp_pure pred.pure pp_nounfold pred.nounfold name
-    Fmt.(list ~sep:(any ", ") pp_param)
-    params_with_info
+    pp_pure pred.pure pp_nounfold pred.nounfold name pp_params params
     Fmt.(list ~sep:(any ",@\n") pp_def)
     definitions pp_facts pred.facts
 

--- a/Gillian-JS/lib/JSLogic/JSAsrt.ml
+++ b/Gillian-JS/lib/JSLogic/JSAsrt.ml
@@ -23,7 +23,7 @@ type t =
   | PointsTo of JSExpr.t * JSExpr.t * JSExpr.t
   | MetaData of JSExpr.t * JSExpr.t
   | Emp
-  | Pred of string * JSExpr.t list
+  | Pred of string * JSExpr.t list * JSExpr.t list
   | Types of (string * Type.t) list
   | Scope of string * JSExpr.t
   | VarSChain of string * string * JSExpr.t * JSExpr.t
@@ -71,10 +71,10 @@ let rec js2jsil
   let fp = js2jsil_pure scope_le in
   let fe = JSExpr.js2jsil scope_le in
 
-  let compile_pred s les =
-    let a' = Asrt.Pred (s, List.map fe les) in
+  let compile_pred s ins outs =
+    let a' = Asrt.Pred (s, List.map fe ins, List.map fe outs) in
     if s = funobj_pred_name then
-      match les with
+      match ins @ outs with
       | [ _; Lit (String fid); le_sc; _; _ ] ->
           Asrt.Star (a', f (SChain (fid, le_sc)))
       | _ -> a'
@@ -91,26 +91,34 @@ let rec js2jsil
   | Types vts ->
       Asrt.Types (List.map (fun (v, t) -> (Expr.from_var_name v, t)) vts)
   | EmptyFields (e, domain) -> Asrt.EmptyFields (fe e, fe domain)
-  | Pred (name, [ loc; Lit (String fid); sch; args_len; fproto ])
-    when name = "JSFunctionObject" || name = "JSFunctionObjectStrong" ->
-      let len = List.length (get_vis_list vis_tbl fid) in
-      let a_len =
-        Asrt.Pure
-          (BinOp
-             (Lit (Num (float_of_int (len - 1))), Equal, UnOp (LstLen, fe sch)))
-      in
-      let a_lg =
-        Asrt.Pure
-          (BinOp
-             ( Lit (Loc locGlobName),
-               Equal,
-               Expr.BinOp (fe sch, LstNth, Expr.Lit (Num (float_of_int 0))) ))
-      in
-      let a_pred =
-        compile_pred name [ loc; Lit (String fid); sch; args_len; fproto ]
-      in
-      Asrt.star [ a_lg; a_len; a_pred ]
-  | Pred (s, les) -> compile_pred s les
+  | Pred (name, ins, outs)
+    when (name = "JSFunctionObject" || name = "JSFunctionObjectStrong")
+         &&
+         match ins @ outs with
+         | [ _; Lit (String _); _; _; _ ] -> true
+         | _ -> false -> (
+      match ins @ outs with
+      | [ _loc; Lit (String fid); sch; _args_len; _fproto ] ->
+          let len = List.length (get_vis_list vis_tbl fid) in
+          let a_len =
+            Asrt.Pure
+              (BinOp
+                 ( Lit (Num (float_of_int (len - 1))),
+                   Equal,
+                   UnOp (LstLen, fe sch) ))
+          in
+          let a_lg =
+            Asrt.Pure
+              (BinOp
+                 ( Lit (Loc locGlobName),
+                   Equal,
+                   Expr.BinOp (fe sch, LstNth, Expr.Lit (Num (float_of_int 0)))
+                 ))
+          in
+          let a_pred = compile_pred name ins outs in
+          Asrt.star [ a_lg; a_len; a_pred ]
+      | _ -> assert false)
+  | Pred (s, ins, outs) -> compile_pred s ins outs
   (* le_x'  = Te(le_x)
         le_sc' = Te(le_sc)
      ----------------------------------------------
@@ -257,8 +265,8 @@ let rec js2jsil
 
 let errors_assertion () =
   Asrt.Star
-    ( Pred (type_error_pred_name, [ PVar var_te ]),
-      Pred (syntax_error_pred_name, [ PVar var_se ]) )
+    ( Pred (type_error_pred_name, [ PVar var_te ], []),
+      Pred (syntax_error_pred_name, [ PVar var_se ], []) )
 
 let js2jsil_tactic
     (cc_tbl : cc_tbl_type)

--- a/Gillian-JS/lib/JSLogic/JSLCmd.ml
+++ b/Gillian-JS/lib/JSLogic/JSLCmd.ml
@@ -33,15 +33,17 @@ let rec js2jsil
   in
 
   match logic_cmd with
-  | Fold (Pred (s, les), fold_info) ->
+  | Fold (Pred (s, ins, outs), fold_info) ->
+      let les = ins @ outs in
       [ LCmd.SL (Fold (s, List.map fe les, translate_folding_info fold_info)) ]
-  | Flash (Pred (s, les)) ->
-      let p_name, les' = (s, List.map fe les) in
+  | Flash (Pred (s, ins, outs)) ->
+      let p_name, les' = (s, List.map fe (ins @ outs)) in
       [
         LCmd.SL (Unfold (p_name, les', None, false));
         LCmd.SL (Fold (p_name, les', None));
       ]
-  | Unfold (Pred (s, les), unfold_info) ->
+  | Unfold (Pred (s, ins, outs), unfold_info) ->
+      let les = ins @ outs in
       [ LCmd.SL (Unfold (s, List.map fe les, unfold_info, false)) ]
   | GUnfold name -> [ LCmd.SL (GUnfold name) ]
   | Assert (assertion, binders) ->

--- a/Gillian-JS/lib/JSLogic/JSPred.ml
+++ b/Gillian-JS/lib/JSLogic/JSPred.ml
@@ -7,7 +7,7 @@ type t = {
   name : string;
   num_params : int;
   params : (string * Type.t option) list;
-  ins : int list;
+  ins_number : int;
   definitions : ((string * string list) option * JSAsrt.t) list;
   facts : Expr.t list;
   abstract : bool;
@@ -29,7 +29,7 @@ let js2jsil
     Pred.name = pred_def.name;
     num_params = pred_def.num_params;
     params = pred_def.params;
-    ins = pred_def.ins;
+    ins_number = pred_def.ins_number;
     definitions = jsil_definitions;
     facts = pred_def.facts;
     pure = pred_def.pure;

--- a/Gillian-JS/lib/Parsing/Javert_Parser.mly
+++ b/Gillian-JS/lib/Parsing/Javert_Parser.mly
@@ -496,7 +496,10 @@ assertion_target:
   | LMETADATA; LBRACE; eo = expr_target; COMMA; em = expr_target; RBRACE
     { Asrt.MetaData (eo, em) }
   | LEMP; { Asrt.Emp }
-  | name = VAR; LBRACE; ins = separated_list(COMMA, expr_target); SCOLON; outs = separated_list(COMMA, expr_target); RBRACE
+  | name = VAR; LBRACE;
+    ins = separated_list(COMMA, expr_target);
+    outs = outs(expr_target);
+    RBRACE
     { Asrt.Pred (name, ins, outs) }
   | LTYPES; LBRACE; type_pairs = separated_list(COMMA, type_env_pair_target); RBRACE
     { Asrt.Types type_pairs }
@@ -789,8 +792,8 @@ pred_param_target:
    semicolon. E.g. [(in1, in2; out1, out2)], [(in1, in2;)], [(;out1, out2)]. *)
 pred_head_target:
   name = VAR; LBRACE;
-    ins = separated_list(COMMA, pred_param_target); SCOLON;
-    outs = separated_list(COMMA, pred_param_target);
+    ins = separated_list(COMMA, pred_param_target);
+    outs = outs(pred_param_target);
   RBRACE;
   { let params = ins @ outs in
     let num_params = List.length params in
@@ -1066,7 +1069,10 @@ js_assertion_target:
   | SCHAIN; LBRACE; fid=VAR; COLON; le=js_lexpr_target; RBRACE
     { JSAsrt.SChain (fid, le) }
 (* x(e1, ..., en) *)
-  | name = VAR; LBRACE; ins = separated_list(COMMA, js_lexpr_target); SCOLON; outs = separated_list(COMMA, js_lexpr_target); RBRACE
+  | name = VAR; LBRACE;
+    ins = separated_list(COMMA, js_lexpr_target);
+    outs = outs(js_lexpr_target);
+    RBRACE
     { JSAsrt.Pred (name, ins, outs) }
 (* types (type_pairs) *)
   | LTYPES; LBRACE; type_pairs = separated_list(COMMA, js_type_env_pair_target); RBRACE
@@ -1270,3 +1276,12 @@ top_level_js_pre_target:
 
 top_level_expr_target:
   e = expr_target; EOF { e }
+
+%inline outs(X):
+  xs = option_preceded_separated_list(SCOLON, COMMA, X)
+  { xs }
+
+%inline option_preceded_separated_list(PREC, SEP, X):
+  | PREC; xs = separated_list(SEP, X) { xs }
+  | { [] }
+

--- a/Gillian-JS/lib/Parsing/Javert_Parser.mly
+++ b/Gillian-JS/lib/Parsing/Javert_Parser.mly
@@ -496,9 +496,8 @@ assertion_target:
   | LMETADATA; LBRACE; eo = expr_target; COMMA; em = expr_target; RBRACE
     { Asrt.MetaData (eo, em) }
   | LEMP; { Asrt.Emp }
-  | name = VAR; LBRACE; params = separated_list(COMMA, expr_target); RBRACE
-    { (* validate_pred_assertion (name, params); *)
-      Asrt.Pred (name, params) }
+  | name = VAR; LBRACE; ins = separated_list(COMMA, expr_target); SCOLON; outs = separated_list(COMMA, expr_target); RBRACE
+    { Asrt.Pred (name, ins, outs) }
   | LTYPES; LBRACE; type_pairs = separated_list(COMMA, type_env_pair_target); RBRACE
     { Asrt.Types type_pairs }
   | EMPTYFIELDS; LBRACE; le=expr_target; COLON; domain=expr_target; RBRACE
@@ -1067,11 +1066,8 @@ js_assertion_target:
   | SCHAIN; LBRACE; fid=VAR; COLON; le=js_lexpr_target; RBRACE
     { JSAsrt.SChain (fid, le) }
 (* x(e1, ..., en) *)
-  | name = VAR; LBRACE; params = separated_list(COMMA, js_lexpr_target); RBRACE
-    {
-      (* validate_pred_assertion (name, params); *)
-      JSAsrt.Pred (name, params)
-    }
+  | name = VAR; LBRACE; ins = separated_list(COMMA, js_lexpr_target); SCOLON; outs = separated_list(COMMA, js_lexpr_target); RBRACE
+    { JSAsrt.Pred (name, ins, outs) }
 (* types (type_pairs) *)
   | LTYPES; LBRACE; type_pairs = separated_list(COMMA, js_type_env_pair_target); RBRACE
     { JSAsrt.Types type_pairs }

--- a/Gillian-JS/lib/Parsing/Javert_Parser.mly
+++ b/Gillian-JS/lib/Parsing/Javert_Parser.mly
@@ -782,22 +782,21 @@ named_assertion_target:
   { (id, a) }
 
 pred_param_target:
-  (* Program variable with in-parameter status and optional type *)
-  | in_param = option(PLUS); v = VAR; t = option(preceded(COLON, type_target))
-    { let in_param = Option.fold ~some:(fun _ -> true) ~none:false in_param in
-      (v, t), in_param }
+  (* Program variable with optional type *)
+  | v = VAR; t = option(preceded(COLON, type_target))
+    { (v, t) }
 
+(* Predicate parameters: in-parameters and out-parameters, separated by a
+   semicolon. E.g. [(in1, in2; out1, out2)], [(in1, in2;)], [(;out1, out2)]. *)
 pred_head_target:
-  name = VAR; LBRACE; params = separated_list(COMMA, pred_param_target); RBRACE;
-  { (* Register the predicate declaration in the syntax checker *)
+  name = VAR; LBRACE;
+    ins = separated_list(COMMA, pred_param_target); SCOLON;
+    outs = separated_list(COMMA, pred_param_target);
+  RBRACE;
+  { let params = ins @ outs in
     let num_params = List.length params in
-    let params, ins = List.split params in
-    let param_names, _ = List.split params in
-    let ins = List.map Option.get (List.filter (fun x -> x <> None) (List.mapi (fun i is_in -> if is_in then Some i else None) ins)) in
-    let ins = if (List.length ins > 0) then ins else (List.mapi (fun i _ -> i) param_names) in
-    (* register_predicate name num_params; *)
-    (* enter_predicate params; *)
-    (name, num_params, params, ins)
+    let ins_number = List.length ins in
+    (name, num_params, params, ins_number)
   }
 
 pred_defs_target:
@@ -816,14 +815,14 @@ pred_target:
     let abstract = Option.is_some a in
     let nounfold = abstract || Option.is_some n in
     let pure = Option.is_some p in
-    let (name, num_params, params, ins) = pred_head in
+    let (name, num_params, params, ins_number) = pred_head in
     let definitions = Option.value ~default:[] definitions in
     let () = if (abstract <> (definitions = [])) then
       raise (Failure (Format.asprintf "JSIL: Malformed predicate %s: either abstract with definition or non-abstract without definition." name))
     in
     let normalised = !Config.previously_normalised in
     let facts = Option.value ~default:[] facts in
-    Pred.{ name; num_params; params; ins; definitions; facts; pure; abstract; nounfold; normalised } }
+    Pred.{ name; num_params; params; ins_number; definitions; facts; pure; abstract; nounfold; normalised } }
 
 /* MACROS */
 
@@ -1121,7 +1120,7 @@ js_pred_target:
   definitions = option(js_pred_defs_target); SCOLON;
   facts=option(js_pred_facts_target); EOF
     { (* Add the predicate to the collection *)
-      let (name, num_params, params, ins) = pred_head in
+      let (name, num_params, params, ins_number) = pred_head in
       let abstract = Option.is_some abstract in
       let nounfold = abstract || Option.is_some nounfold in
       let pure = Option.is_some pure in
@@ -1130,7 +1129,7 @@ js_pred_target:
       let () = if (abstract <> (definitions = [])) then
         raise (Failure (Format.asprintf "JS: Malformed predicate %s: either abstract with definition or non-abstract without definition." name))
       in
-      Jslogic.JSPred.{ name; num_params; params; ins; definitions; facts; abstract; pure; nounfold }
+      Jslogic.JSPred.{ name; num_params; params; ins_number; definitions; facts; abstract; pure; nounfold }
     }
 
 

--- a/Gillian-JS/runtime/ES5/bis_ch15_11_errors.jsil
+++ b/Gillian-JS/runtime/ES5/bis_ch15_11_errors.jsil
@@ -51,7 +51,7 @@ proc TypeError_call (xsc, vthis, v) {
 spec TypeError (v)
     (** 1 **)
     [[ v == undefined ]]
-    [[ TypeError(ret;) * empty_fields(ret : -{ }-) ]]
+    [[ TypeError(ret) * empty_fields(ret : -{ }-) ]]
     normal;
 
     (** 2 **)

--- a/Gillian-JS/runtime/ES5/bis_ch15_11_errors.jsil
+++ b/Gillian-JS/runtime/ES5/bis_ch15_11_errors.jsil
@@ -51,12 +51,12 @@ proc TypeError_call (xsc, vthis, v) {
 spec TypeError (v)
     (** 1 **)
     [[ v == undefined ]]
-    [[ TypeError(ret) * empty_fields(ret : -{ }-) ]]
+    [[ TypeError(ret;) * empty_fields(ret : -{ }-) ]]
     normal;
 
     (** 2 **)
     [[ (v == #v) * types(#v:Str) ]]
-    [[ TypeErrorWithMessage(ret, #v) * empty_fields(ret : -{ "message" }-) ]]
+    [[ TypeErrorWithMessage(ret; #v) * empty_fields(ret : -{ "message" }-) ]]
     normal
 
 proc TypeError (v) {

--- a/Gillian-JS/runtime/ES5/ifs_ch9_type_conversions_and_testing.jsil
+++ b/Gillian-JS/runtime/ES5/ifs_ch9_type_conversions_and_testing.jsil
@@ -403,11 +403,11 @@ proc i__toString (v) {
 
 spec i__toObject (v) 
     [[ (v == undefined) ]]
-    [[ TypeError(ret;) ]]
+    [[ TypeError(ret) ]]
     error;
 
     [[ (v == null) ]]
-    [[ TypeError(ret;) ]]
+    [[ TypeError(ret) ]]
     error;
 
     [[ (v == #v) * types(#v:Obj) ]]
@@ -479,11 +479,11 @@ proc i__toObject (v) {
  *)
 spec i__checkObjectCoercible (v)
     [[ v == undefined ]]
-    [[ TypeError(ret;) ]]
+    [[ TypeError(ret) ]]
     error;
 
     [[ v == null ]]
-    [[ TypeError(ret;) ]]
+    [[ TypeError(ret) ]]
     error;
 
     [[ typeOf(v) --e-- -{ Bool, Num, Str, Obj }- ]]

--- a/Gillian-JS/runtime/ES5/ifs_ch9_type_conversions_and_testing.jsil
+++ b/Gillian-JS/runtime/ES5/ifs_ch9_type_conversions_and_testing.jsil
@@ -403,11 +403,11 @@ proc i__toString (v) {
 
 spec i__toObject (v) 
     [[ (v == undefined) ]]
-    [[ TypeError(ret) ]]
+    [[ TypeError(ret;) ]]
     error;
 
     [[ (v == null) ]]
-    [[ TypeError(ret) ]]
+    [[ TypeError(ret;) ]]
     error;
 
     [[ (v == #v) * types(#v:Obj) ]]
@@ -479,11 +479,11 @@ proc i__toObject (v) {
  *)
 spec i__checkObjectCoercible (v)
     [[ v == undefined ]]
-    [[ TypeError(ret) ]]
+    [[ TypeError(ret;) ]]
     error;
 
     [[ v == null ]]
-    [[ TypeError(ret) ]]
+    [[ TypeError(ret;) ]]
     error;
 
     [[ typeOf(v) --e-- -{ Bool, Num, Str, Obj }- ]]

--- a/Gillian-JS/runtime/ES5/preds_ch15_11_errors.jsil
+++ b/Gillian-JS/runtime/ES5/preds_ch15_11_errors.jsil
@@ -26,7 +26,7 @@ pred ErrorObjectWithMessage (l:Obj; pr:Obj, m:Str) :
  * 
  * An object is a type error if it is an Error object with the TypeError prototype
  *)
-pred TypeError(l:Obj;) : ErrorObject (l; $lterr_proto);
+pred TypeError(l:Obj) : ErrorObject (l; $lterr_proto);
 pred TypeErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l; $lterr_proto, m);
 
 (* 
@@ -34,7 +34,7 @@ pred TypeErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l; $lterr_prot
  * 
  * An object is a syntax error if it is an Error object with the SyntaxError prototype
  *)
-pred SyntaxError(l:Obj;) : ErrorObject (l; $lserr_proto);
+pred SyntaxError(l:Obj) : ErrorObject (l; $lserr_proto);
 pred SyntaxErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l; $lserr_proto, m);
 
 (* 
@@ -42,5 +42,5 @@ pred SyntaxErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l; $lserr_pr
  * 
  * An object is a reference error if it is an Error object with the ReferenceError prototype
  *)
-pred ReferenceError(l:Obj;) : ErrorObject (l; $lrferr_proto);
+pred ReferenceError(l:Obj) : ErrorObject (l; $lrferr_proto);
 pred ReferenceErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l; $lrferr_proto, m);

--- a/Gillian-JS/runtime/ES5/preds_ch15_11_errors.jsil
+++ b/Gillian-JS/runtime/ES5/preds_ch15_11_errors.jsil
@@ -6,7 +6,7 @@ import preds_general.jsil;
  * An object at location l with prototype is pr is an Error object 
  * if its class is "Error" and if it is extensible.
  *)
-pred ErrorObject (+l:Obj, pr:Obj) :
+pred ErrorObject (l:Obj; pr:Obj) :
     JSObjGeneral(l, pr, "Error", true);
 
 (* 
@@ -17,7 +17,7 @@ pred ErrorObject (+l:Obj, pr:Obj) :
  * property is a writable, non-enumerable configurable data property
  * with value m.
  *)
-pred ErrorObjectWithMessage (+l:Obj, pr:Obj, m:Str) :
+pred ErrorObjectWithMessage (l:Obj; pr:Obj, m:Str) :
     ErrorObject(l, pr) *
     ((l, "message") -> {{ "d", m, true, false, true }});
 
@@ -26,21 +26,21 @@ pred ErrorObjectWithMessage (+l:Obj, pr:Obj, m:Str) :
  * 
  * An object is a type error if it is an Error object with the TypeError prototype
  *)
-pred TypeError(l:Obj) : ErrorObject (l, $lterr_proto);
-pred TypeErrorWithMessage (+l:Obj, m:Str) : ErrorObjectWithMessage(l, $lterr_proto, m);
+pred TypeError(l:Obj;) : ErrorObject (l, $lterr_proto);
+pred TypeErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l, $lterr_proto, m);
 
 (* 
  * Syntax Error
  * 
  * An object is a syntax error if it is an Error object with the SyntaxError prototype
  *)
-pred SyntaxError(l:Obj) : ErrorObject (l, $lserr_proto);
-pred SyntaxErrorWithMessage (+l:Obj, m:Str) : ErrorObjectWithMessage(l, $lserr_proto, m);
+pred SyntaxError(l:Obj;) : ErrorObject (l, $lserr_proto);
+pred SyntaxErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l, $lserr_proto, m);
 
 (* 
  * Reference Error
  * 
  * An object is a reference error if it is an Error object with the ReferenceError prototype
  *)
-pred ReferenceError(l:Obj) : ErrorObject (l, $lrferr_proto);
-pred ReferenceErrorWithMessage (+l:Obj, m:Str) : ErrorObjectWithMessage(l, $lrferr_proto, m);
+pred ReferenceError(l:Obj;) : ErrorObject (l, $lrferr_proto);
+pred ReferenceErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l, $lrferr_proto, m);

--- a/Gillian-JS/runtime/ES5/preds_ch15_11_errors.jsil
+++ b/Gillian-JS/runtime/ES5/preds_ch15_11_errors.jsil
@@ -7,7 +7,7 @@ import preds_general.jsil;
  * if its class is "Error" and if it is extensible.
  *)
 pred ErrorObject (l:Obj; pr:Obj) :
-    JSObjGeneral(l, pr, "Error", true);
+    JSObjGeneral(l; pr, "Error", true);
 
 (* 
  * Error object with message
@@ -18,7 +18,7 @@ pred ErrorObject (l:Obj; pr:Obj) :
  * with value m.
  *)
 pred ErrorObjectWithMessage (l:Obj; pr:Obj, m:Str) :
-    ErrorObject(l, pr) *
+    ErrorObject(l; pr) *
     ((l, "message") -> {{ "d", m, true, false, true }});
 
 (* 
@@ -26,21 +26,21 @@ pred ErrorObjectWithMessage (l:Obj; pr:Obj, m:Str) :
  * 
  * An object is a type error if it is an Error object with the TypeError prototype
  *)
-pred TypeError(l:Obj;) : ErrorObject (l, $lterr_proto);
-pred TypeErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l, $lterr_proto, m);
+pred TypeError(l:Obj;) : ErrorObject (l; $lterr_proto);
+pred TypeErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l; $lterr_proto, m);
 
 (* 
  * Syntax Error
  * 
  * An object is a syntax error if it is an Error object with the SyntaxError prototype
  *)
-pred SyntaxError(l:Obj;) : ErrorObject (l, $lserr_proto);
-pred SyntaxErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l, $lserr_proto, m);
+pred SyntaxError(l:Obj;) : ErrorObject (l; $lserr_proto);
+pred SyntaxErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l; $lserr_proto, m);
 
 (* 
  * Reference Error
  * 
  * An object is a reference error if it is an Error object with the ReferenceError prototype
  *)
-pred ReferenceError(l:Obj;) : ErrorObject (l, $lrferr_proto);
-pred ReferenceErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l, $lrferr_proto, m);
+pred ReferenceError(l:Obj;) : ErrorObject (l; $lrferr_proto);
+pred ReferenceErrorWithMessage (l:Obj; m:Str) : ErrorObjectWithMessage(l; $lrferr_proto, m);

--- a/Gillian-JS/runtime/ES5/preds_general.jsil
+++ b/Gillian-JS/runtime/ES5/preds_general.jsil
@@ -1,7 +1,7 @@
 (* 
  * General JS Object: location, prototype, class, extensibility
  *)
-pred JSObjGeneral (+l:Obj, proto, class:Str, ext:Bool) :
+pred JSObjGeneral (l:Obj; proto, class:Str, ext:Bool) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> proto) *
   ((#md, "@class")      -> class) *

--- a/Gillian-JS/runtime/JSLogic/ArrayBuffer.jsil
+++ b/Gillian-JS/runtime/JSLogic/ArrayBuffer.jsil
@@ -24,7 +24,7 @@ nounfold pred ArrayBuffer (ab:Obj; data:List) :
  **** Array Buffer Prototype  ****
  *********************************)
 
-nounfold pred ArrayBufferPrototype (proto;) :
+nounfold pred ArrayBufferPrototype (proto) :
   JSObjWithProto (proto; $lobj_proto) *
   empty_fields (proto : -{ "byteLength", "constructor", "slice" }-) *
 

--- a/Gillian-JS/runtime/JSLogic/ArrayBuffer.jsil
+++ b/Gillian-JS/runtime/JSLogic/ArrayBuffer.jsil
@@ -25,17 +25,17 @@ nounfold pred ArrayBuffer (ab:Obj; data:List) :
  *********************************)
 
 nounfold pred ArrayBufferPrototype (proto;) :
-  JSObjWithProto (proto, $lobj_proto) *
+  JSObjWithProto (proto; $lobj_proto) *
   empty_fields (proto : -{ "byteLength", "constructor", "slice" }-) *
 
   ((proto, "byteLength")  -> {{ "a", $lab_byteLength, undefined, false, true }}) * (* Array.prototype.bytelength  *)
   ((proto, "constructor") -> {{ "d", $lab, true, false, true }}) *                 (* Array.prototype.constructor *)
   ((proto, "slice")       -> {{ "d", $lab_slice, true, false, true }}) *           (* Array.prototype.slice       *)
 
-  JSBIFunction($lab_byteLength, "ABP_byteLength", 0) * (* Actual byteLength function *)
+  JSBIFunction($lab_byteLength; "ABP_byteLength", 0) * (* Actual byteLength function *)
   empty_fields($lab_byteLength : -{ "length" }-) *
 
-  JSBIFunction($lab_slice, "ABP_slice", 2) * (* Actual slice function *)
+  JSBIFunction($lab_slice; "ABP_slice", 2) * (* Actual slice function *)
   empty_fields($lab_slice : -{ "length" }-);
 
 (*************************************************************************
@@ -43,11 +43,11 @@ nounfold pred ArrayBufferPrototype (proto;) :
  *************************************************************************)
 
 axiomatic spec ABP_byteLength (xsc, vthis)
-    [[ (vthis == #vthis) * ArrayBuffer(#vthis, #data) ]]
-    [[ ArrayBuffer(#vthis, #data) * (ret == (l-len #data)) ]]
+    [[ (vthis == #vthis) * ArrayBuffer(#vthis; #data) ]]
+    [[ ArrayBuffer(#vthis; #data) * (ret == (l-len #data)) ]]
     normal
 
 axiomatic spec ABP_slice (xsc, vthis, start, end)
-    [[ (vthis == #vthis) * ArrayBuffer(#vthis, #data) * (0 <=# start) * (end <=# (l-len #data)) ]]
-    [[ ArrayBuffer(#vthis, #data) * ArrayBuffer(ret, #sub_array) * (#sub_array == l-sub (#data, start, end - start)) ]]
+    [[ (vthis == #vthis) * ArrayBuffer(#vthis; #data) * (0 <=# start) * (end <=# (l-len #data)) ]]
+    [[ ArrayBuffer(#vthis; #data) * ArrayBuffer(ret; #sub_array) * (#sub_array == l-sub (#data, start, end - start)) ]]
     normal

--- a/Gillian-JS/runtime/JSLogic/ArrayBuffer.jsil
+++ b/Gillian-JS/runtime/JSLogic/ArrayBuffer.jsil
@@ -6,7 +6,7 @@
  **** Array Buffer Instances  ****
  *********************************)
 
-nounfold pred ArrayBuffer (+ab:Obj, data:List) :
+nounfold pred ArrayBuffer (ab:Obj; data:List) :
   ((ab, "slice") -> none) *                            (* Slice must be found in the prototype           *)
 
   MetaData(ab, #md) * MetaData(#md, null) *
@@ -24,7 +24,7 @@ nounfold pred ArrayBuffer (+ab:Obj, data:List) :
  **** Array Buffer Prototype  ****
  *********************************)
 
-nounfold pred ArrayBufferPrototype (proto) :
+nounfold pred ArrayBufferPrototype (proto;) :
   JSObjWithProto (proto, $lobj_proto) *
   empty_fields (proto : -{ "byteLength", "constructor", "slice" }-) *
 

--- a/Gillian-JS/runtime/JSLogic/ArrayLogic.jsil
+++ b/Gillian-JS/runtime/JSLogic/ArrayLogic.jsil
@@ -42,17 +42,17 @@ pred ArrayOfUInt8ArraysContents(a:Obj, start:Num, contentsLength:Num; contents:L
     (contents == #element :: #rest) *
     (#rest_start == start + 1) *
     (#rest_length == contentsLength - 1) *
-    DataProp(a, #index, #ui8a) *
-    Uint8Array (#ui8a, #ab, 0, #viewSize) *
-    ArrayBuffer(#ab, #element) *
+    DataProp(a, #index; #ui8a) *
+    Uint8Array (#ui8a; #ab, 0, #viewSize) *
+    ArrayBuffer(#ab; #element) *
     (#viewSize == l-len #element) *
-    ArrayOfUInt8ArraysContents(a, #rest_start, #rest_length, #rest);
+    ArrayOfUInt8ArraysContents(a, #rest_start, #rest_length; #rest);
 
     facts: (contentsLength == l-len contents);
 
 pred ArrayOfUInt8Arrays (a:Obj; contents:List, arrayLength:Num) :
-    ArrayStructure(a, arrayLength) *
-    ArrayOfUInt8ArraysContents(a, 0, arrayLength, contents);
+    ArrayStructure(a, arrayLength;) *
+    ArrayOfUInt8ArraysContents(a, 0, arrayLength; contents);
 
 (* ----------------------------------------------------------------------------------- *)
 
@@ -63,25 +63,25 @@ pred ArrayOfArraysOfUInt8ArraysContents(a:Obj, start:Num, contentsLength:Num; co
     (#index == num_to_string start) *
     (contents == #elementContents :: #rest) *
     (#rest_length == contentsLength - 1) *
-    DataProp(a, #index, #aui8a) *
-    ArrayOfUInt8Arrays (#aui8a, #elementContents, _) *
+    DataProp(a, #index; #aui8a) *
+    ArrayOfUInt8Arrays (#aui8a; #elementContents, _) *
     (#rest_start == start + 1) *
-    ArrayOfArraysOfUInt8ArraysContents(a, #rest_start, #rest_length, #rest);
+    ArrayOfArraysOfUInt8ArraysContents(a, #rest_start, #rest_length; #rest);
 
     facts: (contentsLength == l-len contents);
 
 pred ArrayOfArraysOfUInt8Arrays (a:Obj; contents:List) :
-    ArrayStructure(a, l-len contents) *
-    ArrayOfArraysOfUInt8ArraysContents(a, 0, l-len contents, contents);
+    ArrayStructure(a, l-len contents;) *
+    ArrayOfArraysOfUInt8ArraysContents(a, 0, l-len contents; contents);
 
 lemma ArrayOfArraysOfUInt8ArraysContentsAppend(a, contents, start, contentsLength)
 [[
-    ArrayOfArraysOfUInt8ArraysContents(#a, #start, #contentsLength, #contents) *
-    DataProp(#a, num_to_string (#start + #contentsLength), #aui8a) *
-    ArrayOfUInt8Arrays (#aui8a, #elementContents, #elementLength)
+    ArrayOfArraysOfUInt8ArraysContents(#a, #start, #contentsLength; #contents) *
+    DataProp(#a, num_to_string (#start + #contentsLength); #aui8a) *
+    ArrayOfUInt8Arrays (#aui8a; #elementContents, #elementLength)
 ]]
 [[
-    ArrayOfArraysOfUInt8ArraysContents(#a, #start, #contentsLength + 1, l+ (#contents, {{ #elementContents }}))
+    ArrayOfArraysOfUInt8ArraysContents(#a, #start, #contentsLength + 1; l+ (#contents, {{ #elementContents }}))
 ]]
 
 
@@ -90,15 +90,15 @@ lemma ArrayOfArraysOfUInt8ArraysContentsAppend(a, contents, start, contentsLengt
  **************************)
 
 nounfold pred ArrayPrototype (proto;) :
-  JSObjWithProto (proto, $lobj_proto) *
+  JSObjWithProto (proto; $lobj_proto) *
   empty_fields (proto : -{ "push", "map" }-) *
 
   ((proto, "push") -> {{ "d", $lap_push, true, false, true }}) * (* Array.prototype.push  *)
   ((proto, "map")  -> {{ "d", $lap_map,  true, false, true }}) * (* Array.prototype.map   *)
 
-  JSBIFunction($lap_push, "AP_push", 1) * (* Actual push function *)
+  JSBIFunction($lap_push; "AP_push", 1) * (* Actual push function *)
     empty_fields($lap_push : -{ "length" }-) *
-  JSBIFunction($lap_map, "AP_map", 1) *  (* Actual map function *)
+  JSBIFunction($lap_map; "AP_map", 1) *  (* Actual map function *)
     empty_fields($lap_map : -{ "length" }-);
 
 (*******************************************************************
@@ -107,16 +107,16 @@ nounfold pred ArrayPrototype (proto;) :
 
 axiomatic spec AP_push (xsc, vthis, element)
     [[ (vthis == #vthis) * (element == #ui8a) *
-       Uint8Array (#ui8a, #ab, 0, #viewSize) *
-       ArrayBuffer(#ab, #element) *
+       Uint8Array (#ui8a; #ab, 0, #viewSize) *
+       ArrayBuffer(#ab; #element) *
        (#viewSize == l-len #element) *
-       ArrayOfUInt8Arrays(#vthis, #contents, #arraylength) ]]
-    [[ ArrayOfUInt8Arrays(#vthis, l+ (#contents, {{ #element }}), #arraylength + 1) * (ret == undefined) ]]
+       ArrayOfUInt8Arrays(#vthis; #contents, #arraylength) ]]
+    [[ ArrayOfUInt8Arrays(#vthis; l+ (#contents, {{ #element }}), #arraylength + 1) * (ret == undefined) ]]
     normal;
 
     [[ (vthis == #vthis) * (element == #aui8a) *
-       ArrayOfUInt8Arrays (#aui8a, #aContents, _) *
-       ArrayOfArraysOfUInt8Arrays(#vthis, #contents) ]]
-    [[ ArrayOfArraysOfUInt8Arrays(#vthis, l+ (#contents, {{ #aContents }})) * (ret == undefined) ]]
+       ArrayOfUInt8Arrays (#aui8a; #aContents, _) *
+       ArrayOfArraysOfUInt8Arrays(#vthis; #contents) ]]
+    [[ ArrayOfArraysOfUInt8Arrays(#vthis; l+ (#contents, {{ #aContents }})) * (ret == undefined) ]]
     normal
 

--- a/Gillian-JS/runtime/JSLogic/ArrayLogic.jsil
+++ b/Gillian-JS/runtime/JSLogic/ArrayLogic.jsil
@@ -34,7 +34,7 @@ pred FrozenArrayStructure(a:Obj, arrayLength:Num) :
  **** Array of Uint8Arrays  ****
  *******************************)
 
-pred ArrayOfUInt8ArraysContents(+a:Obj, contents:List, +start:Num, +contentsLength:Num) :
+pred ArrayOfUInt8ArraysContents(+a:Obj, +start:Num, +contentsLength:Num, contents:List) :
     (contentsLength == 0) * (contents == {{ }}),
 
     (contentsLength == l-len contents) *
@@ -46,17 +46,17 @@ pred ArrayOfUInt8ArraysContents(+a:Obj, contents:List, +start:Num, +contentsLeng
     Uint8Array (#ui8a, #ab, 0, #viewSize) *
     ArrayBuffer(#ab, #element) *
     (#viewSize == l-len #element) *
-    ArrayOfUInt8ArraysContents(a, #rest, #rest_start, #rest_length);
+    ArrayOfUInt8ArraysContents(a, #rest_start, #rest_length, #rest);
 
     facts: (contentsLength == l-len contents);
 
 pred ArrayOfUInt8Arrays (+a:Obj, contents:List, arrayLength:Num) :
     ArrayStructure(a, arrayLength) *
-    ArrayOfUInt8ArraysContents(a, contents, 0, arrayLength);
+    ArrayOfUInt8ArraysContents(a, 0, arrayLength, contents);
 
 (* ----------------------------------------------------------------------------------- *)
 
-pred ArrayOfArraysOfUInt8ArraysContents(+a:Obj, contents:List, +start:Num, +contentsLength:Num) :
+pred ArrayOfArraysOfUInt8ArraysContents(+a:Obj, +start:Num, +contentsLength:Num, contents:List) :
     (contentsLength == 0) * (contents == {{ }}),
 
     (contentsLength == l-len contents) *
@@ -66,22 +66,22 @@ pred ArrayOfArraysOfUInt8ArraysContents(+a:Obj, contents:List, +start:Num, +cont
     DataProp(a, #index, #aui8a) *
     ArrayOfUInt8Arrays (#aui8a, #elementContents, _) *
     (#rest_start == start + 1) *
-    ArrayOfArraysOfUInt8ArraysContents(a, #rest, #rest_start, #rest_length);
+    ArrayOfArraysOfUInt8ArraysContents(a, #rest_start, #rest_length, #rest);
 
     facts: (contentsLength == l-len contents);
 
 pred ArrayOfArraysOfUInt8Arrays (+a:Obj, contents:List) :
     ArrayStructure(a, l-len contents) *
-    ArrayOfArraysOfUInt8ArraysContents(a, contents, 0, l-len contents);
+    ArrayOfArraysOfUInt8ArraysContents(a, 0, l-len contents, contents);
 
 lemma ArrayOfArraysOfUInt8ArraysContentsAppend(a, contents, start, contentsLength)
 [[
-    ArrayOfArraysOfUInt8ArraysContents(#a, #contents, #start, #contentsLength) *
+    ArrayOfArraysOfUInt8ArraysContents(#a, #start, #contentsLength, #contents) *
     DataProp(#a, num_to_string (#start + #contentsLength), #aui8a) *
     ArrayOfUInt8Arrays (#aui8a, #elementContents, #elementLength)
 ]]
 [[
-    ArrayOfArraysOfUInt8ArraysContents(#a, l+ (#contents, {{ #elementContents }}), #start, #contentsLength + 1)
+    ArrayOfArraysOfUInt8ArraysContents(#a, #start, #contentsLength + 1, l+ (#contents, {{ #elementContents }}))
 ]]
 
 

--- a/Gillian-JS/runtime/JSLogic/ArrayLogic.jsil
+++ b/Gillian-JS/runtime/JSLogic/ArrayLogic.jsil
@@ -6,7 +6,7 @@
  **** Common Array Structure  ****
  *********************************)
 
-pred ArrayStructure(a:Obj, arrayLength:Num;) :
+pred ArrayStructure(a:Obj, arrayLength:Num) :
   ((a, "push") -> none) *                            (* Push must be found in the prototype *)
   ((a, "map")  -> none) *
 
@@ -18,7 +18,7 @@ pred ArrayStructure(a:Obj, arrayLength:Num;) :
 
   ((a, "length") -> {{ "d", arrayLength, true, false, false }});
 
-pred FrozenArrayStructure(a:Obj, arrayLength:Num;) :
+pred FrozenArrayStructure(a:Obj, arrayLength:Num) :
   ((a, "push") -> none) *                            (* Push must be found in the prototype *)
   ((a, "map")  -> none) *
 
@@ -51,7 +51,7 @@ pred ArrayOfUInt8ArraysContents(a:Obj, start:Num, contentsLength:Num; contents:L
     facts: (contentsLength == l-len contents);
 
 pred ArrayOfUInt8Arrays (a:Obj; contents:List, arrayLength:Num) :
-    ArrayStructure(a, arrayLength;) *
+    ArrayStructure(a, arrayLength) *
     ArrayOfUInt8ArraysContents(a, 0, arrayLength; contents);
 
 (* ----------------------------------------------------------------------------------- *)
@@ -71,7 +71,7 @@ pred ArrayOfArraysOfUInt8ArraysContents(a:Obj, start:Num, contentsLength:Num; co
     facts: (contentsLength == l-len contents);
 
 pred ArrayOfArraysOfUInt8Arrays (a:Obj; contents:List) :
-    ArrayStructure(a, l-len contents;) *
+    ArrayStructure(a, l-len contents) *
     ArrayOfArraysOfUInt8ArraysContents(a, 0, l-len contents; contents);
 
 lemma ArrayOfArraysOfUInt8ArraysContentsAppend(a, contents, start, contentsLength)
@@ -89,7 +89,7 @@ lemma ArrayOfArraysOfUInt8ArraysContentsAppend(a, contents, start, contentsLengt
  **** Array Prototype  ****
  **************************)
 
-nounfold pred ArrayPrototype (proto;) :
+nounfold pred ArrayPrototype (proto) :
   JSObjWithProto (proto; $lobj_proto) *
   empty_fields (proto : -{ "push", "map" }-) *
 

--- a/Gillian-JS/runtime/JSLogic/ArrayLogic.jsil
+++ b/Gillian-JS/runtime/JSLogic/ArrayLogic.jsil
@@ -6,7 +6,7 @@
  **** Common Array Structure  ****
  *********************************)
 
-pred ArrayStructure(a:Obj, arrayLength:Num) :
+pred ArrayStructure(a:Obj, arrayLength:Num;) :
   ((a, "push") -> none) *                            (* Push must be found in the prototype *)
   ((a, "map")  -> none) *
 
@@ -18,7 +18,7 @@ pred ArrayStructure(a:Obj, arrayLength:Num) :
 
   ((a, "length") -> {{ "d", arrayLength, true, false, false }});
 
-pred FrozenArrayStructure(a:Obj, arrayLength:Num) :
+pred FrozenArrayStructure(a:Obj, arrayLength:Num;) :
   ((a, "push") -> none) *                            (* Push must be found in the prototype *)
   ((a, "map")  -> none) *
 
@@ -34,7 +34,7 @@ pred FrozenArrayStructure(a:Obj, arrayLength:Num) :
  **** Array of Uint8Arrays  ****
  *******************************)
 
-pred ArrayOfUInt8ArraysContents(+a:Obj, +start:Num, +contentsLength:Num, contents:List) :
+pred ArrayOfUInt8ArraysContents(a:Obj, start:Num, contentsLength:Num; contents:List) :
     (contentsLength == 0) * (contents == {{ }}),
 
     (contentsLength == l-len contents) *
@@ -50,13 +50,13 @@ pred ArrayOfUInt8ArraysContents(+a:Obj, +start:Num, +contentsLength:Num, content
 
     facts: (contentsLength == l-len contents);
 
-pred ArrayOfUInt8Arrays (+a:Obj, contents:List, arrayLength:Num) :
+pred ArrayOfUInt8Arrays (a:Obj; contents:List, arrayLength:Num) :
     ArrayStructure(a, arrayLength) *
     ArrayOfUInt8ArraysContents(a, 0, arrayLength, contents);
 
 (* ----------------------------------------------------------------------------------- *)
 
-pred ArrayOfArraysOfUInt8ArraysContents(+a:Obj, +start:Num, +contentsLength:Num, contents:List) :
+pred ArrayOfArraysOfUInt8ArraysContents(a:Obj, start:Num, contentsLength:Num; contents:List) :
     (contentsLength == 0) * (contents == {{ }}),
 
     (contentsLength == l-len contents) *
@@ -70,7 +70,7 @@ pred ArrayOfArraysOfUInt8ArraysContents(+a:Obj, +start:Num, +contentsLength:Num,
 
     facts: (contentsLength == l-len contents);
 
-pred ArrayOfArraysOfUInt8Arrays (+a:Obj, contents:List) :
+pred ArrayOfArraysOfUInt8Arrays (a:Obj; contents:List) :
     ArrayStructure(a, l-len contents) *
     ArrayOfArraysOfUInt8ArraysContents(a, 0, l-len contents, contents);
 
@@ -89,7 +89,7 @@ lemma ArrayOfArraysOfUInt8ArraysContentsAppend(a, contents, start, contentsLengt
  **** Array Prototype  ****
  **************************)
 
-nounfold pred ArrayPrototype (proto) :
+nounfold pred ArrayPrototype (proto;) :
   JSObjWithProto (proto, $lobj_proto) *
   empty_fields (proto : -{ "push", "map" }-) *
 

--- a/Gillian-JS/runtime/JSLogic/ByteLogic.gil
+++ b/Gillian-JS/runtime/JSLogic/ByteLogic.gil
@@ -7,14 +7,14 @@
  ****************************************)
 
 (* Interpretation: one byte as an unsigned 8-bit integer *)
-pure pred rawToUInt8(+bytes:List, x:Num) :
+pure pred rawToUInt8(bytes:List; x:Num) :
     (bytes == {{ #b0 }}) * (x == #b0) *
     (0 <=# #b0) * (#b0 <# 256.) *
     (is_int #b0);
 
 (* Interpretation: two bytes as an unsigned 16-bit integer *)
 @nopath
-pure pred rawToUInt16(+bytes:List, +littleEndian:Bool, x:Num) :
+pure pred rawToUInt16(bytes:List, littleEndian:Bool; x:Num) :
     (littleEndian == false) *
       (bytes == {{ #b0, #b1 }}) *
       (0. <=# #b0) * (#b0 <# 256.) *
@@ -33,7 +33,7 @@ pure pred rawToUInt16(+bytes:List, +littleEndian:Bool, x:Num) :
 
 (* Interpretation: four bytes as an unsigned 32-bit integer *)
 @nopath
-pure pred rawToUInt32(+bytes:List, +littleEndian:Bool, x:Num) :
+pure pred rawToUInt32(bytes:List, littleEndian:Bool; x:Num) :
     (littleEndian == false) *
       (bytes == {{ #b0, #b1, #b2, #b3 }}) *
       (0. <=# #b0) * (#b0 <# 256.) *

--- a/Gillian-JS/runtime/JSLogic/DataView.jsil
+++ b/Gillian-JS/runtime/JSLogic/DataView.jsil
@@ -36,7 +36,7 @@ nounfold pred DataView (dv:Obj; buffer:Obj, byteOffset:Num, byteLength:Num) :
  **** DataView Prototype  ****
  *****************************)
 
-nounfold pred DataViewPrototype (proto;) :
+nounfold pred DataViewPrototype (proto) :
   JSObjWithProto (proto; $lobj_proto) *
   empty_fields (proto : -{ "buffer", "byteLength", "byteOffset", "constructor",
                                 "getUint8", "getUint16", "getUint32", "setUint8", "setUint16", "setUint32" }-) *
@@ -83,7 +83,7 @@ nounfold pred DataViewPrototype (proto;) :
  **** Built-in DataView Object ****
  **********************************)
 
-pred BI_DataViewObject (;) :
+pred BI_DataViewObject () :
   BIFunctionObject ($ldv; 1, $lfun_proto, empty, "DV_construct");
 
 (********************************************************************

--- a/Gillian-JS/runtime/JSLogic/DataView.jsil
+++ b/Gillian-JS/runtime/JSLogic/DataView.jsil
@@ -37,7 +37,7 @@ nounfold pred DataView (dv:Obj; buffer:Obj, byteOffset:Num, byteLength:Num) :
  *****************************)
 
 nounfold pred DataViewPrototype (proto;) :
-  JSObjWithProto (proto, $lobj_proto) *
+  JSObjWithProto (proto; $lobj_proto) *
   empty_fields (proto : -{ "buffer", "byteLength", "byteOffset", "constructor",
                                 "getUint8", "getUint16", "getUint32", "setUint8", "setUint16", "setUint32" }-) *
 
@@ -52,31 +52,31 @@ nounfold pred DataViewPrototype (proto;) :
   ((proto, "setUint16")   -> {{ "d", $ldv_setUint16, true, false, true }}) *       (* DataView.prototype.setUint16   *)
   ((proto, "setUint32")   -> {{ "d", $ldv_setUint32, true, false, true }}) *       (* DataView.prototype.setUint32   *)
 
-  JSBIFunction($ldv_buffer, "DVP_buffer", 0) * (* Actual buffer function *)
+  JSBIFunction($ldv_buffer; "DVP_buffer", 0) * (* Actual buffer function *)
   empty_fields($ldv_buffer : -{ "length" }-) *
 
-  JSBIFunction($ldv_byteLength, "DVP_byteLength", 0) * (* Actual byteLength function *)
+  JSBIFunction($ldv_byteLength; "DVP_byteLength", 0) * (* Actual byteLength function *)
   empty_fields($ldv_byteLength : -{ "length" }-) *
 
-  JSBIFunction($ldv_byteOffset, "DVP_byteOffset", 0) * (* Actual byteOffset function *)
+  JSBIFunction($ldv_byteOffset; "DVP_byteOffset", 0) * (* Actual byteOffset function *)
   empty_fields($ldv_byteOffset : -{ "length" }-) *
 
-  JSBIFunction($ldv_getUint8, "DVP_getUint8", 1) * (* Actual getUint8 function *)
+  JSBIFunction($ldv_getUint8; "DVP_getUint8", 1) * (* Actual getUint8 function *)
   empty_fields($ldv_getUint8 : -{ "length" }-) *
 
-  JSBIFunction($ldv_getUint16, "DVP_getUint16", 2) * (* Actual getUint16 function *)
+  JSBIFunction($ldv_getUint16; "DVP_getUint16", 2) * (* Actual getUint16 function *)
   empty_fields($ldv_getUint16 : -{ "length" }-) *
 
-  JSBIFunction($ldv_getUint32, "DVP_getUint32", 2) * (* Actual getUint32 function *)
+  JSBIFunction($ldv_getUint32; "DVP_getUint32", 2) * (* Actual getUint32 function *)
   empty_fields($ldv_getUint32 : -{ "length" }-) *
 
-  JSBIFunction($ldv_setUint8, "DVP_setUint8", 2) * (* Actual setUint8 function *)
+  JSBIFunction($ldv_setUint8; "DVP_setUint8", 2) * (* Actual setUint8 function *)
   empty_fields($ldv_setUint8 : -{ "length" }-) *
 
-  JSBIFunction($ldv_setUint16, "DVP_setUint16", 3) * (* Actual setUint16 function *)
+  JSBIFunction($ldv_setUint16; "DVP_setUint16", 3) * (* Actual setUint16 function *)
   empty_fields($ldv_setUint16 : -{ "length" }-) *
 
-  JSBIFunction($ldv_setUint32, "DVP_setUint32", 3) * (* Actual setUint32 function *)
+  JSBIFunction($ldv_setUint32; "DVP_setUint32", 3) * (* Actual setUint32 function *)
   empty_fields($ldv_setUint32 : -{ "length" }-);
 
 (**********************************
@@ -84,7 +84,7 @@ nounfold pred DataViewPrototype (proto;) :
  **********************************)
 
 pred BI_DataViewObject (;) :
-  BIFunctionObject ($ldv, 1, $lfun_proto, empty, "DV_construct");
+  BIFunctionObject ($ldv; 1, $lfun_proto, empty, "DV_construct");
 
 (********************************************************************
  **** Axiomatic specifications of the DataView-related functions ****
@@ -92,71 +92,71 @@ pred BI_DataViewObject (;) :
 
 axiomatic spec DV_construct (x_sc, v_this, buffer, byteOffset, byteLength)
     [[ (buffer == #buffer) * (byteOffset == #byteOffset) * (byteLength == #byteLength) *
-       ArrayBuffer(#buffer, #data) * (#bufferLength == l-len #data) *
+       ArrayBuffer(#buffer; #data) * (#bufferLength == l-len #data) *
        (0 <=# #byteOffset) * (0 <=# #byteLength) *
        (#byteOffset + #byteLength <=# #bufferLength) ]]
-    [[ ArrayBuffer(#buffer, #data) * DataView(ret, #buffer, #byteOffset, #byteLength) ]]
+    [[ ArrayBuffer(#buffer; #data) * DataView(ret; #buffer, #byteOffset, #byteLength) ]]
     normal
 
 axiomatic spec DVP_buffer (xsc, vthis)
-    [[ (vthis == #vthis) * DataView(#vthis, #buffer, #byteOffset, #byteLength) ]]
-    [[ DataView(#vthis, #buffer, #byteOffset, #byteLength) * (ret == #buffer) ]]
+    [[ (vthis == #vthis) * DataView(#vthis; #buffer, #byteOffset, #byteLength) ]]
+    [[ DataView(#vthis; #buffer, #byteOffset, #byteLength) * (ret == #buffer) ]]
     normal
 
 axiomatic spec DVP_byteLength (xsc, vthis)
-    [[ (vthis == #vthis) * DataView(#vthis, #buffer, #byteOffset, #byteLength) ]]
-    [[ DataView(#vthis, #buffer, #byteOffset, #byteLength) * (ret == #byteLength) ]]
+    [[ (vthis == #vthis) * DataView(#vthis; #buffer, #byteOffset, #byteLength) ]]
+    [[ DataView(#vthis; #buffer, #byteOffset, #byteLength) * (ret == #byteLength) ]]
     normal
 
 axiomatic spec DVP_byteOffset (xsc, vthis)
-    [[ (vthis == #vthis) * DataView(#vthis, #buffer, #byteOffset, #byteLength) ]]
-    [[ DataView(#vthis, #buffer, #byteOffset, #byteLength) * (ret == #byteOffset) ]]
+    [[ (vthis == #vthis) * DataView(#vthis; #buffer, #byteOffset, #byteLength) ]]
+    [[ DataView(#vthis; #buffer, #byteOffset, #byteLength) * (ret == #byteOffset) ]]
     normal
 
 axiomatic spec DVP_getUint8 (xsc, vthis, byteOffset)
     [[ (vthis == #vthis) * (byteOffset == #byteOffset) *
-       DataView(#vthis, #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer, #data) *
+       DataView(#vthis; #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer; #data) *
        (0 <=# byteOffset) * (#elementSize == 1.) * (#byteOffset + #elementSize <=# #viewSize) *
        (#view == l-sub(#data, #viewOffset, #viewSize)) ]]
-    [[ DataView(#vthis, #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer, #data) *
+    [[ DataView(#vthis; #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer; #data) *
        (#raw == l-sub (#view, #byteOffset, #elementSize)) *
-       rawToUInt8(#raw, ret) ]]
+       rawToUInt8(#raw; ret) ]]
     normal
 
 axiomatic spec DVP_getUint16 (xsc, vthis, byteOffset, littleEndian)
     [[ (vthis == #vthis) * (byteOffset == #byteOffset) * (littleEndian == undefined) *
-       DataView(#vthis, #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer, #data) *
+       DataView(#vthis; #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer; #data) *
        (0 <=# byteOffset) * (#elementSize == 2.) * (#byteOffset + #elementSize <=# #viewSize) *
        (#view == l-sub(#data, #viewOffset, #viewSize)) ]]
-    [[ DataView(#vthis, #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer, #data) *
+    [[ DataView(#vthis; #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer; #data) *
        (#raw == l-sub (#view, #byteOffset, #elementSize)) *
-       rawToUInt16(#raw, false, ret) ]]
+       rawToUInt16(#raw, false; ret) ]]
     normal;
 
     [[ (vthis == #vthis) * (byteOffset == #byteOffset) * (littleEndian == #littleEndian) *
-       DataView(#vthis, #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer, #data) *
+       DataView(#vthis; #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer; #data) *
        (0 <=# byteOffset) * (#elementSize == 2.) * (#byteOffset + #elementSize <=# #viewSize) *
        (#view == l-sub(#data, #viewOffset, #viewSize)) ]]
-    [[ DataView(#vthis, #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer, #data) *
+    [[ DataView(#vthis; #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer; #data) *
        (#raw == l-sub (#view, #byteOffset, #elementSize)) *
-       rawToUInt16(#raw, #littleEndian, ret) ]]
+       rawToUInt16(#raw, #littleEndian; ret) ]]
     normal
 
 axiomatic spec DVP_getUint32 (xsc, vthis, byteOffset, littleEndian)
     [[ (vthis == #vthis) * (byteOffset == #byteOffset) * (littleEndian == undefined) *
-       DataView(#vthis, #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer, #data) *
+       DataView(#vthis; #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer; #data) *
        (0 <=# byteOffset) * (#elementSize == 4.) * (#byteOffset + #elementSize <=# #viewSize) *
        (#view == l-sub(#data, #viewOffset, #viewSize)) ]]
-    [[ DataView(#vthis, #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer, #data) *
+    [[ DataView(#vthis; #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer; #data) *
        (#raw == l-sub (#view, #byteOffset, #elementSize)) *
-       rawToUInt32(#raw, false, ret) ]]
+       rawToUInt32(#raw, false; ret) ]]
     normal;
 
     [[ (vthis == #vthis) * (byteOffset == #byteOffset) * (littleEndian == #littleEndian) *
-       DataView(#vthis, #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer, #data) *
+       DataView(#vthis; #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer; #data) *
        (0 <=# byteOffset) * (#elementSize == 4.) * (#byteOffset + #elementSize <=# #viewSize) *
        (#view == l-sub(#data, #viewOffset, #viewSize)) ]]
-    [[ DataView(#vthis, #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer, #data) *
+    [[ DataView(#vthis; #buffer, #viewOffset, #viewSize) * ArrayBuffer(#buffer; #data) *
        (#raw == l-sub (#view, #byteOffset, #elementSize)) *
-       rawToUInt32(#raw, #littleEndian, ret) ]]
+       rawToUInt32(#raw, #littleEndian; ret) ]]
     normal

--- a/Gillian-JS/runtime/JSLogic/DataView.jsil
+++ b/Gillian-JS/runtime/JSLogic/DataView.jsil
@@ -6,7 +6,7 @@
  **** Data View Instances  ****
  ******************************)
 
-nounfold pred DataView (+dv:Obj, buffer:Obj, byteOffset:Num, byteLength:Num) :
+nounfold pred DataView (dv:Obj; buffer:Obj, byteOffset:Num, byteLength:Num) :
   ((dv, "buffer") -> none) *                    (* Functions to be found in the prototype      *)
   ((dv, "byteLength") -> none) *
   ((dv, "byteOffset") -> none) *
@@ -36,7 +36,7 @@ nounfold pred DataView (+dv:Obj, buffer:Obj, byteOffset:Num, byteLength:Num) :
  **** DataView Prototype  ****
  *****************************)
 
-nounfold pred DataViewPrototype (proto) :
+nounfold pred DataViewPrototype (proto;) :
   JSObjWithProto (proto, $lobj_proto) *
   empty_fields (proto : -{ "buffer", "byteLength", "byteOffset", "constructor",
                                 "getUint8", "getUint16", "getUint32", "setUint8", "setUint16", "setUint32" }-) *
@@ -83,7 +83,7 @@ nounfold pred DataViewPrototype (proto) :
  **** Built-in DataView Object ****
  **********************************)
 
-pred BI_DataViewObject () :
+pred BI_DataViewObject (;) :
   BIFunctionObject ($ldv, 1, $lfun_proto, empty, "DV_construct");
 
 (********************************************************************

--- a/Gillian-JS/runtime/JSLogic/Uint8Array.jsil
+++ b/Gillian-JS/runtime/JSLogic/Uint8Array.jsil
@@ -32,7 +32,7 @@ nounfold pred Uint8Array (ar:Obj; buffer:Obj, byteOffset:Num, arrayLength:Num) :
  *******************************)
 
 nounfold pred Uint8ArrayPrototype (proto;) :
-  JSObjWithProto (proto, $lobj_proto) *
+  JSObjWithProto (proto; $lobj_proto) *
   empty_fields (proto : -{ "buffer", "byteLength", "byteOffset", "constructor", "slice" }-) *
 
   ((proto, "buffer")      -> {{ "a", $lui8ar_buffer,     undefined, false, true }}) * (* Uint8Array.prototype.buffer      *)
@@ -41,16 +41,16 @@ nounfold pred Uint8ArrayPrototype (proto;) :
   ((proto, "constructor") -> {{ "d", $lui8ar, true, false, true }}) *                 (* Uint8Array.prototype.constructor *)
   ((proto, "slice")       -> {{ "d", $lui8ar_slice, true, false, true }}) *           (* Uint8Array.prototype.slice       *)
 
-  JSBIFunction($lui8ar_buffer, "UI8ARP_buffer", 0) * (* Actual buffer function *)
+  JSBIFunction($lui8ar_buffer; "UI8ARP_buffer", 0) * (* Actual buffer function *)
   empty_fields($lui8ar_buffer : -{ "length" }-) *
 
-  JSBIFunction($lui8ar_byteLength, "UI8ARP_byteLength", 0) * (* Actual byteLength function *)
+  JSBIFunction($lui8ar_byteLength; "UI8ARP_byteLength", 0) * (* Actual byteLength function *)
   empty_fields($lui8ar_byteLength : -{ "length" }-) *
 
-  JSBIFunction($lui8ar_byteOffset, "UI8ARP_byteOffset", 0) * (* Actual byteOffset function *)
+  JSBIFunction($lui8ar_byteOffset; "UI8ARP_byteOffset", 0) * (* Actual byteOffset function *)
   empty_fields($lui8ar_byteOffset : -{ "length" }-) *
 
-  JSBIFunction($lui8ar_slice, "UI8ARP_slice", 2) * (* Actual slice function *)
+  JSBIFunction($lui8ar_slice; "UI8ARP_slice", 2) * (* Actual slice function *)
   empty_fields($lui8ar_slice : -{ "length" }-);
 
 (**********************************************************************
@@ -58,26 +58,26 @@ nounfold pred Uint8ArrayPrototype (proto;) :
  **********************************************************************)
 
 axiomatic spec UI8ARP_buffer (xsc, vthis)
-    [[ (vthis == #vthis) * Uint8Array(#vthis, #buffer, #byteOffset, #arrayLength) ]]
-    [[ Uint8Array(#vthis, #buffer, #byteOffset, #arrayLength) * (ret == #buffer) ]]
+    [[ (vthis == #vthis) * Uint8Array(#vthis; #buffer, #byteOffset, #arrayLength) ]]
+    [[ Uint8Array(#vthis; #buffer, #byteOffset, #arrayLength) * (ret == #buffer) ]]
     normal
 
 axiomatic spec UI8ARP_byteLength (xsc, vthis)
-    [[ (vthis == #vthis) * Uint8Array(#vthis, #buffer, #byteOffset, #arrayLength) ]]
-    [[ Uint8Array(#vthis, #buffer, #byteOffset, #arrayLength) * (ret == #arrayLength) ]]
+    [[ (vthis == #vthis) * Uint8Array(#vthis; #buffer, #byteOffset, #arrayLength) ]]
+    [[ Uint8Array(#vthis; #buffer, #byteOffset, #arrayLength) * (ret == #arrayLength) ]]
     normal
 
 axiomatic spec UI8ARP_byteOffset (xsc, vthis)
-    [[ (vthis == #vthis) * Uint8Array(#vthis, #buffer, #byteOffset, #arrayLength) ]]
-    [[ Uint8Array(#vthis, #buffer, #byteOffset, #arrayLength) * (ret == #byteOffset) ]]
+    [[ (vthis == #vthis) * Uint8Array(#vthis; #buffer, #byteOffset, #arrayLength) ]]
+    [[ Uint8Array(#vthis; #buffer, #byteOffset, #arrayLength) * (ret == #byteOffset) ]]
     normal
 
 axiomatic spec UI8ARP_slice (xsc, vthis, start, end)
     [[ (vthis == #vthis) *
-       Uint8Array(#vthis, #buffer, #byteOffset, #arrayLength) * ArrayBuffer(#buffer, #data) *
+       Uint8Array(#vthis; #buffer, #byteOffset, #arrayLength) * ArrayBuffer(#buffer; #data) *
        (0 <=# start) * (0 <=# end) * (end <=# #arrayLength) *
        (#view == l-sub(#data, #byteOffset, #arrayLength)) ]]
-    [[ Uint8Array(#vthis, #buffer, #byteOffset, #arrayLength) * ArrayBuffer(#buffer, #data) *
-       Uint8Array(ret, #sBuffer, #sByteOffset, #sArrayLength) * ArrayBuffer(#sBuffer, #sData) *
+    [[ Uint8Array(#vthis; #buffer, #byteOffset, #arrayLength) * ArrayBuffer(#buffer; #data) *
+       Uint8Array(ret; #sBuffer, #sByteOffset, #sArrayLength) * ArrayBuffer(#sBuffer; #sData) *
        (#sByteOffset == 0) * (#sArrayLength == end - start) * (#sData == l-sub (#view, start, end - start)) ]]
     normal

--- a/Gillian-JS/runtime/JSLogic/Uint8Array.jsil
+++ b/Gillian-JS/runtime/JSLogic/Uint8Array.jsil
@@ -6,7 +6,7 @@
  **** Uint8Array Instances  ****
  *******************************)
 
-nounfold pred Uint8Array (+ar:Obj, buffer:Obj, byteOffset:Num, arrayLength:Num) :
+nounfold pred Uint8Array (ar:Obj; buffer:Obj, byteOffset:Num, arrayLength:Num) :
   ((ar, "buffer")     -> none) *                   (* Functions to be found in the prototype      *)
   ((ar, "byteLength") -> none) *
   ((ar, "byteOffset") -> none) *
@@ -31,7 +31,7 @@ nounfold pred Uint8Array (+ar:Obj, buffer:Obj, byteOffset:Num, arrayLength:Num) 
  **** Uint8Array Prototype  ****
  *******************************)
 
-nounfold pred Uint8ArrayPrototype (+proto) :
+nounfold pred Uint8ArrayPrototype (proto;) :
   JSObjWithProto (proto, $lobj_proto) *
   empty_fields (proto : -{ "buffer", "byteLength", "byteOffset", "constructor", "slice" }-) *
 

--- a/Gillian-JS/runtime/JSLogic/Uint8Array.jsil
+++ b/Gillian-JS/runtime/JSLogic/Uint8Array.jsil
@@ -31,7 +31,7 @@ nounfold pred Uint8Array (ar:Obj; buffer:Obj, byteOffset:Num, arrayLength:Num) :
  **** Uint8Array Prototype  ****
  *******************************)
 
-nounfold pred Uint8ArrayPrototype (proto;) :
+nounfold pred Uint8ArrayPrototype (proto) :
   JSObjWithProto (proto; $lobj_proto) *
   empty_fields (proto : -{ "buffer", "byteLength", "byteOffset", "constructor", "slice" }-) *
 

--- a/Gillian-JS/runtime/JSLogic/bi_javert_predicates.jsil
+++ b/Gillian-JS/runtime/JSLogic/bi_javert_predicates.jsil
@@ -6,7 +6,7 @@
  **** GENERAL OBJECTS ****
  *************************)
 
-pred JSObject (l:Obj;) :
+pred JSObject (l:Obj) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> $lobj_proto) *
   ((#md, "@class")      -> "Object") *
@@ -105,7 +105,7 @@ pred StringObject (l:Obj; s:Str) :
   ((#md, "@primitiveValue") -> s) *
   empty_fields (#md : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred BooleanPrototype (;) :
+pred BooleanPrototype () :
   (($lbool_proto, "constructor") -> {{ "d", $lbool, true, false, true }}) *
   MetaData($lbool_proto, #bpmd) * MetaData(#bpmd, null) *
   ((#bpmd, "@proto")          -> $lobj_proto) *
@@ -114,7 +114,7 @@ pred BooleanPrototype (;) :
   ((#bpmd, "@primitiveValue") -> false) *
   empty_fields (#bpmd : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred NumberPrototype (;) :
+pred NumberPrototype () :
   (($lnum_proto, "constructor") -> {{ "d", $lnum, true, false, true }}) *
   MetaData($lnum_proto, #npmd) * MetaData(#npmd, null) *
   ((#npmd, "@proto")          -> $lobj_proto) *
@@ -123,24 +123,24 @@ pred NumberPrototype (;) :
   ((#npmd, "@primitiveValue") -> 0) *
   empty_fields (#npmd : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred GlobalObject (;) :
-  JSObject ($lg;) * (($lg, "Error") -> {{ "d", $lerr, true, false, true }}) *
+pred GlobalObject () :
+  JSObject ($lg) * (($lg, "Error") -> {{ "d", $lerr, true, false, true }}) *
     (($lg, "Object") -> {{ "d", $lobj, true, false, true }}) *
     (($lg, "undefined") -> {{ "d", undefined, false, false, false }});
 
 pred GlobalVar (v; val) :
   (($lg, v) -> {{ "d", val, true, true, false }}) * types(v : Str);
 
-pred BI_ObjectObject (;) :
+pred BI_ObjectObject () :
   BIFunctionObject ($lobj; 0, $lobj_proto) *
   MetaData($lobj, #mlobj) * ((#mlobj, "@call") -> "Object_call") * ((#mlobj, "@construct") -> "Object_construct");
 
-pred ObjectPrototype (;) :
+pred ObjectPrototype () :
   JSObjWithProto ($lobj_proto; null) * empty_fields ($lobj_proto : -{ "hasOwnProperty" }-) *
   (($lobj_proto, "hasOwnProperty") -> {{ "d", $lop_hasOwnProperty, true, false, true }}) *
   JSBIFunction($lop_hasOwnProperty; "OP_hasOwnProperty", 1) * empty_fields($lop_hasOwnProperty : -{ "length" }-);
 
-pred FunctionPrototype (;) :
+pred FunctionPrototype () :
   JSObjGeneralWeak ($lfun_proto; $lobj_proto, "Function", true) *
   (($lfun_proto, "length") -> {{ "d", 0, false, false, false }}) *
   (($lfun_proto, "call")   -> {{ "d", $lfp_call, true, false, true }}) *
@@ -150,11 +150,11 @@ pred FunctionPrototype (;) :
   empty_fields(#mfp : -{ "@proto", "@class", "@extensible", "@scope", "@call" }-) *
   JSBIFunction($lfp_call; "FP_call", 1);
 
-pred BI_ErrorObject (;) :
+pred BI_ErrorObject () :
   BIFunctionObject ($lerr; 1, $lerr_proto) *
   MetaData($lerr, #mlerr) * ((#mlerr, "@call") -> "Error_call") * ((#mlerr, "@construct") -> "Error_construct");
 
-pred StringPrototype (;) :
+pred StringPrototype () :
   (($lstr_proto, "constructor") -> {{ "d", $lstr, true, false, true }}) *
   empty_fields ($lstr_proto : -{ "constructor" }-) *
   MetaData($lstr_proto, #spmd) * MetaData(#spmd, null) *
@@ -178,65 +178,65 @@ pred ErrorWithMessage (l:Obj; m:Str) :
   ((#md, "@proto") -> $lerr_proto) * ((#md, "@class") -> "Error") * ((#md, "@extensible") -> true) *
   empty_fields(l : -{ "message" }-);
 
-pred TypeError(l:Obj;) : ErrorObject (l; $lterr_proto);
+pred TypeError(l:Obj) : ErrorObject (l; $lterr_proto);
 
-pred SyntaxError(l:Obj;) : ErrorObject (l; $lserr_proto);
+pred SyntaxError(l:Obj) : ErrorObject (l; $lserr_proto);
 
-pred ReferenceError(l:Obj;) : ErrorObject (l; $lrferr_proto);
+pred ReferenceError(l:Obj) : ErrorObject (l; $lrferr_proto);
 
 pred ErrorComplete (l:Obj; pr:Obj) : ErrorObject (l; pr) * empty_fields(l : -{ }-);
 
-pred TypeErrorComplete      (l:Obj;) : TypeError      (l;) * empty_fields(l : -{ }-);
-pred SyntaxErrorComplete    (l:Obj;) : SyntaxError    (l;) * empty_fields(l : -{ }-);
-pred ReferenceErrorComplete (l:Obj;) : ReferenceError (l;) * empty_fields(l : -{ }-);
+pred TypeErrorComplete      (l:Obj) : TypeError      (l) * empty_fields(l : -{ }-);
+pred SyntaxErrorComplete    (l:Obj) : SyntaxError    (l) * empty_fields(l : -{ }-);
+pred ReferenceErrorComplete (l:Obj) : ReferenceError (l) * empty_fields(l : -{ }-);
 
 (************************
  ***** INITIAL HEAP *****
  ************************)
 
-pred initialHeapPost (globals;) :
+pred initialHeapPost (globals) :
     types(globals:Set) *
 
-    GlobalObject(;) *
+    GlobalObject() *
     empty_fields ($lg : -u- (-{ "Error" }-, globals) ) *
 
-    BI_ObjectObject (;) *
-    ObjectPrototype (;) *
+    BI_ObjectObject () *
+    ObjectPrototype () *
 
-    FunctionPrototype (;) *
+    FunctionPrototype () *
 
-    BooleanPrototype (;) * empty_fields ($lbool_proto : -{ "constructor" }-) *
+    BooleanPrototype () * empty_fields ($lbool_proto : -{ "constructor" }-) *
 
-    NumberPrototype (;)  * empty_fields ($lnum_proto : -{ "constructor" }-) *
+    NumberPrototype ()  * empty_fields ($lnum_proto : -{ "constructor" }-) *
 
-    BI_ErrorObject (;) * empty_fields($lerr : -{ "length", "prototype" }-) *
+    BI_ErrorObject () * empty_fields($lerr : -{ "length", "prototype" }-) *
 
     JSObjGeneral ($lerr_proto; $lobj_proto, "Error", true) *
     (($lerr_proto, "message") -> {{ "d", "", true, false, true }}) *
     empty_fields($lerr_proto : -{ "message" }-);
 
-pred initialHeapPostWeak (;) :
+pred initialHeapPostWeak () :
 
-    GlobalObject(;) *
+    GlobalObject() *
 
-    BI_ObjectObject (;) *
-    ObjectPrototype (;) *
+    BI_ObjectObject () *
+    ObjectPrototype () *
 
-    FunctionPrototype (;) *
+    FunctionPrototype () *
 
-    BooleanPrototype (;) *
+    BooleanPrototype () *
     empty_fields ($lbool_proto : -{ "constructor" }-) *
 
-    NumberPrototype (;) *
+    NumberPrototype () *
     empty_fields ($lnum_proto : -{ "constructor" }-) *
 
-    BI_ErrorObject (;) * empty_fields($lerr : -{ "length", "prototype" }-) *
+    BI_ErrorObject () * empty_fields($lerr : -{ "length", "prototype" }-) *
 
     JSObjGeneral ($lerr_proto; $lobj_proto, "Error", true) *
     (($lerr_proto, "message") -> {{ "d", "", true, false, true }}) *
     empty_fields($lerr_proto : -{ "message" }-) *
 
-    StringPrototype (;);
+    StringPrototype ();
 
 
 (********************
@@ -259,14 +259,14 @@ pred DataPropConst (l:Obj, prop:Str; v, enum:Bool) :
  **** ARRAYS ****
  ****************)
 
-pred ArrayObj(x : Obj;) :
+pred ArrayObj(x : Obj) :
   JSObjWithProto(x; $larr_proto) *
   DataProp(x, "length"; #len) *
   ((x, "splice") -> none) *
   types(#len : Num);
 
-pred ArrayProto(;) :
-  JSObject($larr_proto;) *
+pred ArrayProto() :
+  JSObject($larr_proto) *
   DataProp($larr_proto, "length"; 0) *
   DataProp($larr_proto, "splice"; #splice) *
   JSFunctionObject (#splice; "AP_splice", {{ }}, 0, #y);

--- a/Gillian-JS/runtime/JSLogic/bi_javert_predicates.jsil
+++ b/Gillian-JS/runtime/JSLogic/bi_javert_predicates.jsil
@@ -52,7 +52,7 @@ pred JSFunctionObject (l:Obj; fid:Str, sc:List, len:Num, proto:Obj) :
   empty_fields(#md : -{ "@call", "@class", "@construct", "@extensible", "@proto", "@scope" }-);
 
 pred JSFunctionObjectStrong (l:Obj; fid:Str, sc:List, len:Num, proto:Obj) :
-  JSFunctionObject (l, fid, sc, len, proto) *
+  JSFunctionObject (l; fid, sc, len, proto) *
   empty_fields(l : -{ "arguments", "caller", "length", "prototype" }-);
 
 pred JSBIFunction (l:Obj; fid:Str, len:Num) :
@@ -96,7 +96,7 @@ pred NumberObject (l:Obj; n:Num) :
   empty_fields (#md : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
 pred StringObject (l:Obj; s:Str) :
-  DataPropConst(l, "length", #len, false) *
+  DataPropConst(l, "length"; #len, false) *
   (#len == s-len s) *
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> $lstr_proto) *
@@ -124,7 +124,7 @@ pred NumberPrototype (;) :
   empty_fields (#npmd : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
 pred GlobalObject (;) :
-  JSObject ($lg) * (($lg, "Error") -> {{ "d", $lerr, true, false, true }}) *
+  JSObject ($lg;) * (($lg, "Error") -> {{ "d", $lerr, true, false, true }}) *
     (($lg, "Object") -> {{ "d", $lobj, true, false, true }}) *
     (($lg, "undefined") -> {{ "d", undefined, false, false, false }});
 
@@ -132,26 +132,26 @@ pred GlobalVar (v; val) :
   (($lg, v) -> {{ "d", val, true, true, false }}) * types(v : Str);
 
 pred BI_ObjectObject (;) :
-  BIFunctionObject ($lobj, 0, $lobj_proto) *
+  BIFunctionObject ($lobj; 0, $lobj_proto) *
   MetaData($lobj, #mlobj) * ((#mlobj, "@call") -> "Object_call") * ((#mlobj, "@construct") -> "Object_construct");
 
 pred ObjectPrototype (;) :
-  JSObjWithProto ($lobj_proto, null) * empty_fields ($lobj_proto : -{ "hasOwnProperty" }-) *
+  JSObjWithProto ($lobj_proto; null) * empty_fields ($lobj_proto : -{ "hasOwnProperty" }-) *
   (($lobj_proto, "hasOwnProperty") -> {{ "d", $lop_hasOwnProperty, true, false, true }}) *
-  JSBIFunction($lop_hasOwnProperty, "OP_hasOwnProperty", 1) * empty_fields($lop_hasOwnProperty : -{ "length" }-);
+  JSBIFunction($lop_hasOwnProperty; "OP_hasOwnProperty", 1) * empty_fields($lop_hasOwnProperty : -{ "length" }-);
 
 pred FunctionPrototype (;) :
-  JSObjGeneralWeak ($lfun_proto, $lobj_proto, "Function", true) *
+  JSObjGeneralWeak ($lfun_proto; $lobj_proto, "Function", true) *
   (($lfun_proto, "length") -> {{ "d", 0, false, false, false }}) *
   (($lfun_proto, "call")   -> {{ "d", $lfp_call, true, false, true }}) *
   empty_fields($lfun_proto : -{ "call", "length" }-) *
   MetaData($lfun_proto, #mfp) *
   ((#mfp, "@scope") -> empty) * ((#mfp, "@call") -> "FP_default") *
   empty_fields(#mfp : -{ "@proto", "@class", "@extensible", "@scope", "@call" }-) *
-  JSBIFunction($lfp_call, "FP_call", 1);
+  JSBIFunction($lfp_call; "FP_call", 1);
 
 pred BI_ErrorObject (;) :
-  BIFunctionObject ($lerr, 1, $lerr_proto) *
+  BIFunctionObject ($lerr; 1, $lerr_proto) *
   MetaData($lerr, #mlerr) * ((#mlerr, "@call") -> "Error_call") * ((#mlerr, "@construct") -> "Error_construct");
 
 pred StringPrototype (;) :
@@ -170,7 +170,7 @@ pred StringPrototype (;) :
  ***********************)
 
 pred ErrorObject (l:Obj; pr:Obj) :
-  JSObjGeneral(l, pr, "Error", true);
+  JSObjGeneral(l; pr, "Error", true);
 
 pred ErrorWithMessage (l:Obj; m:Str) :
   MetaData(l, #md) *  MetaData(#md, null) *
@@ -178,17 +178,17 @@ pred ErrorWithMessage (l:Obj; m:Str) :
   ((#md, "@proto") -> $lerr_proto) * ((#md, "@class") -> "Error") * ((#md, "@extensible") -> true) *
   empty_fields(l : -{ "message" }-);
 
-pred TypeError(l:Obj;) : ErrorObject (l, $lterr_proto);
+pred TypeError(l:Obj;) : ErrorObject (l; $lterr_proto);
 
-pred SyntaxError(l:Obj;) : ErrorObject (l, $lserr_proto);
+pred SyntaxError(l:Obj;) : ErrorObject (l; $lserr_proto);
 
-pred ReferenceError(l:Obj;) : ErrorObject (l, $lrferr_proto);
+pred ReferenceError(l:Obj;) : ErrorObject (l; $lrferr_proto);
 
-pred ErrorComplete (l:Obj; pr:Obj) : ErrorObject (l, pr) * empty_fields(l : -{ }-);
+pred ErrorComplete (l:Obj; pr:Obj) : ErrorObject (l; pr) * empty_fields(l : -{ }-);
 
-pred TypeErrorComplete      (l:Obj;) : TypeError      (l) * empty_fields(l : -{ }-);
-pred SyntaxErrorComplete    (l:Obj;) : SyntaxError    (l) * empty_fields(l : -{ }-);
-pred ReferenceErrorComplete (l:Obj;) : ReferenceError (l) * empty_fields(l : -{ }-);
+pred TypeErrorComplete      (l:Obj;) : TypeError      (l;) * empty_fields(l : -{ }-);
+pred SyntaxErrorComplete    (l:Obj;) : SyntaxError    (l;) * empty_fields(l : -{ }-);
+pred ReferenceErrorComplete (l:Obj;) : ReferenceError (l;) * empty_fields(l : -{ }-);
 
 (************************
  ***** INITIAL HEAP *****
@@ -197,46 +197,46 @@ pred ReferenceErrorComplete (l:Obj;) : ReferenceError (l) * empty_fields(l : -{ 
 pred initialHeapPost (globals;) :
     types(globals:Set) *
 
-    GlobalObject() *
+    GlobalObject(;) *
     empty_fields ($lg : -u- (-{ "Error" }-, globals) ) *
 
-    BI_ObjectObject () *
-    ObjectPrototype () *
+    BI_ObjectObject (;) *
+    ObjectPrototype (;) *
 
-    FunctionPrototype () *
+    FunctionPrototype (;) *
 
-    BooleanPrototype () * empty_fields ($lbool_proto : -{ "constructor" }-) *
+    BooleanPrototype (;) * empty_fields ($lbool_proto : -{ "constructor" }-) *
 
-    NumberPrototype ()  * empty_fields ($lnum_proto : -{ "constructor" }-) *
+    NumberPrototype (;)  * empty_fields ($lnum_proto : -{ "constructor" }-) *
 
-    BI_ErrorObject () * empty_fields($lerr : -{ "length", "prototype" }-) *
+    BI_ErrorObject (;) * empty_fields($lerr : -{ "length", "prototype" }-) *
 
-    JSObjGeneral ($lerr_proto, $lobj_proto, "Error", true) *
+    JSObjGeneral ($lerr_proto; $lobj_proto, "Error", true) *
     (($lerr_proto, "message") -> {{ "d", "", true, false, true }}) *
     empty_fields($lerr_proto : -{ "message" }-);
 
 pred initialHeapPostWeak (;) :
 
-    GlobalObject() *
+    GlobalObject(;) *
 
-    BI_ObjectObject () *
-    ObjectPrototype () *
+    BI_ObjectObject (;) *
+    ObjectPrototype (;) *
 
-    FunctionPrototype () *
+    FunctionPrototype (;) *
 
-    BooleanPrototype () *
+    BooleanPrototype (;) *
     empty_fields ($lbool_proto : -{ "constructor" }-) *
 
-    NumberPrototype () *
+    NumberPrototype (;) *
     empty_fields ($lnum_proto : -{ "constructor" }-) *
 
-    BI_ErrorObject () * empty_fields($lerr : -{ "length", "prototype" }-) *
+    BI_ErrorObject (;) * empty_fields($lerr : -{ "length", "prototype" }-) *
 
-    JSObjGeneral ($lerr_proto, $lobj_proto, "Error", true) *
+    JSObjGeneral ($lerr_proto; $lobj_proto, "Error", true) *
     (($lerr_proto, "message") -> {{ "d", "", true, false, true }}) *
     empty_fields($lerr_proto : -{ "message" }-) *
 
-    StringPrototype ();
+    StringPrototype (;);
 
 
 (********************
@@ -260,25 +260,25 @@ pred DataPropConst (l:Obj, prop:Str; v, enum:Bool) :
  ****************)
 
 pred ArrayObj(x : Obj;) :
-  JSObjWithProto(x, $larr_proto) *
-  DataProp(x, "length", #len) *
+  JSObjWithProto(x; $larr_proto) *
+  DataProp(x, "length"; #len) *
   ((x, "splice") -> none) *
   types(#len : Num);
 
 pred ArrayProto(;) :
-  JSObject($larr_proto) *
-  DataProp($larr_proto, "length", 0) *
-  DataProp($larr_proto, "splice", #splice) *
-  JSFunctionObject (#splice, "AP_splice", {{ }}, 0, #y);
+  JSObject($larr_proto;) *
+  DataProp($larr_proto, "length"; 0) *
+  DataProp($larr_proto, "splice"; #splice) *
+  JSFunctionObject (#splice; "AP_splice", {{ }}, 0, #y);
 
 pred array_sequence(length : Num; seq : Set) :
   (0 == length) * (seq == -{ }-),
-  (0 <# length) * array_sequence((length - 1), #seq) * (seq == -u- (#seq, -{ num_to_string (length - 1) }-));
+  (0 <# length) * array_sequence((length - 1); #seq) * (seq == -u- (#seq, -{ num_to_string (length - 1) }-));
 
 pred JSArrayContents(l:Obj, length:Num, current:Num; contents:List):
   (current == length) * (contents == {{ }}),
-  DataProp(l, num_to_string current, #first) * (contents == #first    :: #rest) * JSArrayContents(l, length, current + 1, #rest),
-  ((l, num_to_string current) -> none)       * (contents == undefined :: #rest) * JSArrayContents(l, length, current + 1, #rest);
+  DataProp(l, num_to_string current; #first) * (contents == #first    :: #rest) * JSArrayContents(l, length, current + 1; #rest),
+  ((l, num_to_string current) -> none)       * (contents == undefined :: #rest) * JSArrayContents(l, length, current + 1; #rest);
 
 pred JSArray (l:Obj; length:Num, contents:List):
   MetaData(l, #md) * MetaData(#md, null) *
@@ -286,7 +286,7 @@ pred JSArray (l:Obj; length:Num, contents:List):
   ((#md, "@class")      -> "Array") *
   ((#md, "@extensible") -> true) *
   empty_fields (#md : -{ "@class", "@extensible", "@proto" }-) *
-  DataPropGen(l, "length", length, true, false, false) *
-  JSArrayContents(l, length, 0, contents) *
-  array_sequence(length, #ef_seq) *
+  DataPropGen(l, "length"; length, true, false, false) *
+  JSArrayContents(l, length, 0; contents) *
+  array_sequence(length; #ef_seq) *
   empty_fields(l : -u- (#ef_seq, -{ "length" }-));

--- a/Gillian-JS/runtime/JSLogic/bi_javert_predicates.jsil
+++ b/Gillian-JS/runtime/JSLogic/bi_javert_predicates.jsil
@@ -6,28 +6,28 @@
  **** GENERAL OBJECTS ****
  *************************)
 
-pred JSObject (l:Obj) :
+pred JSObject (l:Obj;) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> $lobj_proto) *
   ((#md, "@class")      -> "Object") *
   ((#md, "@extensible") -> true) *
   empty_fields (#md : -{ "@class", "@extensible", "@proto" }-);
 
-pred JSObjWithProto (+l:Obj, proto) :
+pred JSObjWithProto (l:Obj; proto) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> proto) *
   ((#md, "@class")      -> "Object") *
   ((#md, "@extensible") -> true) *
   empty_fields (#md : -{ "@class", "@extensible", "@proto" }-);
 
-pred JSObjGeneral (+l:Obj, proto, class:Str, ext:Bool) :
+pred JSObjGeneral (l:Obj; proto, class:Str, ext:Bool) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> proto) *
   ((#md, "@class")      -> class) *
   ((#md, "@extensible") -> ext) *
   empty_fields (#md : -{ "@class", "@extensible", "@proto" }-);
 
-pred JSObjGeneralWeak (+l:Obj, proto, class:Str, ext:Bool) :
+pred JSObjGeneralWeak (l:Obj; proto, class:Str, ext:Bool) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> proto) *
   ((#md, "@class")      -> class) *
@@ -37,7 +37,7 @@ pred JSObjGeneralWeak (+l:Obj, proto, class:Str, ext:Bool) :
  **** FUNCTION OBJECTS ****
  **************************)
 
-pred JSFunctionObject (+l:Obj, fid:Str, sc:List, len:Num, proto:Obj) :
+pred JSFunctionObject (l:Obj; fid:Str, sc:List, len:Num, proto:Obj) :
   ((l, "length")     -> {{ "d", len, false, false, false }}) *
   ((l, "arguments")  -> {{ "a", $lthrw_type_error, $lthrw_type_error, false, false }}) *
   ((l, "caller")     -> {{ "a", $lthrw_type_error, $lthrw_type_error, false, false }}) *
@@ -51,11 +51,11 @@ pred JSFunctionObject (+l:Obj, fid:Str, sc:List, len:Num, proto:Obj) :
   ((#md, "@scope")      -> sc) *
   empty_fields(#md : -{ "@call", "@class", "@construct", "@extensible", "@proto", "@scope" }-);
 
-pred JSFunctionObjectStrong (+l:Obj, fid:Str, sc:List, len:Num, proto:Obj) :
+pred JSFunctionObjectStrong (l:Obj; fid:Str, sc:List, len:Num, proto:Obj) :
   JSFunctionObject (l, fid, sc, len, proto) *
   empty_fields(l : -{ "arguments", "caller", "length", "prototype" }-);
 
-pred JSBIFunction (+l:Obj, fid:Str, len:Num) :
+pred JSBIFunction (l:Obj; fid:Str, len:Num) :
   ((l, "length")     -> {{ "d", len, false, false, false }}) *
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> $lfun_proto) *
@@ -65,7 +65,7 @@ pred JSBIFunction (+l:Obj, fid:Str, len:Num) :
   ((#md, "@scope")      -> empty) *
   empty_fields(#md : -{ "@call", "@class", "@extensible", "@proto", "@scope" }-);
 
-pred BIFunctionObject (+l:Obj, len:Num, proto:Obj) :
+pred BIFunctionObject (l:Obj; len:Num, proto:Obj) :
   ((l, "length")     -> {{ "d", len, false, false, false }}) *
   ((l, "prototype")  -> {{ "d", proto, false, false, false }}) *
   MetaData(l, #md) * MetaData(#md, null) *
@@ -79,7 +79,7 @@ pred BIFunctionObject (+l:Obj, len:Num, proto:Obj) :
  **** BUILT-IN OBJECTS ****
  **************************)
 
-pred BooleanObject (+l:Obj, b:Bool) :
+pred BooleanObject (l:Obj; b:Bool) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> $lbool_proto) *
   ((#md, "@class")      -> "Boolean") *
@@ -87,7 +87,7 @@ pred BooleanObject (+l:Obj, b:Bool) :
   ((#md, "@primitiveValue") -> b) *
   empty_fields (#md : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred NumberObject (+l:Obj, n:Num) :
+pred NumberObject (l:Obj; n:Num) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> $lnum_proto) *
   ((#md, "@class")      -> "Number") *
@@ -95,7 +95,7 @@ pred NumberObject (+l:Obj, n:Num) :
   ((#md, "@primitiveValue") -> n) *
   empty_fields (#md : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred StringObject (+l:Obj, s:Str) :
+pred StringObject (l:Obj; s:Str) :
   DataPropConst(l, "length", #len, false) *
   (#len == s-len s) *
   MetaData(l, #md) * MetaData(#md, null) *
@@ -105,7 +105,7 @@ pred StringObject (+l:Obj, s:Str) :
   ((#md, "@primitiveValue") -> s) *
   empty_fields (#md : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred BooleanPrototype () :
+pred BooleanPrototype (;) :
   (($lbool_proto, "constructor") -> {{ "d", $lbool, true, false, true }}) *
   MetaData($lbool_proto, #bpmd) * MetaData(#bpmd, null) *
   ((#bpmd, "@proto")          -> $lobj_proto) *
@@ -114,7 +114,7 @@ pred BooleanPrototype () :
   ((#bpmd, "@primitiveValue") -> false) *
   empty_fields (#bpmd : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred NumberPrototype () :
+pred NumberPrototype (;) :
   (($lnum_proto, "constructor") -> {{ "d", $lnum, true, false, true }}) *
   MetaData($lnum_proto, #npmd) * MetaData(#npmd, null) *
   ((#npmd, "@proto")          -> $lobj_proto) *
@@ -123,24 +123,24 @@ pred NumberPrototype () :
   ((#npmd, "@primitiveValue") -> 0) *
   empty_fields (#npmd : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred GlobalObject () :
+pred GlobalObject (;) :
   JSObject ($lg) * (($lg, "Error") -> {{ "d", $lerr, true, false, true }}) *
     (($lg, "Object") -> {{ "d", $lobj, true, false, true }}) *
     (($lg, "undefined") -> {{ "d", undefined, false, false, false }});
 
-pred GlobalVar (+v, val) :
+pred GlobalVar (v; val) :
   (($lg, v) -> {{ "d", val, true, true, false }}) * types(v : Str);
 
-pred BI_ObjectObject () :
+pred BI_ObjectObject (;) :
   BIFunctionObject ($lobj, 0, $lobj_proto) *
   MetaData($lobj, #mlobj) * ((#mlobj, "@call") -> "Object_call") * ((#mlobj, "@construct") -> "Object_construct");
 
-pred ObjectPrototype () :
+pred ObjectPrototype (;) :
   JSObjWithProto ($lobj_proto, null) * empty_fields ($lobj_proto : -{ "hasOwnProperty" }-) *
   (($lobj_proto, "hasOwnProperty") -> {{ "d", $lop_hasOwnProperty, true, false, true }}) *
   JSBIFunction($lop_hasOwnProperty, "OP_hasOwnProperty", 1) * empty_fields($lop_hasOwnProperty : -{ "length" }-);
 
-pred FunctionPrototype () :
+pred FunctionPrototype (;) :
   JSObjGeneralWeak ($lfun_proto, $lobj_proto, "Function", true) *
   (($lfun_proto, "length") -> {{ "d", 0, false, false, false }}) *
   (($lfun_proto, "call")   -> {{ "d", $lfp_call, true, false, true }}) *
@@ -150,11 +150,11 @@ pred FunctionPrototype () :
   empty_fields(#mfp : -{ "@proto", "@class", "@extensible", "@scope", "@call" }-) *
   JSBIFunction($lfp_call, "FP_call", 1);
 
-pred BI_ErrorObject () :
+pred BI_ErrorObject (;) :
   BIFunctionObject ($lerr, 1, $lerr_proto) *
   MetaData($lerr, #mlerr) * ((#mlerr, "@call") -> "Error_call") * ((#mlerr, "@construct") -> "Error_construct");
 
-pred StringPrototype () :
+pred StringPrototype (;) :
   (($lstr_proto, "constructor") -> {{ "d", $lstr, true, false, true }}) *
   empty_fields ($lstr_proto : -{ "constructor" }-) *
   MetaData($lstr_proto, #spmd) * MetaData(#spmd, null) *
@@ -169,32 +169,32 @@ pred StringPrototype () :
  **** ERROR OBJECTS ****
  ***********************)
 
-pred ErrorObject (+l:Obj, pr:Obj) :
+pred ErrorObject (l:Obj; pr:Obj) :
   JSObjGeneral(l, pr, "Error", true);
 
-pred ErrorWithMessage (+l:Obj, m:Str) :
+pred ErrorWithMessage (l:Obj; m:Str) :
   MetaData(l, #md) *  MetaData(#md, null) *
   ((l, "message") -> {{"d", m, true, false, true}}) *
   ((#md, "@proto") -> $lerr_proto) * ((#md, "@class") -> "Error") * ((#md, "@extensible") -> true) *
   empty_fields(l : -{ "message" }-);
 
-pred TypeError(l:Obj) : ErrorObject (l, $lterr_proto);
+pred TypeError(l:Obj;) : ErrorObject (l, $lterr_proto);
 
-pred SyntaxError(l:Obj) : ErrorObject (l, $lserr_proto);
+pred SyntaxError(l:Obj;) : ErrorObject (l, $lserr_proto);
 
-pred ReferenceError(l:Obj) : ErrorObject (l, $lrferr_proto);
+pred ReferenceError(l:Obj;) : ErrorObject (l, $lrferr_proto);
 
-pred ErrorComplete (+l:Obj, pr:Obj) : ErrorObject (l, pr) * empty_fields(l : -{ }-);
+pred ErrorComplete (l:Obj; pr:Obj) : ErrorObject (l, pr) * empty_fields(l : -{ }-);
 
-pred TypeErrorComplete      (l:Obj) : TypeError      (l) * empty_fields(l : -{ }-);
-pred SyntaxErrorComplete    (l:Obj) : SyntaxError    (l) * empty_fields(l : -{ }-);
-pred ReferenceErrorComplete (l:Obj) : ReferenceError (l) * empty_fields(l : -{ }-);
+pred TypeErrorComplete      (l:Obj;) : TypeError      (l) * empty_fields(l : -{ }-);
+pred SyntaxErrorComplete    (l:Obj;) : SyntaxError    (l) * empty_fields(l : -{ }-);
+pred ReferenceErrorComplete (l:Obj;) : ReferenceError (l) * empty_fields(l : -{ }-);
 
 (************************
  ***** INITIAL HEAP *****
  ************************)
 
-pred initialHeapPost (globals) :
+pred initialHeapPost (globals;) :
     types(globals:Set) *
 
     GlobalObject() *
@@ -215,7 +215,7 @@ pred initialHeapPost (globals) :
     (($lerr_proto, "message") -> {{ "d", "", true, false, true }}) *
     empty_fields($lerr_proto : -{ "message" }-);
 
-pred initialHeapPostWeak ( ) :
+pred initialHeapPostWeak (;) :
 
     GlobalObject() *
 
@@ -243,15 +243,15 @@ pred initialHeapPostWeak ( ) :
  **** PROPERTIES ****
  ********************)
 
-pred DataProp (+l:Obj, +prop:Str, v) :
+pred DataProp (l:Obj, prop:Str; v) :
   ((l, prop) -> {{ "d", v, true, true, true }}) *
   (! (v == empty));
 
-pred DataPropGen (+l:Obj, +prop:Str, v, writ:Bool, enum:Bool, conf:Bool) :
+pred DataPropGen (l:Obj, prop:Str; v, writ:Bool, enum:Bool, conf:Bool) :
   ((l, prop) -> {{ "d", v, writ, enum, conf }}) *
   (! (v == empty));
 
-pred DataPropConst (+l:Obj, +prop:Str, v, enum:Bool) :
+pred DataPropConst (l:Obj, prop:Str; v, enum:Bool) :
   ((l, prop) -> {{ "d", v, false, enum, false }}) *
   (! (v == empty));
 
@@ -259,28 +259,28 @@ pred DataPropConst (+l:Obj, +prop:Str, v, enum:Bool) :
  **** ARRAYS ****
  ****************)
 
-pred ArrayObj(x : Obj) :
+pred ArrayObj(x : Obj;) :
   JSObjWithProto(x, $larr_proto) *
   DataProp(x, "length", #len) *
   ((x, "splice") -> none) *
   types(#len : Num);
 
-pred ArrayProto() :
+pred ArrayProto(;) :
   JSObject($larr_proto) *
   DataProp($larr_proto, "length", 0) *
   DataProp($larr_proto, "splice", #splice) *
   JSFunctionObject (#splice, "AP_splice", {{ }}, 0, #y);
 
-pred array_sequence(+length : Num, seq : Set) :
+pred array_sequence(length : Num; seq : Set) :
   (0 == length) * (seq == -{ }-),
   (0 <# length) * array_sequence((length - 1), #seq) * (seq == -u- (#seq, -{ num_to_string (length - 1) }-));
 
-pred JSArrayContents(+l:Obj, +length:Num, +current:Num, contents:List):
+pred JSArrayContents(l:Obj, length:Num, current:Num; contents:List):
   (current == length) * (contents == {{ }}),
   DataProp(l, num_to_string current, #first) * (contents == #first    :: #rest) * JSArrayContents(l, length, current + 1, #rest),
   ((l, num_to_string current) -> none)       * (contents == undefined :: #rest) * JSArrayContents(l, length, current + 1, #rest);
 
-pred JSArray (+l:Obj, length:Num, contents:List):
+pred JSArray (l:Obj; length:Num, contents:List):
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> $larr_proto) *
   ((#md, "@class")      -> "Array") *

--- a/Gillian-JS/runtime/JSLogic/internal_functions_full.jsil
+++ b/Gillian-JS/runtime/JSLogic/internal_functions_full.jsil
@@ -48,8 +48,8 @@ pred AccessorDescriptor (d;) :
  *
  *)
 pred Descriptor (d;) :
-    DataDescriptor (d),
-    AccessorDescriptor (d);
+    DataDescriptor (d;),
+    AccessorDescriptor (d;);
 
 (*
  * Predicate: GenericDescriptor
@@ -85,7 +85,7 @@ pred desc_conf (d, v;) :
     types (d : List) * v == l-nth(d, 4);
 
 (*
- * Predicate: Cell_o(l, prop, X)
+ * Predicate: Cell_o(l, prop, X;)
  *
  * Resource:
  *      (l, prop)
@@ -93,10 +93,10 @@ pred desc_conf (d, v;) :
  * Note: We are not allowing accessor descriptors in the heap yet
  *)
 pred Cell_o (l, prop, none;) :
-    types(l : Obj) * isNamedProperty(prop) * ((l, prop) -> none);
+    types(l : Obj) * isNamedProperty(prop;) * ((l, prop) -> none);
 
 pred Cell_o (l, prop, d;) :
-    types(l : Obj) * isNamedProperty(prop) * ((l, prop) -> d) * Descriptor(d);
+    types(l : Obj) * isNamedProperty(prop;) * ((l, prop) -> d) * Descriptor(d;);
 
 (*
  * Predicate: IsStringIndex - how do we deal with integers?
@@ -109,7 +109,7 @@ pred IsStringIndex(S, prop, i;) :
     (prop == num_to_string i) * (0 <=# i) * (i <# s-len S);
 
 (*
- * Predicate: Cell_s(l, prop, _, X, primitiveValue)
+ * Predicate: Cell_s(l, prop, _, X, primitiveValue;)
  *
  * Resource:
  *      (l, prop)               via Cell_o
@@ -121,23 +121,23 @@ pred IsStringIndex(S, prop, i;) :
  *)
 pred Cell_s (l, prop, "none", none, pv;) :
      types (l : Obj, prop : Str, pv : Str) *
-	 Cell_o (l, prop, none) * ((l, "@primitiveValue") -> pv) *
-     (#i == num_to_int (string_to_num prop)) * (! IsStringIndex(pv, prop, #i));
+	 Cell_o (l, prop, none;) * ((l, "@primitiveValue") -> pv) *
+     (#i == num_to_int (string_to_num prop)) * (! IsStringIndex(pv, prop, #i;));
 
 pred Cell_s (l, prop, "SI", desc, pv;) :
      types(l : Obj, #prop : Str, desc : List, pv : Str, #i : Num, #v : Str) *
-	 (prop == #prop) * Cell_o (l, #prop, none) * ((l, "@primitiveValue") -> pv) *
+	 (prop == #prop) * Cell_o (l, #prop, none;) * ((l, "@primitiveValue") -> pv) *
      (desc == {{ "d", #v, false, true, false }}) *  (#v == s-nth(pv, #i)) *
-	 (#i == num_to_int (string_to_num #prop)) * IsStringIndex(pv, #prop, #i);
+	 (#i == num_to_int (string_to_num #prop)) * IsStringIndex(pv, #prop, #i;);
 
 pred Cell_s (l, prop, "NSI", desc, pv;) :
 	 types (l : Obj, prop : Str, desc : List, pv : Str, #i : Num) *
-	 Cell_o (l, prop, desc) * ((l, "@primitiveValue") -> pv) *
-	 (#i == num_to_int (string_to_num prop)) * (! IsStringIndex(pv, prop, #i)) *
+	 Cell_o (l, prop, desc;) * ((l, "@primitiveValue") -> pv) *
+	 (#i == num_to_int (string_to_num prop)) * (! IsStringIndex(pv, prop, #i;)) *
      (! (desc == none));
 
 (*
- * Predicate: ErrorObject(l, pr)
+ * Predicate: ErrorObject(l, pr;)
  *
  * Resource:
  *      (l, "@proto")	(l, "@class")	(l, "@extensible")
@@ -149,16 +149,16 @@ pred ErrorObject (l, pr;) :
 	((l, "@proto") -> pr) * ((l, "@class") -> "Error") * ((l, "@extensible") -> true) * empty_fields(l : "@proto", "@class", "@extensible");
 
 pred isTypeError(l;) :
-    ErrorObject (l, $lterr_proto);
+    ErrorObject (l, $lterr_proto;);
 
 pred isSyntaxError(l;) :
-    ErrorObject (l, $lserr_proto);
+    ErrorObject (l, $lserr_proto;);
 
 pred isReferenceError(l;) :
-    ErrorObject (l, $lrferr_proto);
+    ErrorObject (l, $lrferr_proto;);
 
 (*
- * Predicate: isClass(c, X)
+ * Predicate: isClass(c, X;)
  *
  * Resource:
  *      (l, "@class")
@@ -181,7 +181,7 @@ pred isClass (c, "Non-Array";)  : types (c : Str) * (! (c == "Array"));
 pred Pi (l, prop, lcls, undefined, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, ls : List, ltf : List, lpv : List) *
 	((l, "@proto") -> null) * ((l, "@class") -> #cls) *
-	isClass (#cls, "Non-String") * Cell_o (l, prop, none) *
+	isClass (#cls, "Non-String";) * Cell_o (l, prop, none;) *
     (lcls == {{ #cls }}) * (ls == {{ l }}) * (ltf == {{ false }}) * (lpv == {{ "" }});
 
 (*
@@ -192,7 +192,7 @@ pred Pi (l, prop, lcls, undefined, ls, ltf, lpv;) :
 pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, d : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) *
-	isClass (#cls, "Non-String") * Cell_o (l, prop, d) * (! (d == none)) *
+	isClass (#cls, "Non-String";) * Cell_o (l, prop, d;) * (! (d == none)) *
     (lcls == {{ #cls }}) * (ls == {{ l }}) * (ltf == {{ false }}) * (lpv == {{ "" }});
 
 (*
@@ -206,9 +206,9 @@ pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
 pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, lcls : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) * ((l, "@proto") -> #lp) *
-	isClass (#cls, "Non-String") * Cell_o (l, prop, none) *
+	isClass (#cls, "Non-String";) * Cell_o (l, prop, none;) *
 	types(#lcls : List, #lls : List, #ltf  : List, #lpv : List) *
-    Pi (#lp, prop, #lcls, d, #lls, #ltf, #lpv) *
+    Pi (#lp, prop, #lcls, d, #lls, #ltf, #lpv;) *
 	types(#pcls : Str,  #ocls : List,
 	        #lp : Obj,  #ols  : List,
 		   #ptf : Bool, #otf  : List,
@@ -224,7 +224,7 @@ pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
 pred Pi (l, prop, lcls, undefined, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, ls : List, ltf : List, lpv : List) *
 	((l, "@proto") -> null) * ((l, "@class") -> #cls) *
-    isClass (#cls, "String") * Cell_s (l, prop, "none", none, #pv) *
+    isClass (#cls, "String";) * Cell_s (l, prop, "none", none, #pv;) *
     (lcls == {{ #cls }}) * (ls == {{ l }}) * (ltf == {{ true }}) * (lpv == {{ #pv }});
 
 (*
@@ -235,7 +235,7 @@ pred Pi (l, prop, lcls, undefined, ls, ltf, lpv;) :
 pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, d : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) *
-	isClass (#cls, "String") * Cell_s (l, prop, "SI", d, #pv) *
+	isClass (#cls, "String";) * Cell_s (l, prop, "SI", d, #pv;) *
 	(lcls == {{ #cls }}) * (ls == {{ l }}) * (ltf == {{ true }}) * (lpv == {{ #pv }});
 
 (*
@@ -246,7 +246,7 @@ pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
 pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, d : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) *
-	isClass (#cls, "String") * Cell_s (l, prop, "NSI", d, #pv) *
+	isClass (#cls, "String";) * Cell_s (l, prop, "NSI", d, #pv;) *
     (lcls == {{ #cls }}) * (ls == {{ l }}) * (ltf == {{ true }}) * (lpv == {{ #pv }});
 
 (*
@@ -259,9 +259,9 @@ pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
 pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, lcls : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) * ((l, "@proto") -> #lp) *
-	isClass (#cls, "String") * Cell_s (l, prop, "none", none, #pv) *
+	isClass (#cls, "String";) * Cell_s (l, prop, "none", none, #pv;) *
 	types(#lcls : List, #lls : List, #ltf  : List, #lpv : List) *
-    Pi (#lp, prop, #lcls, d, #lls, #ltf, #lpv) *
+    Pi (#lp, prop, #lcls, d, #lls, #ltf, #lpv;) *
 	types(#pcls : Str,  #ocls : List,
 	        #lp : Obj,  #ols  : List,
 		   #ptf : Bool, #otf  : List,
@@ -378,7 +378,7 @@ spec create_function_object (xsc, call, construct, params)
     [[ (xsc == #xsc) * (call == #call) * (construct == #construct) * (params == #params) *
 	   types(#xsc : List, #call : Str, #construct: Str, #params : List) ]]
     [[ types(#l : Obj, #xsc : List, #call : Str, #construct: Str, #params : List, #len : Num, ret : Obj) *
-	   function_object(ret, #xsc, #call, #construct, #len, prototype) * (#len == l-len #params) *
+	   function_object(ret, #xsc, #call, #construct, #len, prototype;) * (#len == l-len #params) *
 	   ((prototype, "@proto") -> $lobj_proto) * ((prototype, "@class") -> "Object") * ((prototype, "@extensible") -> true) *
 	   ((prototype, "constructor") -> {{ "d", ret, true, false, true }} ) *
 	   empty_fields(prototype : "@proto", "@class", "@extensible", "constructor") ]]
@@ -502,7 +502,7 @@ proc i__toBoolean (v) {
 spec TypeError_call (xsc, vthis, v)
 
     [[ (v == undefined) ]]
-    [[ isTypeError(ret) ]]
+    [[ isTypeError(ret;) ]]
     normal
 
 proc TypeError_call (xsc, vthis, v) {
@@ -518,7 +518,7 @@ proc TypeError_call (xsc, vthis, v) {
 spec TypeError (v)
 
     [[ (v == undefined) ]]
-    [[ isTypeError(ret) ]]
+    [[ isTypeError(ret;) ]]
     normal
 
 proc TypeError (v) {
@@ -535,7 +535,7 @@ proc TypeError (v) {
 spec ReferenceError_call (xsc, vthis, v)
 
     [[ (v == undefined) ]]
-    [[ isReferenceError(ret) ]]
+    [[ isReferenceError(ret;) ]]
     normal
 
 proc ReferenceError_call (xsc, vthis, v) {
@@ -551,7 +551,7 @@ proc ReferenceError_call (xsc, vthis, v) {
 spec ReferenceError (v)
 
     [[ (v == undefined) ]]
-    [[ isReferenceError(ret) ]]
+    [[ isReferenceError(ret;) ]]
     normal
 
 proc ReferenceError (v) {
@@ -568,7 +568,7 @@ proc ReferenceError (v) {
 spec SyntaxError_call (xsc, vthis, v)
 
     [[ (v == undefined) ]]
-    [[ isSyntaxError(ret) ]]
+    [[ isSyntaxError(ret;) ]]
     normal
 
 proc SyntaxError_call (xsc, vthis, v) {
@@ -584,7 +584,7 @@ proc SyntaxError_call (xsc, vthis, v) {
 spec SyntaxError (v)
 
     [[ (v == undefined) ]]
-    [[ isSyntaxError(ret) ]]
+    [[ isSyntaxError(ret;) ]]
     normal
 
 proc SyntaxError (v) {
@@ -617,8 +617,8 @@ pred initialHeapPost (;) :
 
 spec setupInitialHeap ()
 
-	[[ initialHeapPre() ]]
-	[[ initialHeapPost() * (ret == empty) ]]
+	[[ initialHeapPre(;) ]]
+	[[ initialHeapPost(;) * (ret == empty) ]]
 	normal
 
 proc setupInitialHeap () {
@@ -1043,27 +1043,27 @@ spec i__isDataDescriptor (desc)
     normal;
 
     (* Data descriptor *)
-    [[ DataDescriptor(desc) ]]
+    [[ DataDescriptor(desc;) ]]
     [[ ret == true ]]
     normal;
 
     (* Accessor descriptor *)
-    [[ AccessorDescriptor(desc) ]]
+    [[ AccessorDescriptor(desc;) ]]
     [[ ret == false ]]
     normal;
 
     (* Generic descriptor, no data descriptor components *)
-    [[ GenericDescriptor(desc) * (l-nth (desc, 3) == empty) * (l-nth (desc, 4) == empty) ]]
+    [[ GenericDescriptor(desc;) * (l-nth (desc, 3) == empty) * (l-nth (desc, 4) == empty) ]]
     [[ ret == false ]]
     normal;
 
     (* Generic descriptor, with value *)
-    [[ GenericDescriptor(desc) * (! l-nth (desc, 3) == empty) ]]
+    [[ GenericDescriptor(desc;) * (! l-nth (desc, 3) == empty) ]]
     [[ ret == true ]]
     normal;
 
     (* Generic descriptor, with writable *)
-    [[ GenericDescriptor(desc) * (! l-nth (desc, 4) == empty) ]]
+    [[ GenericDescriptor(desc;) * (! l-nth (desc, 4) == empty) ]]
     [[ ret == true ]]
     normal
 
@@ -1093,27 +1093,27 @@ spec i__isAccessorDescriptor (desc)
     normal;
 
     (* Data descriptor *)
-    [[ DataDescriptor(desc) ]]
+    [[ DataDescriptor(desc;) ]]
     [[ ret == false ]]
     normal;
 
     (* Data descriptor *)
-    [[ AccessorDescriptor(desc) ]]
+    [[ AccessorDescriptor(desc;) ]]
     [[ ret == true ]]
     normal;
 
     (* Generic descriptor, no data descriptor components *)
-    [[ GenericDescriptor(desc) * (l-nth (desc, 5) == empty) * (l-nth (desc, 6) == empty) ]]
+    [[ GenericDescriptor(desc;) * (l-nth (desc, 5) == empty) * (l-nth (desc, 6) == empty) ]]
     [[ ret == false ]]
     normal;
 
     (* Generic descriptor, with get *)
-    [[ GenericDescriptor(desc) * (! l-nth (desc, 5) == empty) ]]
+    [[ GenericDescriptor(desc;) * (! l-nth (desc, 5) == empty) ]]
     [[ ret == true ]]
     normal;
 
     (* Generic descriptor, with set *)
-    [[ GenericDescriptor(desc) * (! l-nth (desc, 6) == empty) ]]
+    [[ GenericDescriptor(desc;) * (! l-nth (desc, 6) == empty) ]]
     [[ ret == true ]]
     normal
 
@@ -1143,39 +1143,39 @@ spec i__isGenericDescriptor (desc)
     normal;
 
 	(* Data descriptor *)
-	[[ DataDescriptor(desc) ]]
+	[[ DataDescriptor(desc;) ]]
 	[[ ret == false ]]
 	normal;
 
 	(* Accessor descriptor *)
-	[[ AccessorDescriptor(desc) ]]
+	[[ AccessorDescriptor(desc;) ]]
 	[[ ret == false ]]
 	normal;
 
 	(* Generic descriptor, no data descriptor components *)
-	[[ GenericDescriptor(desc) *
+	[[ GenericDescriptor(desc;) *
 	   (l-nth (desc, 3) == empty) * (l-nth (desc, 4) == empty) *
 	   (l-nth (desc, 5) == empty) * (l-nth (desc, 6) == empty) ]]
 	[[ ret == true ]]
 	normal;
 
 	(* Generic descriptor, with value *)
-	[[ GenericDescriptor(desc) * (! (l-nth (desc, 3) == empty)) ]]
+	[[ GenericDescriptor(desc;) * (! (l-nth (desc, 3) == empty)) ]]
 	[[ ret == false ]]
 	normal;
 
 	(* Generic descriptor, with writable *)
-	[[ GenericDescriptor(desc) * (! (l-nth (desc, 4) == empty)) ]]
+	[[ GenericDescriptor(desc;) * (! (l-nth (desc, 4) == empty)) ]]
 	[[ ret == false ]]
 	normal;
 
 	(* Generic descriptor, with get *)
-	[[ GenericDescriptor(desc) * (! (l-nth (desc, 5) == empty)) ]]
+	[[ GenericDescriptor(desc;) * (! (l-nth (desc, 5) == empty)) ]]
 	[[ ret == false ]]
 	normal;
 
 	(* Generic descriptor, with get *)
-	[[ GenericDescriptor(desc) * (! (l-nth (desc, 6) == empty)) ]]
+	[[ GenericDescriptor(desc;) * (! (l-nth (desc, 6) == empty)) ]]
 	[[ ret == false ]]
 	normal
 
@@ -1197,7 +1197,7 @@ proc i__isGenericDescriptor (desc) {
 
 spec i__toDataDescriptor (desc)
 
-    [[ (desc == #desc) * DataDescriptor (#desc) ]]
+    [[ (desc == #desc) * DataDescriptor (#desc;) ]]
     [[ (ret == #desc) ]]
     normal
 
@@ -1237,7 +1237,7 @@ proc i__toDataDescriptor (desc) {
 
 spec i__toAccessorDescriptor (desc)
 
-    [[ (desc == #desc) * AccessorDescriptor (#desc) ]]
+    [[ (desc == #desc) * AccessorDescriptor (#desc;) ]]
     [[ (ret == #desc) ]]
     normal
 
@@ -1379,11 +1379,11 @@ spec i__checkAssignmentErrors (v)
     normal;
 
     [[ (v == #v) * types (#v : List, #l : Obj) * (#v == {{ "v", #l, "eval" }}) ]]
-    [[ isSyntaxError(ret) ]]
+    [[ isSyntaxError(ret;) ]]
     error;
 
     [[ (v == #v) * types (#v : List, #l : Obj) * (#v == {{ "v", #l, "arguments" }}) ]]
-    [[ isSyntaxError(ret) ]]
+    [[ isSyntaxError(ret;) ]]
     error;
 
     [[ (v == #v) * types (#v : List, #base : Obj, #field : Str) * (#v == {{ "o", #base, #field }}) ]]
@@ -1412,11 +1412,11 @@ proc i__checkAssignmentErrors (v) {
 spec i__checkObjectCoercible (v)
 
 	[[ v == undefined ]]
-	[[ isTypeError(ret) ]]
+	[[ isTypeError(ret;) ]]
 	normal;
 
 	[[ v == null ]]
-	[[ isTypeError(ret) ]]
+	[[ isTypeError(ret;) ]]
 	normal;
 
 	[[ types (v : Num) ]]
@@ -1524,14 +1524,14 @@ spec o__getOwnProperty (l, prop)
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str) *
-	   Cell_o (#l, #prop, none) ]]
-    [[ Cell_o (#l, #prop, none) * (ret == undefined) ]]
+	   Cell_o (#l, #prop, none;) ]]
+    [[ Cell_o (#l, #prop, none;) * (ret == undefined) ]]
     normal;
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #dx : List) *
-	   Cell_o (#l, #prop, #dx) ]]
-    [[ Cell_o (#l, #prop, #dx) * (ret == #dx) ]]
+	   Cell_o (#l, #prop, #dx;) ]]
+    [[ Cell_o (#l, #prop, #dx;) * (ret == #dx) ]]
     normal
 
 proc o__getOwnProperty (l, prop) {
@@ -1565,20 +1565,20 @@ proc o__getOwnProperty (l, prop) {
 spec s__getOwnProperty (l, prop)
 
     [[ (l == #l) * (prop == #prop) *
-	   Cell_s (#l, #prop, "none", none, #pv) ]]
-    [[ Cell_s (#l, #prop, "none", none, #pv) *
+	   Cell_s (#l, #prop, "none", none, #pv;) ]]
+    [[ Cell_s (#l, #prop, "none", none, #pv;) *
 	   (ret == undefined) ]]
    	normal;
 
    	[[ (l == #l) * (prop == #prop) *
-	   Cell_s (#l, #prop, "SI", #u, #pv) ]]
-   	[[ Cell_s (#l, #prop, "SI", #u, #pv) *
+	   Cell_s (#l, #prop, "SI", #u, #pv;) ]]
+   	[[ Cell_s (#l, #prop, "SI", #u, #pv;) *
 	   (ret == #u) ]]
    	normal;
 
    	[[ (l == #l) * (prop == #prop) *
-	   Cell_s (#l, #prop, "NSI", #u, #pv) ]]
-   	[[ Cell_s (#l, #prop, "NSI", #u, #pv) *
+	   Cell_s (#l, #prop, "NSI", #u, #pv;) ]]
+   	[[ Cell_s (#l, #prop, "NSI", #u, #pv;) *
 	   (ret == #u) ]]
    	normal
 
@@ -1627,36 +1627,36 @@ spec getOwnProperty (l, prop)
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : Str) *
-	   Cell_o (#l, #prop, none) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
-    [[ Cell_o (#l, #prop, none) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String") *
+	   Cell_o (#l, #prop, none;) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+    [[ Cell_o (#l, #prop, none;) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String";) *
 	   (ret == undefined) ]]
     normal;
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #dx : List) *
-	   Cell_o (#l, #prop, #dx) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
-    [[ Cell_o (#l, #prop, #dx) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String") *
+	   Cell_o (#l, #prop, #dx;) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+    [[ Cell_o (#l, #prop, #dx;) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String";) *
 	   (ret == #dx) ]]
     normal;
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : Str) *
-	   Cell_s (#l, #prop, "none", none, #pv) * ((#l, "@class") -> #cls) * isClass(#cls, "String") ]]
-    [[ Cell_s (#l, #prop, "none", none, #pv) * ((#l, "@class") -> #cls) * isClass(#cls, "String") *
+	   Cell_s (#l, #prop, "none", none, #pv;) * ((#l, "@class") -> #cls) * isClass(#cls, "String";) ]]
+    [[ Cell_s (#l, #prop, "none", none, #pv;) * ((#l, "@class") -> #cls) * isClass(#cls, "String";) *
 	   (ret == undefined) ]]
    	normal;
 
    	[[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #u : List) *
-	   Cell_s (#l, #prop, "SI", #u, #pv) * ((#l, "@class") -> #cls) * isClass(#cls, "String") ]]
-   	[[ Cell_s (#l, #prop, "SI", #u, #pv) * ((#l, "@class") -> #cls) * isClass(#cls, "String") *
+	   Cell_s (#l, #prop, "SI", #u, #pv;) * ((#l, "@class") -> #cls) * isClass(#cls, "String";) ]]
+   	[[ Cell_s (#l, #prop, "SI", #u, #pv;) * ((#l, "@class") -> #cls) * isClass(#cls, "String";) *
 	   (ret == #u) ]]
    	normal;
 
    	[[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #u : List) *
-	   Cell_s (#l, #prop, "NSI", #u, #pv) * ((#l, "@class") -> #cls) * isClass(#cls, "String") ]]
-   	[[ Cell_s (#l, #prop, "NSI", #u, #pv) * ((#l, "@class") -> #cls) * isClass(#cls, "String") *
+	   Cell_s (#l, #prop, "NSI", #u, #pv;) * ((#l, "@class") -> #cls) * isClass(#cls, "String";) ]]
+   	[[ Cell_s (#l, #prop, "NSI", #u, #pv;) * ((#l, "@class") -> #cls) * isClass(#cls, "String";) *
 	   (ret == #u) ]]
    	normal
 
@@ -1692,8 +1692,8 @@ spec getProperty (l, prop)
 
 	[[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str) *
-	   Pi (#l, #prop, #gp_aux_0, #gp_aux_1, #gp_aux_2, #gp_aux_3, #gp_aux_4) ]]
-	[[ Pi (#l, #prop, #gp_aux_0, #gp_aux_1, #gp_aux_2, #gp_aux_3, #gp_aux_4) * (ret == #gp_aux_1) ]]
+	   Pi (#l, #prop, #gp_aux_0, #gp_aux_1, #gp_aux_2, #gp_aux_3, #gp_aux_4;) ]]
+	[[ Pi (#l, #prop, #gp_aux_0, #gp_aux_1, #gp_aux_2, #gp_aux_3, #gp_aux_4;) * (ret == #gp_aux_1) ]]
 	normal
 
 proc getProperty (l, prop) {
@@ -1734,14 +1734,14 @@ spec get (l, prop)
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str) *
-	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * DataDescriptor (#g_aux_1) ]]
-    [[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * desc_val (#g_aux_1, #desc_val) * (ret == #desc_val) ]]
+	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * DataDescriptor (#g_aux_1;) ]]
+    [[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * desc_val (#g_aux_1, #desc_val;) * (ret == #desc_val) ]]
     normal;
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str) *
-	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * (#g_aux_1 == undefined) ]]
-    [[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * (#g_aux_1 == undefined) * (ret == undefined) ]]
+	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * (#g_aux_1 == undefined) ]]
+    [[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * (#g_aux_1 == undefined) * (ret == undefined) ]]
     normal
 
 proc get (l, prop) {
@@ -1795,29 +1795,29 @@ proc get (l, prop) {
 
 spec i__getValue (v)
 
-    [[ (v == {{ "o", #obj, #field }}) * types (#obj : Obj, #field : Str) * isNamedProperty(#field) *
-       Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * DataDescriptor (#g_aux_1)  ]]
-    [[ Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * desc_val (#g_aux_1, #desc_val) * (ret == #desc_val) ]]
+    [[ (v == {{ "o", #obj, #field }}) * types (#obj : Obj, #field : Str) * isNamedProperty(#field;) *
+       Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * DataDescriptor (#g_aux_1;)  ]]
+    [[ Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * desc_val (#g_aux_1, #desc_val;) * (ret == #desc_val) ]]
     normal;
 
-    [[ (v == {{ "v", #obj, #field }}) * (! (#obj == $lg)) * ((#obj, #field) -> #value) * isNamedProperty(#field) *
+    [[ (v == {{ "v", #obj, #field }}) * (! (#obj == $lg)) * ((#obj, #field) -> #value) * isNamedProperty(#field;) *
        types (#obj : Obj, #field : Str) ]]
     [[ ((#obj, #field) -> #value) * (ret == #value) ]]
     normal;
 
-    [[ (v == {{ "v", $lg, #field }}) * types (#field : Str) * isNamedProperty(#field) *
-       Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * DataDescriptor (#g_aux_1)  ]]
-    [[ Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * desc_val (#g_aux_1, #desc_val) * (ret == #desc_val) ]]
+    [[ (v == {{ "v", $lg, #field }}) * types (#field : Str) * isNamedProperty(#field;) *
+       Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * DataDescriptor (#g_aux_1;)  ]]
+    [[ Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * desc_val (#g_aux_1, #desc_val;) * (ret == #desc_val) ]]
     normal;
 
-    [[ (v == {{ "o", #obj, #field }}) * types (#obj : Obj, #field : Str) * isNamedProperty(#field) *
-       Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * (#g_aux_1 == undefined) ]]
-    [[ Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * (ret == undefined) ]]
+    [[ (v == {{ "o", #obj, #field }}) * types (#obj : Obj, #field : Str) * isNamedProperty(#field;) *
+       Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * (#g_aux_1 == undefined) ]]
+    [[ Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * (ret == undefined) ]]
     normal;
 
-    [[ (v == {{ "v", $lg, #field }}) * types (#field : Str) * isNamedProperty(#field) *
-       Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * (#g_aux_1 == undefined) ]]
-    [[ Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * (ret == undefined) ]]
+    [[ (v == {{ "v", $lg, #field }}) * types (#field : Str) * isNamedProperty(#field;) *
+       Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * (#g_aux_1 == undefined) ]]
+    [[ Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * (ret == undefined) ]]
     normal;
 
     [[ v == null ]]
@@ -1844,12 +1844,12 @@ spec i__getValue (v)
     [[ ret == undefined ]]
     normal;
 
-	[[ (v == {{ "o", undefined, #field }}) * types (#field : Str) * isNamedProperty(#field) ]]
-    [[ isReferenceError(ret) ]]
+	[[ (v == {{ "o", undefined, #field }}) * types (#field : Str) * isNamedProperty(#field;) ]]
+    [[ isReferenceError(ret;) ]]
     error;
 
-	[[ (v == {{ "v", undefined, #field }}) * types (#field : Str) * isNamedProperty(#field) ]]
-    [[ isReferenceError(ret) ]]
+	[[ (v == {{ "v", undefined, #field }}) * types (#field : Str) * isNamedProperty(#field;) ]]
+    [[ isReferenceError(ret;) ]]
     error
 
 proc i__getValue (v) {
@@ -1919,14 +1919,14 @@ spec hasProperty (l, prop)
 
 	[[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : List) *
-	   Pi (#l, #prop, #cls, undefined, #gp_aux_2, #gp_aux_3, #gp_aux_4) ]]
-	[[ Pi (#l, #prop, #cls, undefined, #gp_aux_2, #gp_aux_3, #gp_aux_4) * (ret == false) ]]
+	   Pi (#l, #prop, #cls, undefined, #gp_aux_2, #gp_aux_3, #gp_aux_4;) ]]
+	[[ Pi (#l, #prop, #cls, undefined, #gp_aux_2, #gp_aux_3, #gp_aux_4;) * (ret == false) ]]
 	normal;
 
 	[[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : List, #desc : List) *
-	   Pi (#l, #prop, #cls, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4) ]]
-	[[ Pi (#l, #prop, #cls, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4) * (ret == true) ]]
+	   Pi (#l, #prop, #cls, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4;) ]]
+	[[ Pi (#l, #prop, #cls, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4;) * (ret == true) ]]
 	normal
 
 proc hasProperty (l, prop) {
@@ -1957,32 +1957,32 @@ spec deleteProperty (l, prop, thrw)
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #clsx : List) *
-	   Pi (#l, #prop, #clsx, undefined, {{ #l }}, #gp_aux_3, #gp_aux_4) ]]
-	[[ Pi (#l, #prop, #clsx, undefined, #gp_aux_2, #gp_aux_3, #gp_aux_4) * (ret == true) ]]
+	   Pi (#l, #prop, #clsx, undefined, {{ #l }}, #gp_aux_3, #gp_aux_4;) ]]
+	[[ Pi (#l, #prop, #clsx, undefined, #gp_aux_2, #gp_aux_3, #gp_aux_4;) * (ret == true) ]]
 	normal;
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #clsx : List) *
-	   Pi (#l, #prop, #clsx, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4) * (#gp_aux_2 == #l :: #lp :: #rest) * types (#lp : Obj, #rest : List) ]]
-	[[ Pi (#l, #prop, #clsx, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4) * (ret == true) ]]
+	   Pi (#l, #prop, #clsx, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4;) * (#gp_aux_2 == #l :: #lp :: #rest) * types (#lp : Obj, #rest : List) ]]
+	[[ Pi (#l, #prop, #clsx, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4;) * (ret == true) ]]
 	normal;
 
 	[[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #clsx : List, #desc : List) *
-	   Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4) * desc_conf(#desc, true) ]]
-	[[ Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4) * (ret == true) ]]
+	   Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4;) * desc_conf(#desc, true;) ]]
+	[[ Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4;) * (ret == true) ]]
 	normal;
 
 	[[ (l == #l) * (prop == #prop) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #clsx : List, #desc : List) *
-	   Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4) * desc_conf(#desc, false) ]]
-	[[ Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4) * (ret == false) ]]
+	   Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4;) * desc_conf(#desc, false;) ]]
+	[[ Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4;) * (ret == false) ]]
 	normal;
 
 	[[ (l == #l) * (prop == #prop) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #clsx : List, #desc : List) *
-	   Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4) * desc_conf(#desc, false) ]]
-	[[ Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4) * isTypeError(ret) ]]
+	   Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4;) * desc_conf(#desc, false;) ]]
+	[[ Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4;) * isTypeError(ret;) ]]
 	error
 
 proc deleteProperty (l, prop, thrw) {
@@ -2017,9 +2017,9 @@ spec canPut (l, prop)
     (* 01 - Property not defined at all, rtrning "@extensible" *)
     [[ (l == #l) * (prop == #prop) *
 	   types(#ext : Bool) *
-	   Pi (#l, #prop, #g_aux_0, undefined, #g_aux_2, #g_aux_3, #g_aux_4) *
+	   Pi (#l, #prop, #g_aux_0, undefined, #g_aux_2, #g_aux_3, #g_aux_4;) *
        ((#l, "@extensible") -> #ext) ]]
-    [[ Pi (#l, #prop, #g_aux_0, undefined, #g_aux_2, #g_aux_3, #g_aux_4) *
+    [[ Pi (#l, #prop, #g_aux_0, undefined, #g_aux_2, #g_aux_3, #g_aux_4;) *
        ((#l, "@extensible") -> #ext) *
 	   (ret == #ext) ]]
     normal;
@@ -2027,35 +2027,35 @@ spec canPut (l, prop)
 	(* 02 - Property defined in the object itself, data descriptor, rtrning writable *)
 	[[ (l == #l) * (prop == #prop) *
 	   types(#writ : Bool) *
-	   Pi (#l, #prop, #g_aux_0, #g_aux_1, {{ #l }}, #g_aux_3, #g_aux_4) * DataDescriptor(#g_aux_1) * desc_writ(#g_aux_1, #writ) ]]
-	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, {{ #l }}, #g_aux_3, #g_aux_4) *
+	   Pi (#l, #prop, #g_aux_0, #g_aux_1, {{ #l }}, #g_aux_3, #g_aux_4;) * DataDescriptor(#g_aux_1;) * desc_writ(#g_aux_1, #writ;) ]]
+	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, {{ #l }}, #g_aux_3, #g_aux_4;) *
 	   (ret == #writ) ]]
 	normal;
 
 	(* 03 - Property defined as a data descriptor outside, but object not extensible, rtrn false *)
 	[[ (l == #l) * (prop == #prop) *
 	   types (#g_aux_2 : List, #l : Obj, #lp : Obj, #other : List) *
-       Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) *
-		   DataDescriptor(#g_aux_1) * (#g_aux_2 == (#l :: #lp :: #other)) * ((#l, "@extensible") -> false) ]]
-	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) *
+       Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) *
+		   DataDescriptor(#g_aux_1;) * (#g_aux_2 == (#l :: #lp :: #other)) * ((#l, "@extensible") -> false) ]]
+	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) *
 	   ((#l, "@extensible") -> false) * (ret == false) ]]
 	normal;
 
 	(* 04 - Property defined as a data descriptor outside, object extensible, rtrn writable *)
 	[[ (l == #l) * (prop == #prop) *
 	   types (#g_aux_2 : List, #l : Obj, #lp : Obj, #other : List, #writ : Bool) *
-	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) *
-	   DataDescriptor(#g_aux_1) * desc_writ(#g_aux_1, #writ) * (#g_aux_2 == (#l :: #lp :: #other)) *
+	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) *
+	   DataDescriptor(#g_aux_1;) * desc_writ(#g_aux_1, #writ;) * (#g_aux_2 == (#l :: #lp :: #other)) *
 	   ((#l, "@extensible") -> true) ]]
-	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) *
+	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) *
 	   ((#l, "@extensible") -> true) * (ret == #writ) ]]
 	normal;
 
 	(* 05 - Property defined as an accessor descriptor, rtrn (setter <> undefined) *)
 	[[ (l == #l) * (prop == #prop) *
-	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) *
-	   AccessorDescriptor(#g_aux_1) * desc_set(#g_aux_1, #set) ]]
-	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) *
+	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) *
+	   AccessorDescriptor(#g_aux_1;) * desc_set(#g_aux_1, #set;) ]]
+	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) *
 	   (ret == (not (#set = undefined))) ]]
 	normal
 
@@ -2120,21 +2120,21 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, none) * ((#l, "@extensible") -> false) *
-	   isTypeError(err) ]]
+	   Cell_o (#l, #prop, none;) * ((#l, "@extensible") -> false) *
+	   isTypeError(err;) ]]
     error;
 
     (* 02 - Current is undefined, object is not extensible, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, none) * ((#l, "@extensible") -> false) *
+	   Cell_o (#l, #prop, none;) * ((#l, "@extensible") -> false) *
 	   (ret == false) ]]
     normal;
 
@@ -2142,21 +2142,21 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv) *
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "none", none, #pv) * ((#l, "@extensible") -> false) *
-	   isTypeError(err) ]]
+	   Cell_s (#l, #prop, "none", none, #pv;) * ((#l, "@extensible") -> false) *
+	   isTypeError(err;) ]]
     error;
 
     (* 04 - Current is undefined, object is not extensible, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv) *
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "none", none, #pv) * ((#l, "@extensible") -> false) *
+	   Cell_s (#l, #prop, "none", none, #pv;) * ((#l, "@extensible") -> false) *
 	   (ret == false) ]]
     normal;
 
@@ -2164,11 +2164,11 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
-	   DataDescriptor (#desc) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
+	   DataDescriptor (#desc;) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> true) *
+	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
@@ -2176,11 +2176,11 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
-	   AccessorDescriptor (#desc) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
+	   AccessorDescriptor (#desc;) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> true) *
+	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
@@ -2188,11 +2188,11 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv) *
-	   DataDescriptor (#desc) *
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;) *
+	   DataDescriptor (#desc;) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> true) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
@@ -2200,59 +2200,59 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv)  *
-	   AccessorDescriptor (#desc) *
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;)  *
+	   AccessorDescriptor (#desc;) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> true) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
 	(* 09 - Current is defined, configurable is true, data descriptor, non-string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       DataDescriptor(#desc) * desc_conf(#dcur, true) *
+       DataDescriptor(#desc;) * desc_conf(#dcur, true;) *
        ((#l, "@class") -> #cls) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> #ext) *
+	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
 	(* 10 - Current is defined, configurable is true, accessor descriptor, non-string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       AccessorDescriptor(#desc) * desc_conf(#dcur, true) *
+       AccessorDescriptor(#desc;) * desc_conf(#dcur, true;) *
        ((#l, "@class") -> #cls) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> #ext) *
+	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
 	(* 11 - Current is defined, configurable is true, data descriptor, string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       DataDescriptor(#desc) * desc_conf(#dcur, true) *
+       DataDescriptor(#desc;) * desc_conf(#dcur, true;) *
        ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> #ext) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
 	(* 12 - Current is defined, configurable is true, accessor descriptor, string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       AccessorDescriptor(#desc) * desc_conf(#dcur, true) *
+       AccessorDescriptor(#desc;) * desc_conf(#dcur, true;) *
        ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> #ext) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
@@ -2260,11 +2260,11 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
        (#desc == {{ "g", empty, empty, #gval, empty, empty, empty }}) * (! (#gval == empty)) *
-	   DataDescriptor(#dcur) * desc_writ(#dcur, true) * desc_enum(#dcur, #dec) * desc_conf(#dcur, #dcc) *
+	   DataDescriptor(#dcur;) * desc_writ(#dcur, true;) * desc_enum(#dcur, #dec;) * desc_conf(#dcur, #dcc;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, {{ "d", #gval, true, #dec, #dcc }}) *
+	   Cell_o (#l, #prop, {{ "d", #gval, true, #dec, #dcc }};) *
 	   (ret == true) ]]
 	normal;
 
@@ -2272,77 +2272,77 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
        (#desc == {{ "g", empty, empty, #gval, empty, empty, empty }}) * (! (#gval == empty)) *
-	   DataDescriptor(#dcur) * desc_writ(#dcur, true) * desc_enum(#dcur, #dec) * desc_conf(#dcur, #dcc) *
+	   DataDescriptor(#dcur;) * desc_writ(#dcur, true;) * desc_enum(#dcur, #dec;) * desc_conf(#dcur, #dcc;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", {{ "d", #gval, true, #dec, #dcc }}, #pv) *
+	   Cell_s (#l, #prop, "NSI", {{ "d", #gval, true, #dec, #dcc }}, #pv;) *
 	   (ret == true) ]]
 	normal;
 
 	(* 15 - Current is defined, configurable is false, descriptor, configurable is true, non-string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
+       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) *
-	   isTypeError(err) ]]
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 16 - Current is defined, configurable is false, descriptor, configurable is true, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
+       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur) *
+	   Cell_o (#l, #prop, #dcur;) *
 	   (ret == false) ]]
 	normal;
 
 	(* 17 - Current is defined, configurable is false, descriptor, configurable is true, string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, true) *
+       Descriptor(#desc;) * desc_conf(#desc, true;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
-	   isTypeError(err) ]]
+	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 18 - Current is defined, configurable is false, descriptor, configurable is true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, true) *
+       Descriptor(#desc;) * desc_conf(#desc, true;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
+	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
 	   (ret == false) ]]
 	normal;
 
 	(* 19 - Current is defined, configurable is false, descriptor, configurable is true, string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
+       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
-	   isTypeError(err) ]]
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 20 - Current is defined, configurable is false, descriptor, configurable is true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
+       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
 	   (ret == false) ]]
 	normal;
 
@@ -2350,27 +2350,27 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, false) *
-       Descriptor(#dcur) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
+       Descriptor(#desc;) * desc_conf(#desc, false;) *
+       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur) *
-	   isTypeError(err) ]]
+	   Cell_o (#l, #prop, #dcur;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 22 - Current is defined, configurable is false, descriptor, configurable is false, enumerables are different, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, false) *
-       Descriptor(#dcur) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
+       Descriptor(#desc;) * desc_conf(#desc, false;) *
+       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur) *
+	   Cell_o (#l, #prop, #dcur;) *
 	   (ret == false) ]]
 	normal;
 
@@ -2378,23 +2378,23 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, false) *
+       Descriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
-	   isTypeError(err) ]]
+	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 24 - Current is defined, configurable is false, descriptor, configurable is false, enumerables are different, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, false) *
+       Descriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv)  ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;)  ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv)  *
+	   Cell_s (#l, #prop, "SI", #dcur, #pv;)  *
 	   (ret == false) ]]
 	normal;
 
@@ -2402,27 +2402,27 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, false) *
-       Descriptor(#dcur) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
+       Descriptor(#desc;) * desc_conf(#desc, false;) *
+       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
-	   isTypeError(err) ]]
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 26 - Current is defined, configurable is false, descriptor, configurable is false, enumerables are different, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, false) *
-       Descriptor(#dcur) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
+       Descriptor(#desc;) * desc_conf(#desc, false;) *
+       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv)  ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;)  ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv)  *
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv;)  *
 	   (ret == false) ]]
 	normal;
 
@@ -2430,29 +2430,29 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * DataDescriptor(#dcur) *
-       desc_conf(#desc, false) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
-	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
+       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
+       desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
+	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur) *
-	   isTypeError(err) ]]
+	   Cell_o (#l, #prop, #dcur;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 28 - Current is defined, configurables are false, enumerables are same, writables false and true, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * DataDescriptor(#dcur) *
-	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
-	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
+       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
+	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
+	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur) *
+	   Cell_o (#l, #prop, #dcur;) *
 	   (ret == false) ]]
 	normal;
 
@@ -2460,23 +2460,23 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, true) * desc_writ(#desc, true) *
+       DataDescriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, true;) * desc_writ(#desc, true;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
-	   isTypeError(err) ]]
+	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 30 - Current is defined, configurables are false, enumerables are same, writables false and true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, true) * desc_writ(#desc, true) *
+       DataDescriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, true;) * desc_writ(#desc, true;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
+	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
 	   (ret == false) ]]
 	normal;
 
@@ -2484,29 +2484,29 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * DataDescriptor(#dcur) *
-       desc_conf(#desc, false) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
-	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
+       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
+       desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
+	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
-	   isTypeError(err) ]]
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 32 - Current is defined, configurables are false, enumerables are same, writables false and true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * DataDescriptor(#dcur) *
-	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
-	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
+       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
+	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
+	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
 	   (ret == false) ]]
 	normal;
 
@@ -2514,14 +2514,14 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * DataDescriptor(#dcur) *
-	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
-	   desc_writ(#dcur, true) *
+       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
+	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
+	   desc_writ(#dcur, true;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #desc) *
+	   Cell_o (#l, #prop, #desc;) *
 	   (ret == true) ]]
 	normal;
 
@@ -2529,14 +2529,14 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * DataDescriptor(#dcur) *
-	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
-	   desc_writ(#dcur, true) *
+       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
+	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
+	   desc_writ(#dcur, true;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv;) *
 	   (ret == true) ]]
 	normal
 
@@ -2742,22 +2742,22 @@ spec defineOwnProperty (l, prop, desc, thrw)
     (* 01 - Current is undefined, object is not extensible, non-string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
-	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
+	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, none) * ((#l, "@extensible") -> false) *
-	   isTypeError(err) ]]
+	   Cell_o (#l, #prop, none;) * ((#l, "@extensible") -> false) *
+	   isTypeError(err;) ]]
     error;
 
     (* 02 - Current is undefined, object is not extensible, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
-	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
+	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, none) * ((#l, "@extensible") -> false) *
+	   Cell_o (#l, #prop, none;) * ((#l, "@extensible") -> false) *
 	   (ret == false) ]]
     normal;
 
@@ -2765,45 +2765,45 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv) *
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "none", none, #pv) * ((#l, "@extensible") -> false) *
-	   isTypeError(err) ]]
+	   Cell_s (#l, #prop, "none", none, #pv;) * ((#l, "@extensible") -> false) *
+	   isTypeError(err;) ]]
     error;
 
     (* 04 - Current is undefined, object is not extensible, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv) *
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "none", none, #pv) * ((#l, "@extensible") -> false) *
+	   Cell_s (#l, #prop, "none", none, #pv;) * ((#l, "@extensible") -> false) *
 	   (ret == false) ]]
     normal;
 
 	(* 05 - Current is undefined, object is extensible, non-string, data descriptor, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
-	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
-	   DataDescriptor (#desc) *
+	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
+	   DataDescriptor (#desc;) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> true) *
+	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
     (* 06 - Current is undefined, object is extensible, non-string, accessor descriptor, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
-	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
-	   AccessorDescriptor (#desc) *
+	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
+	   AccessorDescriptor (#desc;) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> true) *
+	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
@@ -2811,11 +2811,11 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv) *
-	   DataDescriptor (#desc) *
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;) *
+	   DataDescriptor (#desc;) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> true) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
@@ -2823,59 +2823,59 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv)  *
-	   AccessorDescriptor (#desc) *
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;)  *
+	   AccessorDescriptor (#desc;) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> true) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
 	(* 09 - Current is defined, configurable is true, data descriptor, non-string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       DataDescriptor(#desc) * desc_conf(#dcur, true) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) *
+       DataDescriptor(#desc;) * desc_conf(#dcur, true;) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> #ext) *
+	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
 	(* 10 - Current is defined, configurable is true, accessor descriptor, non-string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       AccessorDescriptor(#desc) * desc_conf(#dcur, true) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) *
+       AccessorDescriptor(#desc;) * desc_conf(#dcur, true;) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> #ext) *
+	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
 	(* 11 - Current is defined, configurable is true, data descriptor, string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       DataDescriptor(#desc) * desc_conf(#dcur, true) *
+       DataDescriptor(#desc;) * desc_conf(#dcur, true;) *
        ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> #ext) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
 	(* 12 - Current is defined, configurable is true, accessor descriptor, string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       AccessorDescriptor(#desc) * desc_conf(#dcur, true) *
+       AccessorDescriptor(#desc;) * desc_conf(#dcur, true;) *
        ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> #ext) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
@@ -2883,11 +2883,11 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
        (#desc == {{ "g", empty, empty, #gval, empty, empty, empty }}) * (! (#gval == empty)) *
-	   DataDescriptor(#dcur) * desc_writ(#dcur, true) * desc_enum(#dcur, #dec) * desc_conf(#dcur, #dcc) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
-    [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) * isClass(#cls, "Non-String") *
-	   Cell_o (#l, #prop, {{ "d", #gval, true, #dec, #dcc }}) *
+	   DataDescriptor(#dcur;) * desc_writ(#dcur, true;) * desc_enum(#dcur, #dec;) * desc_conf(#dcur, #dcc;) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+    [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) * isClass(#cls, "Non-String";) *
+	   Cell_o (#l, #prop, {{ "d", #gval, true, #dec, #dcc }};) *
 	   (ret == true) ]]
 	normal;
 
@@ -2895,77 +2895,77 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
        (#desc == {{ "g", empty, empty, #gval, empty, empty, empty }}) * (! (#gval == empty)) *
-	   DataDescriptor(#dcur) * desc_writ(#dcur, true) * desc_enum(#dcur, #dec) * desc_conf(#dcur, #dcc) *
+	   DataDescriptor(#dcur;) * desc_writ(#dcur, true;) * desc_enum(#dcur, #dec;) * desc_conf(#dcur, #dcc;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", {{ "d", #gval, true, #dec, #dcc }}, #pv) *
+	   Cell_s (#l, #prop, "NSI", {{ "d", #gval, true, #dec, #dcc }}, #pv;) *
 	   (ret == true) ]]
 	normal;
 
 	(* 15 - Current is defined, configurable is false, descriptor, configurable is true, non-string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur) *
-	   isTypeError(err) ]]
+	   Cell_o (#l, #prop, #dcur;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 16 - Current is defined, configurable is false, descriptor, configurable is true, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur) *
+	   Cell_o (#l, #prop, #dcur;) *
 	   (ret == false) ]]
 	normal;
 
 	(* 17 - Current is defined, configurable is false, descriptor, configurable is true, string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, true) *
+       Descriptor(#desc;) * desc_conf(#desc, true;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
-	   isTypeError(err) ]]
+	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 18 - Current is defined, configurable is false, descriptor, configurable is true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, true) *
+       Descriptor(#desc;) * desc_conf(#desc, true;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
+	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
 	   (ret == false) ]]
 	normal;
 
 	(* 19 - Current is defined, configurable is false, descriptor, configurable is true, string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
+       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
-	   isTypeError(err) ]]
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 20 - Current is defined, configurable is false, descriptor, configurable is true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
+       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
 	   (ret == false) ]]
 	normal;
 
@@ -2973,27 +2973,27 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, false) *
-       Descriptor(#dcur) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+       Descriptor(#desc;) * desc_conf(#desc, false;) *
+       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur) *
-	   isTypeError(err) ]]
+	   Cell_o (#l, #prop, #dcur;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 22 - Current is defined, configurable is false, descriptor, configurable is false, enumerables are different, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, false) *
-       Descriptor(#dcur) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+       Descriptor(#desc;) * desc_conf(#desc, false;) *
+       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur) *
+	   Cell_o (#l, #prop, #dcur;) *
 	   (ret == false) ]]
 	normal;
 
@@ -3001,23 +3001,23 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, false) *
+       Descriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) *
-	   isTypeError(err) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 24 - Current is defined, configurable is false, descriptor, configurable is false, enumerables are different, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, false) *
+       Descriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv)  ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;)  ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv)  *
+	   Cell_s (#l, #prop, "SI", #dcur, #pv;)  *
 	   (ret == false) ]]
 	normal;
 
@@ -3025,27 +3025,27 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, false) *
-       Descriptor(#dcur) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
+       Descriptor(#desc;) * desc_conf(#desc, false;) *
+       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
-	   isTypeError(err) ]]
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 26 - Current is defined, configurable is false, descriptor, configurable is false, enumerables are different, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc) * desc_conf(#desc, false) *
-       Descriptor(#dcur) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
+       Descriptor(#desc;) * desc_conf(#desc, false;) *
+       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv)  ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;)  ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv)  *
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv;)  *
 	   (ret == false) ]]
 	normal;
 
@@ -3053,29 +3053,29 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * DataDescriptor(#dcur) *
-       desc_conf(#desc, false) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
-	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
+       desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
+	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur) *
-	   isTypeError(err) ]]
+	   Cell_o (#l, #prop, #dcur;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 28 - Current is defined, configurables are false, enumerables are same, writables false and true, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * DataDescriptor(#dcur) *
-	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
-	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
+	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
+	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur) *
+	   Cell_o (#l, #prop, #dcur;) *
 	   (ret == false) ]]
 	normal;
 
@@ -3083,23 +3083,23 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, true) * desc_writ(#desc, true) *
+       DataDescriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, true;) * desc_writ(#desc, true;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
-	   isTypeError(err) ]]
+	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 30 - Current is defined, configurables are false, enumerables are same, writables false and true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, true) * desc_writ(#desc, true) *
+       DataDescriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, true;) * desc_writ(#desc, true;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
+	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
 	   (ret == false) ]]
 	normal;
 
@@ -3107,29 +3107,29 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * DataDescriptor(#dcur) *
-       desc_conf(#desc, false) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
-	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
+       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
+       desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
+	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
-	   isTypeError(err) ]]
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   isTypeError(err;) ]]
 	error;
 
 	(* 32 - Current is defined, configurables are false, enumerables are same, writables false and true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * DataDescriptor(#dcur) *
-	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
-	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
+	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
+	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
 	   (ret == false) ]]
 	normal;
 
@@ -3137,14 +3137,14 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * DataDescriptor(#dcur) *
-	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
-	   desc_writ(#dcur, true) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
+	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
+	   desc_writ(#dcur, true;) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #desc) *
+	   Cell_o (#l, #prop, #desc;) *
 	   (ret == true) ]]
 	normal;
 
@@ -3152,14 +3152,14 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc) * DataDescriptor(#dcur) *
-	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
-	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
-	   desc_writ(#dcur, true) *
+       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
+	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
+	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
+	   desc_writ(#dcur, true;) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
+	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv;) *
 	   (ret == true) ]]
 	normal
 

--- a/Gillian-JS/runtime/JSLogic/internal_functions_full.jsil
+++ b/Gillian-JS/runtime/JSLogic/internal_functions_full.jsil
@@ -8,7 +8,7 @@
  * Resource: none
  *
  *)
-pred isInternalProperty (prop;) :
+pred isInternalProperty (prop) :
     types (prop : Str) * (! (prop == "")) * (s-nth (prop, 0) == "@");
 
 (*
@@ -17,7 +17,7 @@ pred isInternalProperty (prop;) :
  * Resource: none
  *
  *)
-pred isNamedProperty (prop;) :
+pred isNamedProperty (prop) :
     types (prop : Str) * (! (prop == "")) * (! (s-nth (prop, 0) == "@"));
 
 (*
@@ -26,7 +26,7 @@ pred isNamedProperty (prop;) :
  * Resource: none
  *
  *)
-pred DataDescriptor (d;) :
+pred DataDescriptor (d) :
     types (d : List, #dwrit : Bool, #denum : Bool, #dconf : Bool) *
     (! (#dval == empty)) * (d == {{ "d", #dval, #dwrit, #denum, #dconf }});
 
@@ -36,7 +36,7 @@ pred DataDescriptor (d;) :
  * Resource: none
  *
  *)
-pred AccessorDescriptor (d;) :
+pred AccessorDescriptor (d) :
     types (d : List, #denum : Bool, #dconf : Bool) *
     (! (#dget == empty)) * (! (#dset == empty)) *
     (d == {{ "a", #dget, #dset, #denum, #dconf }});
@@ -47,9 +47,9 @@ pred AccessorDescriptor (d;) :
  * Resource: none
  *
  *)
-pred Descriptor (d;) :
-    DataDescriptor (d;),
-    AccessorDescriptor (d;);
+pred Descriptor (d) :
+    DataDescriptor (d),
+    AccessorDescriptor (d);
 
 (*
  * Predicate: GenericDescriptor
@@ -57,7 +57,7 @@ pred Descriptor (d;) :
  * Resource: none
  *
  *)
-pred GenericDescriptor (d;) :
+pred GenericDescriptor (d) :
     types (d : List) * (d == {{ "g", #genum, #gconf, #gval, #gwrit, #gget, #gset }});
 
 (*
@@ -66,37 +66,37 @@ pred GenericDescriptor (d;) :
  * Resource: none
  *
  *)
-pred desc_val (d, v;) :
+pred desc_val (d, v) :
     types (d : List) * v == l-nth(d, 1);
 
-pred desc_writ (d, v;) :
+pred desc_writ (d, v) :
     types (d : List) * v == l-nth(d, 2);
 
-pred desc_get (d, v;) :
+pred desc_get (d, v) :
     types (d : List) * v == l-nth(d, 1);
 
-pred desc_set (d, v;) :
+pred desc_set (d, v) :
     types (d : List) * v == l-nth(d, 2);
 
-pred desc_enum (d, v;) :
+pred desc_enum (d, v) :
     types (d : List) * v == l-nth(d, 3);
 
-pred desc_conf (d, v;) :
+pred desc_conf (d, v) :
     types (d : List) * v == l-nth(d, 4);
 
 (*
- * Predicate: Cell_o(l, prop, X;)
+ * Predicate: Cell_o(l, prop, X)
  *
  * Resource:
  *      (l, prop)
  *
  * Note: We are not allowing accessor descriptors in the heap yet
  *)
-pred Cell_o (l, prop, none;) :
-    types(l : Obj) * isNamedProperty(prop;) * ((l, prop) -> none);
+pred Cell_o (l, prop, none) :
+    types(l : Obj) * isNamedProperty(prop) * ((l, prop) -> none);
 
-pred Cell_o (l, prop, d;) :
-    types(l : Obj) * isNamedProperty(prop;) * ((l, prop) -> d) * Descriptor(d;);
+pred Cell_o (l, prop, d) :
+    types(l : Obj) * isNamedProperty(prop) * ((l, prop) -> d) * Descriptor(d);
 
 (*
  * Predicate: IsStringIndex - how do we deal with integers?
@@ -104,12 +104,12 @@ pred Cell_o (l, prop, d;) :
  * Resource: none
  *
  *)
-pred IsStringIndex(S, prop, i;) :
+pred IsStringIndex(S, prop, i) :
     types(S : Str, prop : Str, i : Num) *
     (prop == num_to_string i) * (0 <=# i) * (i <# s-len S);
 
 (*
- * Predicate: Cell_s(l, prop, _, X, primitiveValue;)
+ * Predicate: Cell_s(l, prop, _, X, primitiveValue)
  *
  * Resource:
  *      (l, prop)               via Cell_o
@@ -119,55 +119,55 @@ pred IsStringIndex(S, prop, i;) :
  *       otherwise (l, "@primitiveValue") WILL NOT EXIST OR BE STUPID
  *
  *)
-pred Cell_s (l, prop, "none", none, pv;) :
+pred Cell_s (l, prop, "none", none, pv) :
      types (l : Obj, prop : Str, pv : Str) *
-	 Cell_o (l, prop, none;) * ((l, "@primitiveValue") -> pv) *
-     (#i == num_to_int (string_to_num prop)) * (! IsStringIndex(pv, prop, #i;));
+	 Cell_o (l, prop, none) * ((l, "@primitiveValue") -> pv) *
+     (#i == num_to_int (string_to_num prop)) * (! IsStringIndex(pv, prop, #i));
 
-pred Cell_s (l, prop, "SI", desc, pv;) :
+pred Cell_s (l, prop, "SI", desc, pv) :
      types(l : Obj, #prop : Str, desc : List, pv : Str, #i : Num, #v : Str) *
-	 (prop == #prop) * Cell_o (l, #prop, none;) * ((l, "@primitiveValue") -> pv) *
+	 (prop == #prop) * Cell_o (l, #prop, none) * ((l, "@primitiveValue") -> pv) *
      (desc == {{ "d", #v, false, true, false }}) *  (#v == s-nth(pv, #i)) *
-	 (#i == num_to_int (string_to_num #prop)) * IsStringIndex(pv, #prop, #i;);
+	 (#i == num_to_int (string_to_num #prop)) * IsStringIndex(pv, #prop, #i);
 
-pred Cell_s (l, prop, "NSI", desc, pv;) :
+pred Cell_s (l, prop, "NSI", desc, pv) :
 	 types (l : Obj, prop : Str, desc : List, pv : Str, #i : Num) *
-	 Cell_o (l, prop, desc;) * ((l, "@primitiveValue") -> pv) *
-	 (#i == num_to_int (string_to_num prop)) * (! IsStringIndex(pv, prop, #i;)) *
+	 Cell_o (l, prop, desc) * ((l, "@primitiveValue") -> pv) *
+	 (#i == num_to_int (string_to_num prop)) * (! IsStringIndex(pv, prop, #i)) *
      (! (desc == none));
 
 (*
- * Predicate: ErrorObject(l, pr;)
+ * Predicate: ErrorObject(l, pr)
  *
  * Resource:
  *      (l, "@proto")	(l, "@class")	(l, "@extensible")
  *
  *)
 
-pred ErrorObject (l, pr;) :
+pred ErrorObject (l, pr) :
 	types (l : Obj, pr : Obj) *
 	((l, "@proto") -> pr) * ((l, "@class") -> "Error") * ((l, "@extensible") -> true) * empty_fields(l : "@proto", "@class", "@extensible");
 
-pred isTypeError(l;) :
-    ErrorObject (l, $lterr_proto;);
+pred isTypeError(l) :
+    ErrorObject (l, $lterr_proto);
 
-pred isSyntaxError(l;) :
-    ErrorObject (l, $lserr_proto;);
+pred isSyntaxError(l) :
+    ErrorObject (l, $lserr_proto);
 
-pred isReferenceError(l;) :
-    ErrorObject (l, $lrferr_proto;);
+pred isReferenceError(l) :
+    ErrorObject (l, $lrferr_proto);
 
 (*
- * Predicate: isClass(c, X;)
+ * Predicate: isClass(c, X)
  *
  * Resource:
  *      (l, "@class")
  *
  *)
-pred isClass (c, "Array";)      : types (c : Str) * (c == "Array");
-pred isClass (c, "String";)     : types (c : Str) * (c == "String");
-pred isClass (c, "Non-String";) : types (c : Str) * (! (c == "String"));
-pred isClass (c, "Non-Array";)  : types (c : Str) * (! (c == "Array"));
+pred isClass (c, "Array")      : types (c : Str) * (c == "Array");
+pred isClass (c, "String")     : types (c : Str) * (c == "String");
+pred isClass (c, "Non-String") : types (c : Str) * (! (c == "String"));
+pred isClass (c, "Non-Array")  : types (c : Str) * (! (c == "Array"));
 
 (*
  * The PI predicate
@@ -178,10 +178,10 @@ pred isClass (c, "Non-Array";)  : types (c : Str) * (! (c == "Array"));
  *		(l, "@class")   via isClass
  *		(l, "@proto")	(l, "prop")
  *)
-pred Pi (l, prop, lcls, undefined, ls, ltf, lpv;) :
+pred Pi (l, prop, lcls, undefined, ls, ltf, lpv) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, ls : List, ltf : List, lpv : List) *
 	((l, "@proto") -> null) * ((l, "@class") -> #cls) *
-	isClass (#cls, "Non-String";) * Cell_o (l, prop, none;) *
+	isClass (#cls, "Non-String") * Cell_o (l, prop, none) *
     (lcls == {{ #cls }}) * (ls == {{ l }}) * (ltf == {{ false }}) * (lpv == {{ "" }});
 
 (*
@@ -189,10 +189,10 @@ pred Pi (l, prop, lcls, undefined, ls, ltf, lpv;) :
  *		(l, "@class")   via isClass
  *		(l, "@proto")	(l, "prop")
  *)
-pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
+pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, d : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) *
-	isClass (#cls, "Non-String";) * Cell_o (l, prop, d;) * (! (d == none)) *
+	isClass (#cls, "Non-String") * Cell_o (l, prop, d) * (! (d == none)) *
     (lcls == {{ #cls }}) * (ls == {{ l }}) * (ltf == {{ false }}) * (lpv == {{ "" }});
 
 (*
@@ -203,12 +203,12 @@ pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
  *		Those five fields captured throughout the chain
  *)
 
-pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
+pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
     types(l : Obj, prop : Str, lcls : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) * ((l, "@proto") -> #lp) *
-	isClass (#cls, "Non-String";) * Cell_o (l, prop, none;) *
+	isClass (#cls, "Non-String") * Cell_o (l, prop, none) *
 	types(#lcls : List, #lls : List, #ltf  : List, #lpv : List) *
-    Pi (#lp, prop, #lcls, d, #lls, #ltf, #lpv;) *
+    Pi (#lp, prop, #lcls, d, #lls, #ltf, #lpv) *
 	types(#pcls : Str,  #ocls : List,
 	        #lp : Obj,  #ols  : List,
 		   #ptf : Bool, #otf  : List,
@@ -221,10 +221,10 @@ pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
  *		(l, "@class")   via isClass
  *		(l, "@proto")	(l, "prop")		(l, "@primitiveValue")
  *)
-pred Pi (l, prop, lcls, undefined, ls, ltf, lpv;) :
+pred Pi (l, prop, lcls, undefined, ls, ltf, lpv) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, ls : List, ltf : List, lpv : List) *
 	((l, "@proto") -> null) * ((l, "@class") -> #cls) *
-    isClass (#cls, "String";) * Cell_s (l, prop, "none", none, #pv;) *
+    isClass (#cls, "String") * Cell_s (l, prop, "none", none, #pv) *
     (lcls == {{ #cls }}) * (ls == {{ l }}) * (ltf == {{ true }}) * (lpv == {{ #pv }});
 
 (*
@@ -232,10 +232,10 @@ pred Pi (l, prop, lcls, undefined, ls, ltf, lpv;) :
  *		(l, "@class")   via isClass
  *		(l, "@proto")	(l, "prop")		(l, "@primitiveValue")
  *)
-pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
+pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, d : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) *
-	isClass (#cls, "String";) * Cell_s (l, prop, "SI", d, #pv;) *
+	isClass (#cls, "String") * Cell_s (l, prop, "SI", d, #pv) *
 	(lcls == {{ #cls }}) * (ls == {{ l }}) * (ltf == {{ true }}) * (lpv == {{ #pv }});
 
 (*
@@ -243,10 +243,10 @@ pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
  *		(l, "@class")   via isClass
  *		(l, "@proto")	(l, "prop")		(l, "@primitiveValue")
  *)
-pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
+pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, d : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) *
-	isClass (#cls, "String";) * Cell_s (l, prop, "NSI", d, #pv;) *
+	isClass (#cls, "String") * Cell_s (l, prop, "NSI", d, #pv) *
     (lcls == {{ #cls }}) * (ls == {{ l }}) * (ltf == {{ true }}) * (lpv == {{ #pv }});
 
 (*
@@ -256,12 +256,12 @@ pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
  *
  *		Those five fields captured throughout the chain
  *)
-pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
+pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
     types(l : Obj, prop : Str, lcls : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) * ((l, "@proto") -> #lp) *
-	isClass (#cls, "String";) * Cell_s (l, prop, "none", none, #pv;) *
+	isClass (#cls, "String") * Cell_s (l, prop, "none", none, #pv) *
 	types(#lcls : List, #lls : List, #ltf  : List, #lpv : List) *
-    Pi (#lp, prop, #lcls, d, #lls, #ltf, #lpv;) *
+    Pi (#lp, prop, #lcls, d, #lls, #ltf, #lpv) *
 	types(#pcls : Str,  #ocls : List,
 	        #lp : Obj,  #ols  : List,
 		   #ptf : Bool, #otf  : List,
@@ -364,7 +364,7 @@ proc create_object_with_call_construct (l, call, construct, len) {
 	rlab:	ret := l
 };
 
-pred function_object (l, xsc, call, construct, len, prototype;) :
+pred function_object (l, xsc, call, construct, len, prototype) :
 	types(l : Obj, xsc : List, call : Str, construct: Str, len : Num, prototype : Obj) *
 	((l, "@proto") -> $lfun_proto) * ((l, "@class") -> "Function") * ((l, "@extensible") -> true) *
 	((l, "@scope") -> xsc)  * ((l, "length") -> {{ "d", len, false, false, false }}) *
@@ -378,7 +378,7 @@ spec create_function_object (xsc, call, construct, params)
     [[ (xsc == #xsc) * (call == #call) * (construct == #construct) * (params == #params) *
 	   types(#xsc : List, #call : Str, #construct: Str, #params : List) ]]
     [[ types(#l : Obj, #xsc : List, #call : Str, #construct: Str, #params : List, #len : Num, ret : Obj) *
-	   function_object(ret, #xsc, #call, #construct, #len, prototype;) * (#len == l-len #params) *
+	   function_object(ret, #xsc, #call, #construct, #len, prototype) * (#len == l-len #params) *
 	   ((prototype, "@proto") -> $lobj_proto) * ((prototype, "@class") -> "Object") * ((prototype, "@extensible") -> true) *
 	   ((prototype, "constructor") -> {{ "d", ret, true, false, true }} ) *
 	   empty_fields(prototype : "@proto", "@class", "@extensible", "constructor") ]]
@@ -502,7 +502,7 @@ proc i__toBoolean (v) {
 spec TypeError_call (xsc, vthis, v)
 
     [[ (v == undefined) ]]
-    [[ isTypeError(ret;) ]]
+    [[ isTypeError(ret) ]]
     normal
 
 proc TypeError_call (xsc, vthis, v) {
@@ -518,7 +518,7 @@ proc TypeError_call (xsc, vthis, v) {
 spec TypeError (v)
 
     [[ (v == undefined) ]]
-    [[ isTypeError(ret;) ]]
+    [[ isTypeError(ret) ]]
     normal
 
 proc TypeError (v) {
@@ -535,7 +535,7 @@ proc TypeError (v) {
 spec ReferenceError_call (xsc, vthis, v)
 
     [[ (v == undefined) ]]
-    [[ isReferenceError(ret;) ]]
+    [[ isReferenceError(ret) ]]
     normal
 
 proc ReferenceError_call (xsc, vthis, v) {
@@ -551,7 +551,7 @@ proc ReferenceError_call (xsc, vthis, v) {
 spec ReferenceError (v)
 
     [[ (v == undefined) ]]
-    [[ isReferenceError(ret;) ]]
+    [[ isReferenceError(ret) ]]
     normal
 
 proc ReferenceError (v) {
@@ -568,7 +568,7 @@ proc ReferenceError (v) {
 spec SyntaxError_call (xsc, vthis, v)
 
     [[ (v == undefined) ]]
-    [[ isSyntaxError(ret;) ]]
+    [[ isSyntaxError(ret) ]]
     normal
 
 proc SyntaxError_call (xsc, vthis, v) {
@@ -584,7 +584,7 @@ proc SyntaxError_call (xsc, vthis, v) {
 spec SyntaxError (v)
 
     [[ (v == undefined) ]]
-    [[ isSyntaxError(ret;) ]]
+    [[ isSyntaxError(ret) ]]
     normal
 
 proc SyntaxError (v) {
@@ -598,13 +598,13 @@ proc SyntaxError (v) {
    *** *** ***   INITIAL HEAP   *** *** ***
    **************************************** *)
 
-pred initialHeapPre (;) :
+pred initialHeapPre () :
     (($lg,      "@class") -> none) *
     (($lg, 	    "@proto") -> none) *
     (($lg, "@extensible") -> none) *
     empty_fields ( $lobj_proto : ) * empty_fields ($lfun_proto : ) * empty_fields ($lerr : ) * empty_fields ($lerr_proto : );
 
-pred initialHeapPost (;) :
+pred initialHeapPost () :
     (($lg,         "@class") -> "Object")   * (($lg,         "@proto") -> $lobj_proto) * (($lg,         "@extensible") -> true) * (($lg,         "Error") -> {{ "d", $lerr, true, false, true }}) *
 	(($lobj_proto, "@class") -> "Object")   * (($lobj_proto, "@proto") -> null)      * (($lobj_proto, "@extensible") -> true) * empty_fields ( $lobj_proto : "@class", "@proto", "@extensible" ) *
 	(($lfun_proto, "@class") -> "Function") * (($lfun_proto, "@proto") -> $lobj_proto) * (($lfun_proto, "@extensible") -> true) *
@@ -617,8 +617,8 @@ pred initialHeapPost (;) :
 
 spec setupInitialHeap ()
 
-	[[ initialHeapPre(;) ]]
-	[[ initialHeapPost(;) * (ret == empty) ]]
+	[[ initialHeapPre() ]]
+	[[ initialHeapPost() * (ret == empty) ]]
 	normal
 
 proc setupInitialHeap () {
@@ -1043,27 +1043,27 @@ spec i__isDataDescriptor (desc)
     normal;
 
     (* Data descriptor *)
-    [[ DataDescriptor(desc;) ]]
+    [[ DataDescriptor(desc) ]]
     [[ ret == true ]]
     normal;
 
     (* Accessor descriptor *)
-    [[ AccessorDescriptor(desc;) ]]
+    [[ AccessorDescriptor(desc) ]]
     [[ ret == false ]]
     normal;
 
     (* Generic descriptor, no data descriptor components *)
-    [[ GenericDescriptor(desc;) * (l-nth (desc, 3) == empty) * (l-nth (desc, 4) == empty) ]]
+    [[ GenericDescriptor(desc) * (l-nth (desc, 3) == empty) * (l-nth (desc, 4) == empty) ]]
     [[ ret == false ]]
     normal;
 
     (* Generic descriptor, with value *)
-    [[ GenericDescriptor(desc;) * (! l-nth (desc, 3) == empty) ]]
+    [[ GenericDescriptor(desc) * (! l-nth (desc, 3) == empty) ]]
     [[ ret == true ]]
     normal;
 
     (* Generic descriptor, with writable *)
-    [[ GenericDescriptor(desc;) * (! l-nth (desc, 4) == empty) ]]
+    [[ GenericDescriptor(desc) * (! l-nth (desc, 4) == empty) ]]
     [[ ret == true ]]
     normal
 
@@ -1093,27 +1093,27 @@ spec i__isAccessorDescriptor (desc)
     normal;
 
     (* Data descriptor *)
-    [[ DataDescriptor(desc;) ]]
+    [[ DataDescriptor(desc) ]]
     [[ ret == false ]]
     normal;
 
     (* Data descriptor *)
-    [[ AccessorDescriptor(desc;) ]]
+    [[ AccessorDescriptor(desc) ]]
     [[ ret == true ]]
     normal;
 
     (* Generic descriptor, no data descriptor components *)
-    [[ GenericDescriptor(desc;) * (l-nth (desc, 5) == empty) * (l-nth (desc, 6) == empty) ]]
+    [[ GenericDescriptor(desc) * (l-nth (desc, 5) == empty) * (l-nth (desc, 6) == empty) ]]
     [[ ret == false ]]
     normal;
 
     (* Generic descriptor, with get *)
-    [[ GenericDescriptor(desc;) * (! l-nth (desc, 5) == empty) ]]
+    [[ GenericDescriptor(desc) * (! l-nth (desc, 5) == empty) ]]
     [[ ret == true ]]
     normal;
 
     (* Generic descriptor, with set *)
-    [[ GenericDescriptor(desc;) * (! l-nth (desc, 6) == empty) ]]
+    [[ GenericDescriptor(desc) * (! l-nth (desc, 6) == empty) ]]
     [[ ret == true ]]
     normal
 
@@ -1143,39 +1143,39 @@ spec i__isGenericDescriptor (desc)
     normal;
 
 	(* Data descriptor *)
-	[[ DataDescriptor(desc;) ]]
+	[[ DataDescriptor(desc) ]]
 	[[ ret == false ]]
 	normal;
 
 	(* Accessor descriptor *)
-	[[ AccessorDescriptor(desc;) ]]
+	[[ AccessorDescriptor(desc) ]]
 	[[ ret == false ]]
 	normal;
 
 	(* Generic descriptor, no data descriptor components *)
-	[[ GenericDescriptor(desc;) *
+	[[ GenericDescriptor(desc) *
 	   (l-nth (desc, 3) == empty) * (l-nth (desc, 4) == empty) *
 	   (l-nth (desc, 5) == empty) * (l-nth (desc, 6) == empty) ]]
 	[[ ret == true ]]
 	normal;
 
 	(* Generic descriptor, with value *)
-	[[ GenericDescriptor(desc;) * (! (l-nth (desc, 3) == empty)) ]]
+	[[ GenericDescriptor(desc) * (! (l-nth (desc, 3) == empty)) ]]
 	[[ ret == false ]]
 	normal;
 
 	(* Generic descriptor, with writable *)
-	[[ GenericDescriptor(desc;) * (! (l-nth (desc, 4) == empty)) ]]
+	[[ GenericDescriptor(desc) * (! (l-nth (desc, 4) == empty)) ]]
 	[[ ret == false ]]
 	normal;
 
 	(* Generic descriptor, with get *)
-	[[ GenericDescriptor(desc;) * (! (l-nth (desc, 5) == empty)) ]]
+	[[ GenericDescriptor(desc) * (! (l-nth (desc, 5) == empty)) ]]
 	[[ ret == false ]]
 	normal;
 
 	(* Generic descriptor, with get *)
-	[[ GenericDescriptor(desc;) * (! (l-nth (desc, 6) == empty)) ]]
+	[[ GenericDescriptor(desc) * (! (l-nth (desc, 6) == empty)) ]]
 	[[ ret == false ]]
 	normal
 
@@ -1197,7 +1197,7 @@ proc i__isGenericDescriptor (desc) {
 
 spec i__toDataDescriptor (desc)
 
-    [[ (desc == #desc) * DataDescriptor (#desc;) ]]
+    [[ (desc == #desc) * DataDescriptor (#desc) ]]
     [[ (ret == #desc) ]]
     normal
 
@@ -1237,7 +1237,7 @@ proc i__toDataDescriptor (desc) {
 
 spec i__toAccessorDescriptor (desc)
 
-    [[ (desc == #desc) * AccessorDescriptor (#desc;) ]]
+    [[ (desc == #desc) * AccessorDescriptor (#desc) ]]
     [[ (ret == #desc) ]]
     normal
 
@@ -1379,11 +1379,11 @@ spec i__checkAssignmentErrors (v)
     normal;
 
     [[ (v == #v) * types (#v : List, #l : Obj) * (#v == {{ "v", #l, "eval" }}) ]]
-    [[ isSyntaxError(ret;) ]]
+    [[ isSyntaxError(ret) ]]
     error;
 
     [[ (v == #v) * types (#v : List, #l : Obj) * (#v == {{ "v", #l, "arguments" }}) ]]
-    [[ isSyntaxError(ret;) ]]
+    [[ isSyntaxError(ret) ]]
     error;
 
     [[ (v == #v) * types (#v : List, #base : Obj, #field : Str) * (#v == {{ "o", #base, #field }}) ]]
@@ -1412,11 +1412,11 @@ proc i__checkAssignmentErrors (v) {
 spec i__checkObjectCoercible (v)
 
 	[[ v == undefined ]]
-	[[ isTypeError(ret;) ]]
+	[[ isTypeError(ret) ]]
 	normal;
 
 	[[ v == null ]]
-	[[ isTypeError(ret;) ]]
+	[[ isTypeError(ret) ]]
 	normal;
 
 	[[ types (v : Num) ]]
@@ -1524,14 +1524,14 @@ spec o__getOwnProperty (l, prop)
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str) *
-	   Cell_o (#l, #prop, none;) ]]
-    [[ Cell_o (#l, #prop, none;) * (ret == undefined) ]]
+	   Cell_o (#l, #prop, none) ]]
+    [[ Cell_o (#l, #prop, none) * (ret == undefined) ]]
     normal;
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #dx : List) *
-	   Cell_o (#l, #prop, #dx;) ]]
-    [[ Cell_o (#l, #prop, #dx;) * (ret == #dx) ]]
+	   Cell_o (#l, #prop, #dx) ]]
+    [[ Cell_o (#l, #prop, #dx) * (ret == #dx) ]]
     normal
 
 proc o__getOwnProperty (l, prop) {
@@ -1565,20 +1565,20 @@ proc o__getOwnProperty (l, prop) {
 spec s__getOwnProperty (l, prop)
 
     [[ (l == #l) * (prop == #prop) *
-	   Cell_s (#l, #prop, "none", none, #pv;) ]]
-    [[ Cell_s (#l, #prop, "none", none, #pv;) *
+	   Cell_s (#l, #prop, "none", none, #pv) ]]
+    [[ Cell_s (#l, #prop, "none", none, #pv) *
 	   (ret == undefined) ]]
    	normal;
 
    	[[ (l == #l) * (prop == #prop) *
-	   Cell_s (#l, #prop, "SI", #u, #pv;) ]]
-   	[[ Cell_s (#l, #prop, "SI", #u, #pv;) *
+	   Cell_s (#l, #prop, "SI", #u, #pv) ]]
+   	[[ Cell_s (#l, #prop, "SI", #u, #pv) *
 	   (ret == #u) ]]
    	normal;
 
    	[[ (l == #l) * (prop == #prop) *
-	   Cell_s (#l, #prop, "NSI", #u, #pv;) ]]
-   	[[ Cell_s (#l, #prop, "NSI", #u, #pv;) *
+	   Cell_s (#l, #prop, "NSI", #u, #pv) ]]
+   	[[ Cell_s (#l, #prop, "NSI", #u, #pv) *
 	   (ret == #u) ]]
    	normal
 
@@ -1627,36 +1627,36 @@ spec getOwnProperty (l, prop)
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : Str) *
-	   Cell_o (#l, #prop, none;) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
-    [[ Cell_o (#l, #prop, none;) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String";) *
+	   Cell_o (#l, #prop, none) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
+    [[ Cell_o (#l, #prop, none) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String") *
 	   (ret == undefined) ]]
     normal;
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #dx : List) *
-	   Cell_o (#l, #prop, #dx;) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
-    [[ Cell_o (#l, #prop, #dx;) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String";) *
+	   Cell_o (#l, #prop, #dx) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
+    [[ Cell_o (#l, #prop, #dx) * ((#l, "@class") -> #cls) * isClass(#cls, "Non-String") *
 	   (ret == #dx) ]]
     normal;
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : Str) *
-	   Cell_s (#l, #prop, "none", none, #pv;) * ((#l, "@class") -> #cls) * isClass(#cls, "String";) ]]
-    [[ Cell_s (#l, #prop, "none", none, #pv;) * ((#l, "@class") -> #cls) * isClass(#cls, "String";) *
+	   Cell_s (#l, #prop, "none", none, #pv) * ((#l, "@class") -> #cls) * isClass(#cls, "String") ]]
+    [[ Cell_s (#l, #prop, "none", none, #pv) * ((#l, "@class") -> #cls) * isClass(#cls, "String") *
 	   (ret == undefined) ]]
    	normal;
 
    	[[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #u : List) *
-	   Cell_s (#l, #prop, "SI", #u, #pv;) * ((#l, "@class") -> #cls) * isClass(#cls, "String";) ]]
-   	[[ Cell_s (#l, #prop, "SI", #u, #pv;) * ((#l, "@class") -> #cls) * isClass(#cls, "String";) *
+	   Cell_s (#l, #prop, "SI", #u, #pv) * ((#l, "@class") -> #cls) * isClass(#cls, "String") ]]
+   	[[ Cell_s (#l, #prop, "SI", #u, #pv) * ((#l, "@class") -> #cls) * isClass(#cls, "String") *
 	   (ret == #u) ]]
    	normal;
 
    	[[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #u : List) *
-	   Cell_s (#l, #prop, "NSI", #u, #pv;) * ((#l, "@class") -> #cls) * isClass(#cls, "String";) ]]
-   	[[ Cell_s (#l, #prop, "NSI", #u, #pv;) * ((#l, "@class") -> #cls) * isClass(#cls, "String";) *
+	   Cell_s (#l, #prop, "NSI", #u, #pv) * ((#l, "@class") -> #cls) * isClass(#cls, "String") ]]
+   	[[ Cell_s (#l, #prop, "NSI", #u, #pv) * ((#l, "@class") -> #cls) * isClass(#cls, "String") *
 	   (ret == #u) ]]
    	normal
 
@@ -1692,8 +1692,8 @@ spec getProperty (l, prop)
 
 	[[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str) *
-	   Pi (#l, #prop, #gp_aux_0, #gp_aux_1, #gp_aux_2, #gp_aux_3, #gp_aux_4;) ]]
-	[[ Pi (#l, #prop, #gp_aux_0, #gp_aux_1, #gp_aux_2, #gp_aux_3, #gp_aux_4;) * (ret == #gp_aux_1) ]]
+	   Pi (#l, #prop, #gp_aux_0, #gp_aux_1, #gp_aux_2, #gp_aux_3, #gp_aux_4) ]]
+	[[ Pi (#l, #prop, #gp_aux_0, #gp_aux_1, #gp_aux_2, #gp_aux_3, #gp_aux_4) * (ret == #gp_aux_1) ]]
 	normal
 
 proc getProperty (l, prop) {
@@ -1734,14 +1734,14 @@ spec get (l, prop)
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str) *
-	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * DataDescriptor (#g_aux_1;) ]]
-    [[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * desc_val (#g_aux_1, #desc_val;) * (ret == #desc_val) ]]
+	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * DataDescriptor (#g_aux_1) ]]
+    [[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * desc_val (#g_aux_1, #desc_val) * (ret == #desc_val) ]]
     normal;
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str) *
-	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * (#g_aux_1 == undefined) ]]
-    [[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * (#g_aux_1 == undefined) * (ret == undefined) ]]
+	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * (#g_aux_1 == undefined) ]]
+    [[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * (#g_aux_1 == undefined) * (ret == undefined) ]]
     normal
 
 proc get (l, prop) {
@@ -1795,29 +1795,29 @@ proc get (l, prop) {
 
 spec i__getValue (v)
 
-    [[ (v == {{ "o", #obj, #field }}) * types (#obj : Obj, #field : Str) * isNamedProperty(#field;) *
-       Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * DataDescriptor (#g_aux_1;)  ]]
-    [[ Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * desc_val (#g_aux_1, #desc_val;) * (ret == #desc_val) ]]
+    [[ (v == {{ "o", #obj, #field }}) * types (#obj : Obj, #field : Str) * isNamedProperty(#field) *
+       Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * DataDescriptor (#g_aux_1)  ]]
+    [[ Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * desc_val (#g_aux_1, #desc_val) * (ret == #desc_val) ]]
     normal;
 
-    [[ (v == {{ "v", #obj, #field }}) * (! (#obj == $lg)) * ((#obj, #field) -> #value) * isNamedProperty(#field;) *
+    [[ (v == {{ "v", #obj, #field }}) * (! (#obj == $lg)) * ((#obj, #field) -> #value) * isNamedProperty(#field) *
        types (#obj : Obj, #field : Str) ]]
     [[ ((#obj, #field) -> #value) * (ret == #value) ]]
     normal;
 
-    [[ (v == {{ "v", $lg, #field }}) * types (#field : Str) * isNamedProperty(#field;) *
-       Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * DataDescriptor (#g_aux_1;)  ]]
-    [[ Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * desc_val (#g_aux_1, #desc_val;) * (ret == #desc_val) ]]
+    [[ (v == {{ "v", $lg, #field }}) * types (#field : Str) * isNamedProperty(#field) *
+       Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * DataDescriptor (#g_aux_1)  ]]
+    [[ Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * desc_val (#g_aux_1, #desc_val) * (ret == #desc_val) ]]
     normal;
 
-    [[ (v == {{ "o", #obj, #field }}) * types (#obj : Obj, #field : Str) * isNamedProperty(#field;) *
-       Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * (#g_aux_1 == undefined) ]]
-    [[ Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * (ret == undefined) ]]
+    [[ (v == {{ "o", #obj, #field }}) * types (#obj : Obj, #field : Str) * isNamedProperty(#field) *
+       Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * (#g_aux_1 == undefined) ]]
+    [[ Pi (#obj, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * (ret == undefined) ]]
     normal;
 
-    [[ (v == {{ "v", $lg, #field }}) * types (#field : Str) * isNamedProperty(#field;) *
-       Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * (#g_aux_1 == undefined) ]]
-    [[ Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) * (ret == undefined) ]]
+    [[ (v == {{ "v", $lg, #field }}) * types (#field : Str) * isNamedProperty(#field) *
+       Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * (#g_aux_1 == undefined) ]]
+    [[ Pi ($lg, #field, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) * (ret == undefined) ]]
     normal;
 
     [[ v == null ]]
@@ -1844,12 +1844,12 @@ spec i__getValue (v)
     [[ ret == undefined ]]
     normal;
 
-	[[ (v == {{ "o", undefined, #field }}) * types (#field : Str) * isNamedProperty(#field;) ]]
-    [[ isReferenceError(ret;) ]]
+	[[ (v == {{ "o", undefined, #field }}) * types (#field : Str) * isNamedProperty(#field) ]]
+    [[ isReferenceError(ret) ]]
     error;
 
-	[[ (v == {{ "v", undefined, #field }}) * types (#field : Str) * isNamedProperty(#field;) ]]
-    [[ isReferenceError(ret;) ]]
+	[[ (v == {{ "v", undefined, #field }}) * types (#field : Str) * isNamedProperty(#field) ]]
+    [[ isReferenceError(ret) ]]
     error
 
 proc i__getValue (v) {
@@ -1919,14 +1919,14 @@ spec hasProperty (l, prop)
 
 	[[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : List) *
-	   Pi (#l, #prop, #cls, undefined, #gp_aux_2, #gp_aux_3, #gp_aux_4;) ]]
-	[[ Pi (#l, #prop, #cls, undefined, #gp_aux_2, #gp_aux_3, #gp_aux_4;) * (ret == false) ]]
+	   Pi (#l, #prop, #cls, undefined, #gp_aux_2, #gp_aux_3, #gp_aux_4) ]]
+	[[ Pi (#l, #prop, #cls, undefined, #gp_aux_2, #gp_aux_3, #gp_aux_4) * (ret == false) ]]
 	normal;
 
 	[[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #cls : List, #desc : List) *
-	   Pi (#l, #prop, #cls, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4;) ]]
-	[[ Pi (#l, #prop, #cls, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4;) * (ret == true) ]]
+	   Pi (#l, #prop, #cls, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4) ]]
+	[[ Pi (#l, #prop, #cls, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4) * (ret == true) ]]
 	normal
 
 proc hasProperty (l, prop) {
@@ -1957,32 +1957,32 @@ spec deleteProperty (l, prop, thrw)
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #clsx : List) *
-	   Pi (#l, #prop, #clsx, undefined, {{ #l }}, #gp_aux_3, #gp_aux_4;) ]]
-	[[ Pi (#l, #prop, #clsx, undefined, #gp_aux_2, #gp_aux_3, #gp_aux_4;) * (ret == true) ]]
+	   Pi (#l, #prop, #clsx, undefined, {{ #l }}, #gp_aux_3, #gp_aux_4) ]]
+	[[ Pi (#l, #prop, #clsx, undefined, #gp_aux_2, #gp_aux_3, #gp_aux_4) * (ret == true) ]]
 	normal;
 
     [[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #clsx : List) *
-	   Pi (#l, #prop, #clsx, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4;) * (#gp_aux_2 == #l :: #lp :: #rest) * types (#lp : Obj, #rest : List) ]]
-	[[ Pi (#l, #prop, #clsx, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4;) * (ret == true) ]]
+	   Pi (#l, #prop, #clsx, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4) * (#gp_aux_2 == #l :: #lp :: #rest) * types (#lp : Obj, #rest : List) ]]
+	[[ Pi (#l, #prop, #clsx, #desc, #gp_aux_2, #gp_aux_3, #gp_aux_4) * (ret == true) ]]
 	normal;
 
 	[[ (l == #l) * (prop == #prop) *
 	   types (#l : Obj, #prop : Str, #clsx : List, #desc : List) *
-	   Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4;) * desc_conf(#desc, true;) ]]
-	[[ Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4;) * (ret == true) ]]
+	   Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4) * desc_conf(#desc, true) ]]
+	[[ Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4) * (ret == true) ]]
 	normal;
 
 	[[ (l == #l) * (prop == #prop) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #clsx : List, #desc : List) *
-	   Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4;) * desc_conf(#desc, false;) ]]
-	[[ Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4;) * (ret == false) ]]
+	   Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4) * desc_conf(#desc, false) ]]
+	[[ Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4) * (ret == false) ]]
 	normal;
 
 	[[ (l == #l) * (prop == #prop) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #clsx : List, #desc : List) *
-	   Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4;) * desc_conf(#desc, false;) ]]
-	[[ Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4;) * isTypeError(ret;) ]]
+	   Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4) * desc_conf(#desc, false) ]]
+	[[ Pi (#l, #prop, #clsx, #desc, {{ #l }}, #gp_aux_3, #gp_aux_4) * isTypeError(ret) ]]
 	error
 
 proc deleteProperty (l, prop, thrw) {
@@ -2017,9 +2017,9 @@ spec canPut (l, prop)
     (* 01 - Property not defined at all, rtrning "@extensible" *)
     [[ (l == #l) * (prop == #prop) *
 	   types(#ext : Bool) *
-	   Pi (#l, #prop, #g_aux_0, undefined, #g_aux_2, #g_aux_3, #g_aux_4;) *
+	   Pi (#l, #prop, #g_aux_0, undefined, #g_aux_2, #g_aux_3, #g_aux_4) *
        ((#l, "@extensible") -> #ext) ]]
-    [[ Pi (#l, #prop, #g_aux_0, undefined, #g_aux_2, #g_aux_3, #g_aux_4;) *
+    [[ Pi (#l, #prop, #g_aux_0, undefined, #g_aux_2, #g_aux_3, #g_aux_4) *
        ((#l, "@extensible") -> #ext) *
 	   (ret == #ext) ]]
     normal;
@@ -2027,35 +2027,35 @@ spec canPut (l, prop)
 	(* 02 - Property defined in the object itself, data descriptor, rtrning writable *)
 	[[ (l == #l) * (prop == #prop) *
 	   types(#writ : Bool) *
-	   Pi (#l, #prop, #g_aux_0, #g_aux_1, {{ #l }}, #g_aux_3, #g_aux_4;) * DataDescriptor(#g_aux_1;) * desc_writ(#g_aux_1, #writ;) ]]
-	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, {{ #l }}, #g_aux_3, #g_aux_4;) *
+	   Pi (#l, #prop, #g_aux_0, #g_aux_1, {{ #l }}, #g_aux_3, #g_aux_4) * DataDescriptor(#g_aux_1) * desc_writ(#g_aux_1, #writ) ]]
+	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, {{ #l }}, #g_aux_3, #g_aux_4) *
 	   (ret == #writ) ]]
 	normal;
 
 	(* 03 - Property defined as a data descriptor outside, but object not extensible, rtrn false *)
 	[[ (l == #l) * (prop == #prop) *
 	   types (#g_aux_2 : List, #l : Obj, #lp : Obj, #other : List) *
-       Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) *
-		   DataDescriptor(#g_aux_1;) * (#g_aux_2 == (#l :: #lp :: #other)) * ((#l, "@extensible") -> false) ]]
-	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) *
+       Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) *
+		   DataDescriptor(#g_aux_1) * (#g_aux_2 == (#l :: #lp :: #other)) * ((#l, "@extensible") -> false) ]]
+	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) *
 	   ((#l, "@extensible") -> false) * (ret == false) ]]
 	normal;
 
 	(* 04 - Property defined as a data descriptor outside, object extensible, rtrn writable *)
 	[[ (l == #l) * (prop == #prop) *
 	   types (#g_aux_2 : List, #l : Obj, #lp : Obj, #other : List, #writ : Bool) *
-	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) *
-	   DataDescriptor(#g_aux_1;) * desc_writ(#g_aux_1, #writ;) * (#g_aux_2 == (#l :: #lp :: #other)) *
+	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) *
+	   DataDescriptor(#g_aux_1) * desc_writ(#g_aux_1, #writ) * (#g_aux_2 == (#l :: #lp :: #other)) *
 	   ((#l, "@extensible") -> true) ]]
-	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) *
+	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) *
 	   ((#l, "@extensible") -> true) * (ret == #writ) ]]
 	normal;
 
 	(* 05 - Property defined as an accessor descriptor, rtrn (setter <> undefined) *)
 	[[ (l == #l) * (prop == #prop) *
-	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) *
-	   AccessorDescriptor(#g_aux_1;) * desc_set(#g_aux_1, #set;) ]]
-	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4;) *
+	   Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) *
+	   AccessorDescriptor(#g_aux_1) * desc_set(#g_aux_1, #set) ]]
+	[[ Pi (#l, #prop, #g_aux_0, #g_aux_1, #g_aux_2, #g_aux_3, #g_aux_4) *
 	   (ret == (not (#set = undefined))) ]]
 	normal
 
@@ -2120,21 +2120,21 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, none;) * ((#l, "@extensible") -> false) *
-	   isTypeError(err;) ]]
+	   Cell_o (#l, #prop, none) * ((#l, "@extensible") -> false) *
+	   isTypeError(err) ]]
     error;
 
     (* 02 - Current is undefined, object is not extensible, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, none;) * ((#l, "@extensible") -> false) *
+	   Cell_o (#l, #prop, none) * ((#l, "@extensible") -> false) *
 	   (ret == false) ]]
     normal;
 
@@ -2142,21 +2142,21 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;) *
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "none", none, #pv;) * ((#l, "@extensible") -> false) *
-	   isTypeError(err;) ]]
+	   Cell_s (#l, #prop, "none", none, #pv) * ((#l, "@extensible") -> false) *
+	   isTypeError(err) ]]
     error;
 
     (* 04 - Current is undefined, object is not extensible, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;) *
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "none", none, #pv;) * ((#l, "@extensible") -> false) *
+	   Cell_s (#l, #prop, "none", none, #pv) * ((#l, "@extensible") -> false) *
 	   (ret == false) ]]
     normal;
 
@@ -2164,11 +2164,11 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
-	   DataDescriptor (#desc;) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
+	   DataDescriptor (#desc) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> true) *
+	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
@@ -2176,11 +2176,11 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
-	   AccessorDescriptor (#desc;) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
+	   AccessorDescriptor (#desc) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> true) *
+	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
@@ -2188,11 +2188,11 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;) *
-	   DataDescriptor (#desc;) *
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv) *
+	   DataDescriptor (#desc) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> true) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
@@ -2200,59 +2200,59 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;)  *
-	   AccessorDescriptor (#desc;) *
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv)  *
+	   AccessorDescriptor (#desc) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> true) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
 	(* 09 - Current is defined, configurable is true, data descriptor, non-string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       DataDescriptor(#desc;) * desc_conf(#dcur, true;) *
+       DataDescriptor(#desc) * desc_conf(#dcur, true) *
        ((#l, "@class") -> #cls) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> #ext) *
+	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
 	(* 10 - Current is defined, configurable is true, accessor descriptor, non-string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       AccessorDescriptor(#desc;) * desc_conf(#dcur, true;) *
+       AccessorDescriptor(#desc) * desc_conf(#dcur, true) *
        ((#l, "@class") -> #cls) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> #ext) *
+	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
 	(* 11 - Current is defined, configurable is true, data descriptor, string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       DataDescriptor(#desc;) * desc_conf(#dcur, true;) *
+       DataDescriptor(#desc) * desc_conf(#dcur, true) *
        ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> #ext) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
 	(* 12 - Current is defined, configurable is true, accessor descriptor, string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       AccessorDescriptor(#desc;) * desc_conf(#dcur, true;) *
+       AccessorDescriptor(#desc) * desc_conf(#dcur, true) *
        ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> #ext) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
@@ -2260,11 +2260,11 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
        (#desc == {{ "g", empty, empty, #gval, empty, empty, empty }}) * (! (#gval == empty)) *
-	   DataDescriptor(#dcur;) * desc_writ(#dcur, true;) * desc_enum(#dcur, #dec;) * desc_conf(#dcur, #dcc;) *
+	   DataDescriptor(#dcur) * desc_writ(#dcur, true) * desc_enum(#dcur, #dec) * desc_conf(#dcur, #dcc) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, {{ "d", #gval, true, #dec, #dcc }};) *
+	   Cell_o (#l, #prop, {{ "d", #gval, true, #dec, #dcc }}) *
 	   (ret == true) ]]
 	normal;
 
@@ -2272,77 +2272,77 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
        (#desc == {{ "g", empty, empty, #gval, empty, empty, empty }}) * (! (#gval == empty)) *
-	   DataDescriptor(#dcur;) * desc_writ(#dcur, true;) * desc_enum(#dcur, #dec;) * desc_conf(#dcur, #dcc;) *
+	   DataDescriptor(#dcur) * desc_writ(#dcur, true) * desc_enum(#dcur, #dec) * desc_conf(#dcur, #dcc) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", {{ "d", #gval, true, #dec, #dcc }}, #pv;) *
+	   Cell_s (#l, #prop, "NSI", {{ "d", #gval, true, #dec, #dcc }}, #pv) *
 	   (ret == true) ]]
 	normal;
 
 	(* 15 - Current is defined, configurable is false, descriptor, configurable is true, non-string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) *
-	   isTypeError(err;) ]]
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 16 - Current is defined, configurable is false, descriptor, configurable is true, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur;) *
+	   Cell_o (#l, #prop, #dcur) *
 	   (ret == false) ]]
 	normal;
 
 	(* 17 - Current is defined, configurable is false, descriptor, configurable is true, string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, true;) *
+       Descriptor(#desc) * desc_conf(#desc, true) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
-	   isTypeError(err;) ]]
+	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 18 - Current is defined, configurable is false, descriptor, configurable is true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, true;) *
+       Descriptor(#desc) * desc_conf(#desc, true) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
+	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
 	   (ret == false) ]]
 	normal;
 
 	(* 19 - Current is defined, configurable is false, descriptor, configurable is true, string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
-	   isTypeError(err;) ]]
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 20 - Current is defined, configurable is false, descriptor, configurable is true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
 	   (ret == false) ]]
 	normal;
 
@@ -2350,27 +2350,27 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, false;) *
-       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
+       Descriptor(#desc) * desc_conf(#desc, false) *
+       Descriptor(#dcur) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur;) *
-	   isTypeError(err;) ]]
+	   Cell_o (#l, #prop, #dcur) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 22 - Current is defined, configurable is false, descriptor, configurable is false, enumerables are different, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, false;) *
-       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
+       Descriptor(#desc) * desc_conf(#desc, false) *
+       Descriptor(#dcur) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur;) *
+	   Cell_o (#l, #prop, #dcur) *
 	   (ret == false) ]]
 	normal;
 
@@ -2378,23 +2378,23 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, false;) *
+       Descriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
-	   isTypeError(err;) ]]
+	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 24 - Current is defined, configurable is false, descriptor, configurable is false, enumerables are different, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, false;) *
+       Descriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;)  ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv)  ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv;)  *
+	   Cell_s (#l, #prop, "SI", #dcur, #pv)  *
 	   (ret == false) ]]
 	normal;
 
@@ -2402,27 +2402,27 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, false;) *
-       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
+       Descriptor(#desc) * desc_conf(#desc, false) *
+       Descriptor(#dcur) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
-	   isTypeError(err;) ]]
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 26 - Current is defined, configurable is false, descriptor, configurable is false, enumerables are different, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, false;) *
-       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
+       Descriptor(#desc) * desc_conf(#desc, false) *
+       Descriptor(#dcur) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;)  ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv)  ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv;)  *
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv)  *
 	   (ret == false) ]]
 	normal;
 
@@ -2430,29 +2430,29 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
-       desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
-	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
+       DataDescriptor(#desc) * DataDescriptor(#dcur) *
+       desc_conf(#desc, false) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
+	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur;) *
-	   isTypeError(err;) ]]
+	   Cell_o (#l, #prop, #dcur) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 28 - Current is defined, configurables are false, enumerables are same, writables false and true, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
-	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
-	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
+       DataDescriptor(#desc) * DataDescriptor(#dcur) *
+	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
+	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur;) *
+	   Cell_o (#l, #prop, #dcur) *
 	   (ret == false) ]]
 	normal;
 
@@ -2460,23 +2460,23 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, true;) * desc_writ(#desc, true;) *
+       DataDescriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, true) * desc_writ(#desc, true) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
-	   isTypeError(err;) ]]
+	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 30 - Current is defined, configurables are false, enumerables are same, writables false and true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, true;) * desc_writ(#desc, true;) *
+       DataDescriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, true) * desc_writ(#desc, true) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
+	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
 	   (ret == false) ]]
 	normal;
 
@@ -2484,29 +2484,29 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
-       desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
-	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
+       DataDescriptor(#desc) * DataDescriptor(#dcur) *
+       desc_conf(#desc, false) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
+	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
-	   isTypeError(err;) ]]
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 32 - Current is defined, configurables are false, enumerables are same, writables false and true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
-	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
-	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
+       DataDescriptor(#desc) * DataDescriptor(#dcur) *
+	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
+	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
 	   (ret == false) ]]
 	normal;
 
@@ -2514,14 +2514,14 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
-	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
-	   desc_writ(#dcur, true;) *
+       DataDescriptor(#desc) * DataDescriptor(#dcur) *
+	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
+	   desc_writ(#dcur, true) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #desc;) *
+	   Cell_o (#l, #prop, #desc) *
 	   (ret == true) ]]
 	normal;
 
@@ -2529,14 +2529,14 @@ spec o__defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
-	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
-	   desc_writ(#dcur, true;) *
+       DataDescriptor(#desc) * DataDescriptor(#dcur) *
+	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
+	   desc_writ(#dcur, true) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv;) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv) *
 	   (ret == true) ]]
 	normal
 
@@ -2742,22 +2742,22 @@ spec defineOwnProperty (l, prop, desc, thrw)
     (* 01 - Current is undefined, object is not extensible, non-string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
-	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
+	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, none;) * ((#l, "@extensible") -> false) *
-	   isTypeError(err;) ]]
+	   Cell_o (#l, #prop, none) * ((#l, "@extensible") -> false) *
+	   isTypeError(err) ]]
     error;
 
     (* 02 - Current is undefined, object is not extensible, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
-	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
+	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, none;) * ((#l, "@extensible") -> false) *
+	   Cell_o (#l, #prop, none) * ((#l, "@extensible") -> false) *
 	   (ret == false) ]]
     normal;
 
@@ -2765,45 +2765,45 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;) *
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "none", none, #pv;) * ((#l, "@extensible") -> false) *
-	   isTypeError(err;) ]]
+	   Cell_s (#l, #prop, "none", none, #pv) * ((#l, "@extensible") -> false) *
+	   isTypeError(err) ]]
     error;
 
     (* 04 - Current is undefined, object is not extensible, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;) *
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv) *
 	   ((#l, "@extensible") -> false) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "none", none, #pv;) * ((#l, "@extensible") -> false) *
+	   Cell_s (#l, #prop, "none", none, #pv) * ((#l, "@extensible") -> false) *
 	   (ret == false) ]]
     normal;
 
 	(* 05 - Current is undefined, object is extensible, non-string, data descriptor, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
-	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
-	   DataDescriptor (#desc;) *
+	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
+	   DataDescriptor (#desc) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> true) *
+	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
     (* 06 - Current is undefined, object is extensible, non-string, accessor descriptor, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
-	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, none;) *
-	   AccessorDescriptor (#desc;) *
+	   ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, none) *
+	   AccessorDescriptor (#desc) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> true) *
+	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
@@ -2811,11 +2811,11 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;) *
-	   DataDescriptor (#desc;) *
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv) *
+	   DataDescriptor (#desc) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> true) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
@@ -2823,59 +2823,59 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #thrw : Bool) *
 	   ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "none", none, #pv;)  *
-	   AccessorDescriptor (#desc;) *
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "none", none, #pv)  *
+	   AccessorDescriptor (#desc) *
 	   ((#l, "@extensible") -> true) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> true) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> true) *
 	   (ret == true) ]]
     normal;
 
 	(* 09 - Current is defined, configurable is true, data descriptor, non-string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       DataDescriptor(#desc;) * desc_conf(#dcur, true;) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) *
+       DataDescriptor(#desc) * desc_conf(#dcur, true) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> #ext) *
+	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
 	(* 10 - Current is defined, configurable is true, accessor descriptor, non-string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       AccessorDescriptor(#desc;) * desc_conf(#dcur, true;) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) *
+       AccessorDescriptor(#desc) * desc_conf(#dcur, true) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_o (#l, #prop, #desc;) * ((#l, "@extensible") -> #ext) *
+	   Cell_o (#l, #prop, #desc) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
 	(* 11 - Current is defined, configurable is true, data descriptor, string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       DataDescriptor(#desc;) * desc_conf(#dcur, true;) *
+       DataDescriptor(#desc) * desc_conf(#dcur, true) *
        ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> #ext) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
 	(* 12 - Current is defined, configurable is true, accessor descriptor, string, success *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #cls : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       AccessorDescriptor(#desc;) * desc_conf(#dcur, true;) *
+       AccessorDescriptor(#desc) * desc_conf(#dcur, true) *
        ((#l, "@class") -> #cls) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) *
 	   ((#l, "@extensible") -> #ext) ]]
     [[ ((#l, "@class") -> #cls) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv;) * ((#l, "@extensible") -> #ext) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv) * ((#l, "@extensible") -> #ext) *
 	   (ret == true) ]]
     normal;
 
@@ -2883,11 +2883,11 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
        (#desc == {{ "g", empty, empty, #gval, empty, empty, empty }}) * (! (#gval == empty)) *
-	   DataDescriptor(#dcur;) * desc_writ(#dcur, true;) * desc_enum(#dcur, #dec;) * desc_conf(#dcur, #dcc;) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
-    [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) * isClass(#cls, "Non-String";) *
-	   Cell_o (#l, #prop, {{ "d", #gval, true, #dec, #dcc }};) *
+	   DataDescriptor(#dcur) * desc_writ(#dcur, true) * desc_enum(#dcur, #dec) * desc_conf(#dcur, #dcc) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
+    [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) * isClass(#cls, "Non-String") *
+	   Cell_o (#l, #prop, {{ "d", #gval, true, #dec, #dcc }}) *
 	   (ret == true) ]]
 	normal;
 
@@ -2895,77 +2895,77 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == #thrw) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
        (#desc == {{ "g", empty, empty, #gval, empty, empty, empty }}) * (! (#gval == empty)) *
-	   DataDescriptor(#dcur;) * desc_writ(#dcur, true;) * desc_enum(#dcur, #dec;) * desc_conf(#dcur, #dcc;) *
+	   DataDescriptor(#dcur) * desc_writ(#dcur, true) * desc_enum(#dcur, #dec) * desc_conf(#dcur, #dcc) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", {{ "d", #gval, true, #dec, #dcc }}, #pv;) *
+	   Cell_s (#l, #prop, "NSI", {{ "d", #gval, true, #dec, #dcc }}, #pv) *
 	   (ret == true) ]]
 	normal;
 
 	(* 15 - Current is defined, configurable is false, descriptor, configurable is true, non-string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur;) *
-	   isTypeError(err;) ]]
+	   Cell_o (#l, #prop, #dcur) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 16 - Current is defined, configurable is false, descriptor, configurable is true, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur;) *
+	   Cell_o (#l, #prop, #dcur) *
 	   (ret == false) ]]
 	normal;
 
 	(* 17 - Current is defined, configurable is false, descriptor, configurable is true, string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, true;) *
+       Descriptor(#desc) * desc_conf(#desc, true) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
-	   isTypeError(err;) ]]
+	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 18 - Current is defined, configurable is false, descriptor, configurable is true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, true;) *
+       Descriptor(#desc) * desc_conf(#desc, true) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
+	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
 	   (ret == false) ]]
 	normal;
 
 	(* 19 - Current is defined, configurable is false, descriptor, configurable is true, string, thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
-	   isTypeError(err;) ]]
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 20 - Current is defined, configurable is false, descriptor, configurable is true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, true;) * Descriptor(#dcur;) * desc_conf(#dcur, false;) *
+       Descriptor(#desc) * desc_conf(#desc, true) * Descriptor(#dcur) * desc_conf(#dcur, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
 	   (ret == false) ]]
 	normal;
 
@@ -2973,27 +2973,27 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, false;) *
-       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+       Descriptor(#desc) * desc_conf(#desc, false) *
+       Descriptor(#dcur) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur;) *
-	   isTypeError(err;) ]]
+	   Cell_o (#l, #prop, #dcur) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 22 - Current is defined, configurable is false, descriptor, configurable is false, enumerables are different, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, false;) *
-       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+       Descriptor(#desc) * desc_conf(#desc, false) *
+       Descriptor(#dcur) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur;) *
+	   Cell_o (#l, #prop, #dcur) *
 	   (ret == false) ]]
 	normal;
 
@@ -3001,23 +3001,23 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, false;) *
+       Descriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) *
-	   isTypeError(err;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 24 - Current is defined, configurable is false, descriptor, configurable is false, enumerables are different, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, false;) *
+       Descriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;)  ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv)  ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv;)  *
+	   Cell_s (#l, #prop, "SI", #dcur, #pv)  *
 	   (ret == false) ]]
 	normal;
 
@@ -3025,27 +3025,27 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, false;) *
-       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
+       Descriptor(#desc) * desc_conf(#desc, false) *
+       Descriptor(#dcur) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
-	   isTypeError(err;) ]]
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 26 - Current is defined, configurable is false, descriptor, configurable is false, enumerables are different, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#ed : Bool, #ec : Bool) *
-       Descriptor(#desc;) * desc_conf(#desc, false;) *
-       Descriptor(#dcur;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #ed;) * desc_enum(#dcur, #ec;) * (! (#ed == #ec)) *
+       Descriptor(#desc) * desc_conf(#desc, false) *
+       Descriptor(#dcur) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #ed) * desc_enum(#dcur, #ec) * (! (#ed == #ec)) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;)  ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv)  ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv;)  *
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv)  *
 	   (ret == false) ]]
 	normal;
 
@@ -3053,29 +3053,29 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
-       desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
-	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+       DataDescriptor(#desc) * DataDescriptor(#dcur) *
+       desc_conf(#desc, false) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
+	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur;) *
-	   isTypeError(err;) ]]
+	   Cell_o (#l, #prop, #dcur) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 28 - Current is defined, configurables are false, enumerables are same, writables false and true, non-string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
-	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
-	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+       DataDescriptor(#desc) * DataDescriptor(#dcur) *
+	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
+	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #dcur;) *
+	   Cell_o (#l, #prop, #dcur) *
 	   (ret == false) ]]
 	normal;
 
@@ -3083,23 +3083,23 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, true;) * desc_writ(#desc, true;) *
+       DataDescriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, true) * desc_writ(#desc, true) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
-	   isTypeError(err;) ]]
+	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 30 - Current is defined, configurables are false, enumerables are same, writables false and true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * desc_conf(#desc, false;) * desc_enum(#desc, true;) * desc_writ(#desc, true;) *
+       DataDescriptor(#desc) * desc_conf(#desc, false) * desc_enum(#desc, true) * desc_writ(#desc, true) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "SI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "SI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "SI", #dcur, #pv;) *
+	   Cell_s (#l, #prop, "SI", #dcur, #pv) *
 	   (ret == false) ]]
 	normal;
 
@@ -3107,29 +3107,29 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == true) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
-       desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
-	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
+       DataDescriptor(#desc) * DataDescriptor(#dcur) *
+       desc_conf(#desc, false) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
+	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
-	   isTypeError(err;) ]]
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
+	   isTypeError(err) ]]
 	error;
 
 	(* 32 - Current is defined, configurables are false, enumerables are same, writables false and true, string, don't thrw *)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) * (thrw == false) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
-	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
-	   desc_writ(#desc, true;) * desc_writ(#dcur, false;) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+       DataDescriptor(#desc) * DataDescriptor(#dcur) *
+	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
+	   desc_writ(#desc, true) * desc_writ(#dcur, false) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #dcur, #pv;) *
+	   Cell_s (#l, #prop, "NSI", #dcur, #pv) *
 	   (ret == false) ]]
 	normal;
 
@@ -3137,14 +3137,14 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
-	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
-	   desc_writ(#dcur, true;) *
-       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array";) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "Non-String";) * Cell_o (#l, #prop, #dcur;) ]]
+       DataDescriptor(#desc) * DataDescriptor(#dcur) *
+	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
+	   desc_writ(#dcur, true) *
+       ((#l, "@class") -> #cls) * isClass(#cls, "Non-Array") * ((#l, "@extensible") -> #ext) *
+	   isClass(#cls, "Non-String") * Cell_o (#l, #prop, #dcur) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_o (#l, #prop, #desc;) *
+	   Cell_o (#l, #prop, #desc) *
 	   (ret == true) ]]
 	normal;
 
@@ -3152,14 +3152,14 @@ spec defineOwnProperty (l, prop, desc, thrw)
     [[ (l == #l) * (prop == #prop) * (desc == #desc) *
 	   types (#l : Obj, #prop : Str, #desc : List, #dcur : List, #thrw : Bool, #ext : Bool, #thrw : Bool) *
 	   types (#enum : Bool) *
-       DataDescriptor(#desc;) * DataDescriptor(#dcur;) *
-	   desc_conf(#desc, false;) * desc_conf(#dcur, false;) *
-	   desc_enum(#desc, #enum;) * desc_enum(#dcur, #enum;) *
-	   desc_writ(#dcur, true;) *
+       DataDescriptor(#desc) * DataDescriptor(#dcur) *
+	   desc_conf(#desc, false) * desc_conf(#dcur, false) *
+	   desc_enum(#desc, #enum) * desc_enum(#dcur, #enum) *
+	   desc_writ(#dcur, true) *
        ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   isClass(#cls, "String";) * Cell_s (#l, #prop, "NSI", #dcur, #pv;) ]]
+	   isClass(#cls, "String") * Cell_s (#l, #prop, "NSI", #dcur, #pv) ]]
     [[ ((#l, "@class") -> #cls) * ((#l, "@extensible") -> #ext) *
-	   Cell_s (#l, #prop, "NSI", #desc, #pv;) *
+	   Cell_s (#l, #prop, "NSI", #desc, #pv) *
 	   (ret == true) ]]
 	normal
 

--- a/Gillian-JS/runtime/JSLogic/internal_functions_full.jsil
+++ b/Gillian-JS/runtime/JSLogic/internal_functions_full.jsil
@@ -8,7 +8,7 @@
  * Resource: none
  *
  *)
-pred isInternalProperty (prop) :
+pred isInternalProperty (prop;) :
     types (prop : Str) * (! (prop == "")) * (s-nth (prop, 0) == "@");
 
 (*
@@ -17,7 +17,7 @@ pred isInternalProperty (prop) :
  * Resource: none
  *
  *)
-pred isNamedProperty (prop) :
+pred isNamedProperty (prop;) :
     types (prop : Str) * (! (prop == "")) * (! (s-nth (prop, 0) == "@"));
 
 (*
@@ -26,7 +26,7 @@ pred isNamedProperty (prop) :
  * Resource: none
  *
  *)
-pred DataDescriptor (d) :
+pred DataDescriptor (d;) :
     types (d : List, #dwrit : Bool, #denum : Bool, #dconf : Bool) *
     (! (#dval == empty)) * (d == {{ "d", #dval, #dwrit, #denum, #dconf }});
 
@@ -36,7 +36,7 @@ pred DataDescriptor (d) :
  * Resource: none
  *
  *)
-pred AccessorDescriptor (d) :
+pred AccessorDescriptor (d;) :
     types (d : List, #denum : Bool, #dconf : Bool) *
     (! (#dget == empty)) * (! (#dset == empty)) *
     (d == {{ "a", #dget, #dset, #denum, #dconf }});
@@ -47,7 +47,7 @@ pred AccessorDescriptor (d) :
  * Resource: none
  *
  *)
-pred Descriptor (d) :
+pred Descriptor (d;) :
     DataDescriptor (d),
     AccessorDescriptor (d);
 
@@ -57,7 +57,7 @@ pred Descriptor (d) :
  * Resource: none
  *
  *)
-pred GenericDescriptor (d) :
+pred GenericDescriptor (d;) :
     types (d : List) * (d == {{ "g", #genum, #gconf, #gval, #gwrit, #gget, #gset }});
 
 (*
@@ -66,22 +66,22 @@ pred GenericDescriptor (d) :
  * Resource: none
  *
  *)
-pred desc_val (d, v) :
+pred desc_val (d, v;) :
     types (d : List) * v == l-nth(d, 1);
 
-pred desc_writ (d, v) :
+pred desc_writ (d, v;) :
     types (d : List) * v == l-nth(d, 2);
 
-pred desc_get (d, v) :
+pred desc_get (d, v;) :
     types (d : List) * v == l-nth(d, 1);
 
-pred desc_set (d, v) :
+pred desc_set (d, v;) :
     types (d : List) * v == l-nth(d, 2);
 
-pred desc_enum (d, v) :
+pred desc_enum (d, v;) :
     types (d : List) * v == l-nth(d, 3);
 
-pred desc_conf (d, v) :
+pred desc_conf (d, v;) :
     types (d : List) * v == l-nth(d, 4);
 
 (*
@@ -92,10 +92,10 @@ pred desc_conf (d, v) :
  *
  * Note: We are not allowing accessor descriptors in the heap yet
  *)
-pred Cell_o (l, prop, none) :
+pred Cell_o (l, prop, none;) :
     types(l : Obj) * isNamedProperty(prop) * ((l, prop) -> none);
 
-pred Cell_o (l, prop, d) :
+pred Cell_o (l, prop, d;) :
     types(l : Obj) * isNamedProperty(prop) * ((l, prop) -> d) * Descriptor(d);
 
 (*
@@ -104,7 +104,7 @@ pred Cell_o (l, prop, d) :
  * Resource: none
  *
  *)
-pred IsStringIndex(S, prop, i) :
+pred IsStringIndex(S, prop, i;) :
     types(S : Str, prop : Str, i : Num) *
     (prop == num_to_string i) * (0 <=# i) * (i <# s-len S);
 
@@ -119,18 +119,18 @@ pred IsStringIndex(S, prop, i) :
  *       otherwise (l, "@primitiveValue") WILL NOT EXIST OR BE STUPID
  *
  *)
-pred Cell_s (l, prop, "none", none, pv) :
+pred Cell_s (l, prop, "none", none, pv;) :
      types (l : Obj, prop : Str, pv : Str) *
 	 Cell_o (l, prop, none) * ((l, "@primitiveValue") -> pv) *
      (#i == num_to_int (string_to_num prop)) * (! IsStringIndex(pv, prop, #i));
 
-pred Cell_s (l, prop, "SI", desc, pv) :
+pred Cell_s (l, prop, "SI", desc, pv;) :
      types(l : Obj, #prop : Str, desc : List, pv : Str, #i : Num, #v : Str) *
 	 (prop == #prop) * Cell_o (l, #prop, none) * ((l, "@primitiveValue") -> pv) *
      (desc == {{ "d", #v, false, true, false }}) *  (#v == s-nth(pv, #i)) *
 	 (#i == num_to_int (string_to_num #prop)) * IsStringIndex(pv, #prop, #i);
 
-pred Cell_s (l, prop, "NSI", desc, pv) :
+pred Cell_s (l, prop, "NSI", desc, pv;) :
 	 types (l : Obj, prop : Str, desc : List, pv : Str, #i : Num) *
 	 Cell_o (l, prop, desc) * ((l, "@primitiveValue") -> pv) *
 	 (#i == num_to_int (string_to_num prop)) * (! IsStringIndex(pv, prop, #i)) *
@@ -144,17 +144,17 @@ pred Cell_s (l, prop, "NSI", desc, pv) :
  *
  *)
 
-pred ErrorObject (l, pr) :
+pred ErrorObject (l, pr;) :
 	types (l : Obj, pr : Obj) *
 	((l, "@proto") -> pr) * ((l, "@class") -> "Error") * ((l, "@extensible") -> true) * empty_fields(l : "@proto", "@class", "@extensible");
 
-pred isTypeError(l) :
+pred isTypeError(l;) :
     ErrorObject (l, $lterr_proto);
 
-pred isSyntaxError(l) :
+pred isSyntaxError(l;) :
     ErrorObject (l, $lserr_proto);
 
-pred isReferenceError(l) :
+pred isReferenceError(l;) :
     ErrorObject (l, $lrferr_proto);
 
 (*
@@ -164,10 +164,10 @@ pred isReferenceError(l) :
  *      (l, "@class")
  *
  *)
-pred isClass (c, "Array")      : types (c : Str) * (c == "Array");
-pred isClass (c, "String")     : types (c : Str) * (c == "String");
-pred isClass (c, "Non-String") : types (c : Str) * (! (c == "String"));
-pred isClass (c, "Non-Array")  : types (c : Str) * (! (c == "Array"));
+pred isClass (c, "Array";)      : types (c : Str) * (c == "Array");
+pred isClass (c, "String";)     : types (c : Str) * (c == "String");
+pred isClass (c, "Non-String";) : types (c : Str) * (! (c == "String"));
+pred isClass (c, "Non-Array";)  : types (c : Str) * (! (c == "Array"));
 
 (*
  * The PI predicate
@@ -178,7 +178,7 @@ pred isClass (c, "Non-Array")  : types (c : Str) * (! (c == "Array"));
  *		(l, "@class")   via isClass
  *		(l, "@proto")	(l, "prop")
  *)
-pred Pi (l, prop, lcls, undefined, ls, ltf, lpv) :
+pred Pi (l, prop, lcls, undefined, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, ls : List, ltf : List, lpv : List) *
 	((l, "@proto") -> null) * ((l, "@class") -> #cls) *
 	isClass (#cls, "Non-String") * Cell_o (l, prop, none) *
@@ -189,7 +189,7 @@ pred Pi (l, prop, lcls, undefined, ls, ltf, lpv) :
  *		(l, "@class")   via isClass
  *		(l, "@proto")	(l, "prop")
  *)
-pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
+pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, d : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) *
 	isClass (#cls, "Non-String") * Cell_o (l, prop, d) * (! (d == none)) *
@@ -203,7 +203,7 @@ pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
  *		Those five fields captured throughout the chain
  *)
 
-pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
+pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, lcls : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) * ((l, "@proto") -> #lp) *
 	isClass (#cls, "Non-String") * Cell_o (l, prop, none) *
@@ -221,7 +221,7 @@ pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
  *		(l, "@class")   via isClass
  *		(l, "@proto")	(l, "prop")		(l, "@primitiveValue")
  *)
-pred Pi (l, prop, lcls, undefined, ls, ltf, lpv) :
+pred Pi (l, prop, lcls, undefined, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, ls : List, ltf : List, lpv : List) *
 	((l, "@proto") -> null) * ((l, "@class") -> #cls) *
     isClass (#cls, "String") * Cell_s (l, prop, "none", none, #pv) *
@@ -232,7 +232,7 @@ pred Pi (l, prop, lcls, undefined, ls, ltf, lpv) :
  *		(l, "@class")   via isClass
  *		(l, "@proto")	(l, "prop")		(l, "@primitiveValue")
  *)
-pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
+pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, d : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) *
 	isClass (#cls, "String") * Cell_s (l, prop, "SI", d, #pv) *
@@ -243,7 +243,7 @@ pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
  *		(l, "@class")   via isClass
  *		(l, "@proto")	(l, "prop")		(l, "@primitiveValue")
  *)
-pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
+pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, #cls : Str, lcls : List, d : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) *
 	isClass (#cls, "String") * Cell_s (l, prop, "NSI", d, #pv) *
@@ -256,7 +256,7 @@ pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
  *
  *		Those five fields captured throughout the chain
  *)
-pred Pi (l, prop, lcls, d, ls, ltf, lpv) :
+pred Pi (l, prop, lcls, d, ls, ltf, lpv;) :
     types(l : Obj, prop : Str, lcls : List, ls : List, ltf : List, lpv : List) *
 	((l, "@class") -> #cls) * ((l, "@proto") -> #lp) *
 	isClass (#cls, "String") * Cell_s (l, prop, "none", none, #pv) *
@@ -364,7 +364,7 @@ proc create_object_with_call_construct (l, call, construct, len) {
 	rlab:	ret := l
 };
 
-pred function_object (l, xsc, call, construct, len, prototype) :
+pred function_object (l, xsc, call, construct, len, prototype;) :
 	types(l : Obj, xsc : List, call : Str, construct: Str, len : Num, prototype : Obj) *
 	((l, "@proto") -> $lfun_proto) * ((l, "@class") -> "Function") * ((l, "@extensible") -> true) *
 	((l, "@scope") -> xsc)  * ((l, "length") -> {{ "d", len, false, false, false }}) *
@@ -598,13 +598,13 @@ proc SyntaxError (v) {
    *** *** ***   INITIAL HEAP   *** *** ***
    **************************************** *)
 
-pred initialHeapPre () :
+pred initialHeapPre (;) :
     (($lg,      "@class") -> none) *
     (($lg, 	    "@proto") -> none) *
     (($lg, "@extensible") -> none) *
     empty_fields ( $lobj_proto : ) * empty_fields ($lfun_proto : ) * empty_fields ($lerr : ) * empty_fields ($lerr_proto : );
 
-pred initialHeapPost () :
+pred initialHeapPost (;) :
     (($lg,         "@class") -> "Object")   * (($lg,         "@proto") -> $lobj_proto) * (($lg,         "@extensible") -> true) * (($lg,         "Error") -> {{ "d", $lerr, true, false, true }}) *
 	(($lobj_proto, "@class") -> "Object")   * (($lobj_proto, "@proto") -> null)      * (($lobj_proto, "@extensible") -> true) * empty_fields ( $lobj_proto : "@class", "@proto", "@extensible" ) *
 	(($lfun_proto, "@class") -> "Function") * (($lfun_proto, "@proto") -> $lobj_proto) * (($lfun_proto, "@extensible") -> true) *

--- a/Gillian-JS/runtime/JSLogic/javert_internal_functions.jsil
+++ b/Gillian-JS/runtime/JSLogic/javert_internal_functions.jsil
@@ -46,7 +46,7 @@ pred JSFunctionObject (l:Obj; fid:Str, sc:List, len:Num, proto:Obj) :
   empty_fields(#md : -{ "@call", "@class", "@construct", "@extensible", "@proto", "@scope" }-);
 
 pred JSFunctionObjectStrong (l:Obj; fid:Str, sc:List, len:Num, proto:Obj) :
-  JSFunctionObject (l, fid, sc, len, proto) *
+  JSFunctionObject (l; fid, sc, len, proto) *
   empty_fields(l : -{ "arguments", "caller", "length", "prototype" }-);
 
 pred JSBIFunction (l:Obj; fid:Str, len:Num) :
@@ -76,16 +76,16 @@ pred BIFunctionObject (l:Obj; len:Num, proto:Obj, call, construct) :
  **************************)
 
 pred JSInternals (;) :
-    GlobalObject () *
-    ObjectPrototype($lobj_proto) *
-    FunctionPrototype($lfun_proto) *
-    ArrayPrototype ($larr_proto) *
-    ArrayBufferPrototype ($lab_proto) *
-    BI_ErrorObject () *
-    BI_ObjectObject () *
-    BI_DataViewObject () *
-    DataViewPrototype($ldv_proto) *
-    Uint8ArrayPrototype($lui8ar_proto);
+    GlobalObject (;) *
+    ObjectPrototype($lobj_proto;) *
+    FunctionPrototype($lfun_proto;) *
+    ArrayPrototype ($larr_proto;) *
+    ArrayBufferPrototype ($lab_proto;) *
+    BI_ErrorObject (;) *
+    BI_ObjectObject (;) *
+    BI_DataViewObject (;) *
+    DataViewPrototype($ldv_proto;) *
+    Uint8ArrayPrototype($lui8ar_proto;);
 
 pred BooleanObject (l:Obj; b:Bool) :
   MetaData(l, #md) * MetaData(#md, null) *
@@ -122,7 +122,7 @@ pred NumberPrototype (;) :
   empty_fields (#npmd : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
 pred GlobalObject (;) :
-  JSObject ($lg) *
+  JSObject ($lg;) *
   (($lg, "Error") -> {{ "d", $lerr, true, false, true }}) *
   (($lg, "Object") -> {{ "d", $lobj, true, false, true }}) *
   (($lg, "DataView") -> {{ "d", $ldv, true, false, true }}) *
@@ -132,23 +132,23 @@ pred GlobalVar (v; val) :
   (($lg, v) -> {{ "d", val, true, true, false }}) * types(v : Str);
 
 pred BI_ObjectObject (;) :
-  BIFunctionObject ($lobj, 0, $lobj_proto, "Object_call", "Object_construct") *
-  DataPropGen($lobj, "create", $lobj_create, true, false, true) *
-  DataPropGen($lobj, "freeze", $lobj_freeze, true, false, true) *
-  JSBIFunction($lobj_create, "Object_create", 2) * empty_fields($lobj_create : -{ "length" }-) *
-  JSBIFunction($lobj_freeze, "Object_freeze", 2) * empty_fields($lobj_freeze : -{ "length" }-);
+  BIFunctionObject ($lobj; 0, $lobj_proto, "Object_call", "Object_construct") *
+  DataPropGen($lobj, "create"; $lobj_create, true, false, true) *
+  DataPropGen($lobj, "freeze"; $lobj_freeze, true, false, true) *
+  JSBIFunction($lobj_create; "Object_create", 2) * empty_fields($lobj_create : -{ "length" }-) *
+  JSBIFunction($lobj_freeze; "Object_freeze", 2) * empty_fields($lobj_freeze : -{ "length" }-);
 
 pred ObjectPrototype (proto;) :
-  JSObjWithProto (proto, null) * empty_fields (proto : -{ "hasOwnProperty" }-) *
+  JSObjWithProto (proto; null) * empty_fields (proto : -{ "hasOwnProperty" }-) *
   ((proto, "hasOwnProperty") -> {{ "d", $lop_hasOwnProperty, true, false, true }}) *
-  JSBIFunction($lop_hasOwnProperty, "OP_hasOwnProperty", 1) * empty_fields($lop_hasOwnProperty : -{ "length" }-);
+  JSBIFunction($lop_hasOwnProperty; "OP_hasOwnProperty", 1) * empty_fields($lop_hasOwnProperty : -{ "length" }-);
 
 pred ObjectPrototypeComplete (;) :
-  JSObjWithProto ($lobj_proto, null) * empty_fields ($lobj_proto : -{ "hasOwnProperty", "toString" }-) *
+  JSObjWithProto ($lobj_proto; null) * empty_fields ($lobj_proto : -{ "hasOwnProperty", "toString" }-) *
   (($lobj_proto, "hasOwnProperty") -> {{ "d", $lop_hasOwnProperty, true, false, true }}) *
   (($lobj_proto, "toString") -> {{ "d", $lop_toString, true, false, true }}) *
-  JSBIFunction($lop_hasOwnProperty, "OP_hasOwnProperty", 1) * empty_fields($lop_hasOwnProperty : -{ "length" }-) *
-  JSBIFunction($lop_toString, "OP_toString", 1) * empty_fields($lop_toString : -{ "length" }-);
+  JSBIFunction($lop_hasOwnProperty; "OP_hasOwnProperty", 1) * empty_fields($lop_hasOwnProperty : -{ "length" }-) *
+  JSBIFunction($lop_toString; "OP_toString", 1) * empty_fields($lop_toString : -{ "length" }-);
 
 pred FunctionPrototype (proto;) :
   ((proto, "length") -> {{ "d", 0, false, false, false }}) *
@@ -160,28 +160,28 @@ pred FunctionPrototype (proto;) :
   ((#mfp, "@extensible") -> true) *
   ((#mfp, "@scope") -> empty) * ((#mfp, "@call") -> "FP_default") *
   empty_fields(#mfp : -{ "@proto", "@class", "@extensible", "@scope", "@call" }-) *
-  JSBIFunction($lfp_call, "FP_call", 1);
+  JSBIFunction($lfp_call; "FP_call", 1);
 
 pred BI_ErrorObject (;) :
-  BIFunctionObject ($lerr, 1, $lerr_proto, "Error_call", "Error_construct");
+  BIFunctionObject ($lerr; 1, $lerr_proto, "Error_call", "Error_construct");
 
 (***********************
  **** ERROR OBJECTS ****
  ***********************)
 
 pred ErrorObject (l:Obj; pr:Obj) :
-  JSObjGeneral(l, pr, "Error", true);
+  JSObjGeneral(l; pr, "Error", true);
 
 pred ErrorObjectWithMessage (l:Obj; m:Str) :
   MetaData(l, #md) *  MetaData(#md, null) *
   ((l, "message") -> {{"d", m, true, false, true}}) *
   ((#md, "@proto") -> $lerr_proto) * ((#md, "@class") -> "Error") * ((#md, "@extensible") -> true);
 
-pred TypeError(l:Obj;) : ErrorObject (l, $lterr_proto);
+pred TypeError(l:Obj;) : ErrorObject (l; $lterr_proto);
 
-pred SyntaxError(l:Obj;) : ErrorObject (l, $lserr_proto);
+pred SyntaxError(l:Obj;) : ErrorObject (l; $lserr_proto);
 
-pred ReferenceError(l:Obj;) : ErrorObject (l, $lrferr_proto);
+pred ReferenceError(l:Obj;) : ErrorObject (l; $lrferr_proto);
 
 (************************
  ***** INITIAL HEAP *****
@@ -190,36 +190,36 @@ pred ReferenceError(l:Obj;) : ErrorObject (l, $lrferr_proto);
 pred initialHeapPost (globals;) :
     types(globals:Set) *
 
-    GlobalObject() *
+    GlobalObject(;) *
     empty_fields ($lg : -u- (-{ "Error", "Object", "DataView" }-, globals) ) *
 
-    ObjectPrototype($lobj_proto) *
-    FunctionPrototype ($lfun_proto) *
-    BooleanPrototype () * empty_fields ($lbool_proto : -{ "constructor" }-) *
-    NumberPrototype ()  * empty_fields ($lnum_proto : -{ "constructor" }-) *
+    ObjectPrototype($lobj_proto;) *
+    FunctionPrototype ($lfun_proto;) *
+    BooleanPrototype (;) * empty_fields ($lbool_proto : -{ "constructor" }-) *
+    NumberPrototype (;)  * empty_fields ($lnum_proto : -{ "constructor" }-) *
 
-    BI_ErrorObject () * empty_fields($lerr : -{ "length", "prototype" }-) *
+    BI_ErrorObject (;) * empty_fields($lerr : -{ "length", "prototype" }-) *
 
-    JSObjGeneral ($lerr_proto, $lobj_proto, "Error", true) *
+    JSObjGeneral ($lerr_proto; $lobj_proto, "Error", true) *
     (($lerr_proto, "message") -> {{ "d", "", true, false, true }}) *
     empty_fields($lerr_proto : -{ "message" }-);
 
 pred initialHeapPostWeak (;) :
-    GlobalObject() *
+    GlobalObject(;) *
 
-    ObjectPrototype($lobj_proto) *
+    ObjectPrototype($lobj_proto;) *
 
-    FunctionPrototype ($lfun_proto) *
+    FunctionPrototype ($lfun_proto;) *
 
-    BooleanPrototype () *
+    BooleanPrototype (;) *
     empty_fields ($lbool_proto : -{ "constructor" }-) *
 
-    NumberPrototype () *
+    NumberPrototype (;) *
     empty_fields ($lnum_proto : -{ "constructor" }-) *
 
-    BI_ErrorObject () * empty_fields($lerr : -{ "length", "prototype" }-) *
+    BI_ErrorObject (;) * empty_fields($lerr : -{ "length", "prototype" }-) *
 
-    JSObjGeneral ($lerr_proto, $lobj_proto, "Error", true) *
+    JSObjGeneral ($lerr_proto; $lobj_proto, "Error", true) *
     (($lerr_proto, "message") -> {{ "d", "", true, false, true }}) *
     empty_fields($lerr_proto : -{ "message" }-);
 
@@ -301,7 +301,7 @@ pure pred desc_conf (d:List; v:Bool) :
  *********************)
 
 (*
- * Predicate: Cell_o(l, prop, X)
+ * Predicate: Cell_o(l, prop; X)
  *
  * Resource:
  *      (l, prop)
@@ -309,15 +309,15 @@ pure pred desc_conf (d:List; v:Bool) :
  *)
 pred Cell_o (l:Obj, prop:Str; d) :
     ((l, prop) -> d) * (d == none),
-    ((l, prop) -> d) * DataDescriptor(d),
-    ((l, prop) -> d) * AccessorDescriptor(d);
+    ((l, prop) -> d) * DataDescriptor(d;),
+    ((l, prop) -> d) * AccessorDescriptor(d;);
 
 (**************************
  **** CLASS CLASSIFIERS ***
  **************************)
 
 (*
- * Predicate: isClass(c, X)
+ * Predicate: isClass(c, X;)
  *
  * Resource:
  *      (l, "@class")
@@ -336,21 +336,21 @@ pure pred isClass (c:Str, case:Str;) :
 pred Pi (l:Obj, prop:Str; d, ls:List, lcls:List, lpv:List) :
 
     (* Any object, cell exists in the heap *)
-    Cell_o (l, prop, d) * types(d : List) *
-    MetaData(l, #md) * ((#md, "@class") -> #cls) * isClass (#cls, "Non-String") *
+    Cell_o (l, prop; d) * types(d : List) *
+    MetaData(l, #md) * ((#md, "@class") -> #cls) * isClass (#cls, "Non-String";) *
     (ls == {{ l }}) * (lcls == {{ #cls }}) * (lpv == {{ "" }}),
 
     (* Non-string object, cell does not exist in the heap, down the prototype chain *)
-    Cell_o (l, prop, none) *
-    MetaData(l, #md) * ((#md, "@class") -> #cls) * isClass (#cls, "Non-String") * ((#md, "@proto") -> #lp) *
+    Cell_o (l, prop; none) *
+    MetaData(l, #md) * ((#md, "@class") -> #cls) * isClass (#cls, "Non-String";) * ((#md, "@proto") -> #lp) *
     (ls == l :: #lls) * (lcls == #cls :: #lcls) * (lpv == "" :: #lpv) * types(#cls:Str) *
     (#lls == #lp :: #ols) * (#lcls == #pcls :: #ocls) * (#lpv == #ppv :: #otv) *
     types(#lp:Obj, #pcls:Str, #ppv:Str) *
-    Pi (#lp, prop, d, #lls, #lcls, #lpv),
+    Pi (#lp, prop; d, #lls, #lcls, #lpv),
 
     (* Non-string object, cell does not exist in the heap, end of prototype chain *)
-    Cell_o (l, prop, none) * (d == undefined) *
-    MetaData(l, #md) * ((#md, "@class") -> #cls) * isClass (#cls, "Non-String") *  ((#md, "@proto") -> null) *
+    Cell_o (l, prop; none) * (d == undefined) *
+    MetaData(l, #md) * ((#md, "@class") -> #cls) * isClass (#cls, "Non-String";) *  ((#md, "@proto") -> null) *
     (ls == {{ l }}) * (lcls == {{ #cls }}) * (lpv == {{ "" }});
 
 (*******************
@@ -409,7 +409,7 @@ proc create_default_object_concrete (l, pr, cl, ext) {
 spec Object_construct (xsc, vthis, l)
 
     [[ (l == #l) * types(#l:Undefined) ]]
-    [[ JSObject(ret) * empty_fields(ret : -{ }-) ]]
+    [[ JSObject(ret;) * empty_fields(ret : -{ }-) ]]
     normal
 
     (* TODO: for Object, Boolean, Number, String *)
@@ -523,10 +523,10 @@ spec create_function_object (xsc, call, construct, params)
       types(#xsc:List, #call:Str, #construct:Str, #params:List)
     ]]
     [[
-      JSFunctionObject(ret, #call, #xsc, #len, #prototype) *
+      JSFunctionObject(ret; #call, #xsc, #len, #prototype) *
       empty_fields(ret : -{ "arguments", "caller", "length", "prototype" }-) *
       (#len == l-len #params) *
-      JSObject(#prototype) *
+      JSObject(#prototype;) *
       ((#prototype, "constructor") -> {{ "d", ret, true, false, true }}) *
       empty_fields(#prototype : -{ "constructor" }-)
     ]]
@@ -560,7 +560,7 @@ proc create_function_object (xsc, call, construct, params) {
 spec setupInitialHeap ()
 
   [[ emp ]]
-  [[ initialHeapPost( -{ }- ) * (ret == empty) ]]
+  [[ initialHeapPost( -{ }- ;) * (ret == empty) ]]
   normal
 
 proc setupInitialHeap () {
@@ -710,7 +710,7 @@ proc SyntaxError (v) {
 spec Boolean_construct (xsc, vthis, v)
 
   [[ (v == #v) * types(v:Bool) ]]
-  [[ BooleanObject(ret, #v) * empty_fields(ret : -{ }-) ]]
+  [[ BooleanObject(ret; #v) * empty_fields(ret : -{ }-) ]]
   normal
 
 proc Boolean_construct (xsc, vthis, v) {
@@ -731,7 +731,7 @@ proc Boolean_construct (xsc, vthis, v) {
 spec Number_construct (xsc, vthis, v)
 
   [[ (v == #v) * types(v:Num) ]]
-  [[ NumberObject(ret, #v) * empty_fields(ret : -{ }-) ]]
+  [[ NumberObject(ret; #v) * empty_fields(ret : -{ }-) ]]
   normal
 
 proc Number_construct (xsc, vthis, v) {
@@ -877,11 +877,11 @@ spec i__toObject (v)
   normal;
 
   [[ (v == #v) * types(#v:Bool) ]]
-  [[ BooleanObject(ret, #v) * empty_fields(ret : -{ }-) ]]
+  [[ BooleanObject(ret; #v) * empty_fields(ret : -{ }-) ]]
   normal;
 
   [[ (v == #v) * types(#v:Num) ]]
-  [[ NumberObject(ret, #v) * empty_fields(ret : -{ }-) ]]
+  [[ NumberObject(ret; #v) * empty_fields(ret : -{ }-) ]]
   normal
 
 proc i__toObject (v) {
@@ -1389,12 +1389,12 @@ proc i__toDataDescriptor (desc) {
 
 spec o__getOwnProperty (l, prop)
 
-    [[ (l == #l) * (prop == #prop) * Cell_o (#l, #prop, none) ]]
-    [[ Cell_o (#l, #prop, none) * (ret == undefined) ]]
+    [[ (l == #l) * (prop == #prop) * Cell_o (#l, #prop; none) ]]
+    [[ Cell_o (#l, #prop; none) * (ret == undefined) ]]
     normal;
 
-    [[ (l == #l) * (prop == #prop) * Cell_o (#l, #prop, #dx) * types(#dx : List) ]]
-    [[ Cell_o (#l, #prop, #dx) * (ret == #dx) ]]
+    [[ (l == #l) * (prop == #prop) * Cell_o (#l, #prop; #dx) * types(#dx : List) ]]
+    [[ Cell_o (#l, #prop; #dx) * (ret == #dx) ]]
     normal *)
 
 proc o__getOwnProperty (l, prop) {
@@ -1425,15 +1425,15 @@ proc o__getOwnProperty (l, prop) {
 
 spec getOwnProperty (l, prop)
 
-    [[ (l == #l) * (prop == #prop) * Cell_o (#l, #prop, none) *
-       MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
-    [[ Cell_o (#l, #prop, none) *
+    [[ (l == #l) * (prop == #prop) * Cell_o (#l, #prop; none) *
+       MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+    [[ Cell_o (#l, #prop; none) *
        MetaData(#l, #md) * ((#md, "@class") -> #cls) * (ret == undefined) ]]
     normal;
 
-    [[ (l == #l) * (prop == #prop) * Cell_o (#l, #prop, #dx) * types(#dx : List) *
-       MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
-    [[ Cell_o (#l, #prop, #dx) * MetaData(#l, #md) * ((#md, "@class") -> #cls) * (ret == #dx) ]]
+    [[ (l == #l) * (prop == #prop) * Cell_o (#l, #prop; #dx) * types(#dx : List) *
+       MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+    [[ Cell_o (#l, #prop; #dx) * MetaData(#l, #md) * ((#md, "@class") -> #cls) * (ret == #dx) ]]
     normal *)
 
 proc getOwnProperty (l, prop) {
@@ -1463,8 +1463,8 @@ proc getOwnProperty (l, prop) {
 
 spec getProperty (l, prop)
 
-  [[ (l == #l) * (prop == #prop) * Pi (#l, #prop, #d, #ls, #cls, #pv) ]]
-  [[ Pi (#l, #prop, #d, #ls, #cls, #pv) * (ret == #d) ]]
+  [[ (l == #l) * (prop == #prop) * Pi (#l, #prop; #d, #ls, #cls, #pv) ]]
+  [[ Pi (#l, #prop; #d, #ls, #cls, #pv) * (ret == #d) ]]
   normal *)
 
 proc getProperty (l, prop) {
@@ -1499,13 +1499,13 @@ proc getProperty (l, prop) {
 spec get (l, prop)
 
     [[ (l == #l) * (prop == #prop) *
-       Pi (#l, #prop, #d, #ls, #cls, #pv) * (#d == undefined)  ]]
-    [[ Pi (#l, #prop, #d, #ls, #cls, #pv) * (ret == undefined) ]]
+       Pi (#l, #prop; #d, #ls, #cls, #pv) * (#d == undefined)  ]]
+    [[ Pi (#l, #prop; #d, #ls, #cls, #pv) * (ret == undefined) ]]
     normal;
 
     [[ (l == #l) * (prop == #prop) *
-       Pi (#l, #prop, #d, #ls, #cls, #pv) * DataDescriptor(#d) ]]
-    [[ Pi (#l, #prop, #d, #ls, #cls, #pv) * desc_val (#d, ret) ]]
+       Pi (#l, #prop; #d, #ls, #cls, #pv) * DataDescriptor(#d;) ]]
+    [[ Pi (#l, #prop; #d, #ls, #cls, #pv) * desc_val (#d; ret) ]]
     normal *)
 
 proc get (l, prop) {
@@ -1583,31 +1583,31 @@ spec i__getValue (v)
     normal;
 
     [[ (v == {{ "v", undefined, #field, true }}) * types (#field:Str) ]]
-    [[ ReferenceError(ret) ]]
+    [[ ReferenceError(ret;) ]]
     error;
 
     [[ (v == {{ "o", undefined, #field, true }}) * types (#field:Str) ]]
-    [[ ReferenceError(ret) ]]
+    [[ ReferenceError(ret;) ]]
     error;
 
     [[ (v == {{ "o", #obj, #field, true }}) *
-       Pi (#obj, #field, #d, #ls, #lcls, #lpv) * (#d == undefined) ]]
-    [[ Pi (#obj, #field, #d, #ls, #lcls, #lpv) * (ret == undefined) ]]
+       Pi (#obj, #field; #d, #ls, #lcls, #lpv) * (#d == undefined) ]]
+    [[ Pi (#obj, #field; #d, #ls, #lcls, #lpv) * (ret == undefined) ]]
     normal;
 
     [[ (v == {{ "o", #obj, #field, true }}) *
-       Pi (#obj, #field, #d, #ls, #lcls, #lpv) * DataDescriptor (#d)  ]]
-    [[ Pi (#obj, #field, #d, #ls, #lcls, #lpv) * desc_val (#d, #desc_val) * (ret == #desc_val) ]]
+       Pi (#obj, #field; #d, #ls, #lcls, #lpv) * DataDescriptor (#d;)  ]]
+    [[ Pi (#obj, #field; #d, #ls, #lcls, #lpv) * desc_val (#d; #desc_val) * (ret == #desc_val) ]]
     normal;
 
     [[ (v == {{ "v", $lg, #field, true }}) *
-       Pi ($lg, #field, #d, #ls, #lcls, #lpv) * (#d == undefined) ]]
-    [[ Pi ($lg, #field, #d, #ls, #lcls, #lpv) * (ret == undefined) ]]
+       Pi ($lg, #field; #d, #ls, #lcls, #lpv) * (#d == undefined) ]]
+    [[ Pi ($lg, #field; #d, #ls, #lcls, #lpv) * (ret == undefined) ]]
     normal;
 
     [[ (v == {{ "v", $lg, #field, true }}) *
-    Pi ($lg, #field, #d, #ls, #lcls, #lpv) * DataDescriptor (#d)  ]]
-    [[ Pi ($lg, #field, #d, #ls, #lcls, #lpv) * desc_val (#d, #desc_val) * (ret == #desc_val) ]]
+    Pi ($lg, #field; #d, #ls, #lcls, #lpv) * DataDescriptor (#d;)  ]]
+    [[ Pi ($lg, #field; #d, #ls, #lcls, #lpv) * desc_val (#d; #desc_val) * (ret == #desc_val) ]]
     normal;
 
     [[ (v == {{ "v", #obj, #field, true }}) * (! (#obj == $lg)) * ((#obj, #field) -> #value) * (! (#value == none)) ]]
@@ -1616,20 +1616,20 @@ spec i__getValue (v)
 
     (* Now come the more involved specs, which are a bit difficult for the solver.
 
-    [[ (v == {{ "o", #b, #field }}) * types(#b:Bool) * Pi($lbool_proto, #field, #d, ($lbool_proto :: #ols), ("Boolean" :: #ocls), ("" :: #opv)) * (#d == undefined) ]]
-    [[ Pi($lbool_proto, #field, #d, ($lbool_proto :: #ols), ("Boolean" :: #ocls), ("" :: #opv)) * (ret == undefined) ]]
+    [[ (v == {{ "o", #b, #field }}) * types(#b:Bool) * Pi($lbool_proto, #field; #d, ($lbool_proto :: #ols), ("Boolean" :: #ocls), ("" :: #opv)) * (#d == undefined) ]]
+    [[ Pi($lbool_proto, #field; #d, ($lbool_proto :: #ols), ("Boolean" :: #ocls), ("" :: #opv)) * (ret == undefined) ]]
     normal;
 
-    [[ (v == {{ "o", #b, #field }}) * types(#b:Bool) * Pi($lbool_proto, #field, #d, ($lbool_proto :: #ols), ("Boolean" :: #ocls), ("" :: #opv)) * DataDescriptor(#d) ]]
-    [[ Pi($lbool_proto, #field, #d, ($lbool_proto :: #ols), ("Boolean" :: #ocls), ("" :: #opv)) * desc_val(#d, #dval) * (ret == #dval) ]]
+    [[ (v == {{ "o", #b, #field }}) * types(#b:Bool) * Pi($lbool_proto, #field; #d, ($lbool_proto :: #ols), ("Boolean" :: #ocls), ("" :: #opv)) * DataDescriptor(#d;) ]]
+    [[ Pi($lbool_proto, #field; #d, ($lbool_proto :: #ols), ("Boolean" :: #ocls), ("" :: #opv)) * desc_val(#d; #dval) * (ret == #dval) ]]
     normal;
 
-    [[ (v == {{ "o", #n, #field }}) * types(#n:Num) * Pi($lnum_proto, #field, #d, ($lnum_proto :: #ols), ("Number" :: #ocls), ("" :: #opv)) * (#d == undefined) ]]
-    [[ Pi($lnum_proto, #field, #d, ($lnum_proto :: #ols), ("Number" :: #ocls), ("" :: #opv)) * (ret == undefined) ]]
+    [[ (v == {{ "o", #n, #field }}) * types(#n:Num) * Pi($lnum_proto, #field; #d, ($lnum_proto :: #ols), ("Number" :: #ocls), ("" :: #opv)) * (#d == undefined) ]]
+    [[ Pi($lnum_proto, #field; #d, ($lnum_proto :: #ols), ("Number" :: #ocls), ("" :: #opv)) * (ret == undefined) ]]
     normal;
 
-    [[ (v == {{ "o", #n, #field }}) * types(#n:Num) * Pi($lnum_proto, #field, #d, ($lnum_proto :: #ols), ("Number" :: #ocls), ("" :: #opv)) * DataDescriptor(#d) ]]
-    [[ Pi($lnum_proto, #field, #d, ($lnum_proto :: #ols), ("Number" :: #ocls), ("" :: #opv)) * desc_val(#d, #dval) * (ret == #dval) ]]
+    [[ (v == {{ "o", #n, #field }}) * types(#n:Num) * Pi($lnum_proto, #field; #d, ($lnum_proto :: #ols), ("Number" :: #ocls), ("" :: #opv)) * DataDescriptor(#d;) ]]
+    [[ Pi($lnum_proto, #field; #d, ($lnum_proto :: #ols), ("Number" :: #ocls), ("" :: #opv)) * desc_val(#d; #dval) * (ret == #dval) ]]
     normal *)
 
 proc i__getValue (v) {
@@ -1684,13 +1684,13 @@ proc i__getValue (v) {
 spec hasProperty (l, prop)
 
   [[ (l == #l) * (prop == #prop) *
-     Pi (#l, #prop, undefined, #ls, #cls, #pv) ]]
-  [[ Pi (#l, #prop, undefined, #ls, #cls, #pv) * (ret == false) ]]
+     Pi (#l, #prop; undefined, #ls, #cls, #pv) ]]
+  [[ Pi (#l, #prop; undefined, #ls, #cls, #pv) * (ret == false) ]]
   normal;
 
   [[ (l == #l) * (prop == #prop) *
-     Pi (#l, #prop, #d, #ls, #cls, #pv) * DataDescriptor(#d) ]]
-  [[ Pi (#l, #prop, #d, #ls, #cls, #pv) * (ret == true) ]]
+     Pi (#l, #prop; #d, #ls, #cls, #pv) * DataDescriptor(#d;) ]]
+  [[ Pi (#l, #prop; #d, #ls, #cls, #pv) * (ret == true) ]]
   normal *)
 
 proc hasProperty (l, prop) {
@@ -1708,31 +1708,31 @@ proc hasProperty (l, prop) {
 
 spec deleteProperty (l, prop, thrw)
 
-    [[ (l == #l) * (prop == #prop) * Cell_o (#l, #prop, none) *
-       MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
-    [[ Cell_o (#l, #prop, none) *
+    [[ (l == #l) * (prop == #prop) * Cell_o (#l, #prop; none) *
+       MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+    [[ Cell_o (#l, #prop; none) *
        MetaData(#l, #md) * ((#md, "@class") -> #cls) * (ret == true) ]]
     normal;
 
   [[ (l == #l) * (prop == #prop) *
-     Cell_o(#l, #prop, #d) * DataDescriptor(#d) * desc_conf(#d, true) *
-     MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
-  [[ Cell_o(#l, #prop, none) *
+     Cell_o(#l, #prop; #d) * DataDescriptor(#d;) * desc_conf(#d; true) *
+     MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+  [[ Cell_o(#l, #prop; none) *
      MetaData(#l, #md) * ((#md, "@class") -> #cls) * (ret == true) ]]
   normal;
 
   [[ (l == #l) * (prop == #prop) * (thrw == false) *
-     Cell_o(#l, #prop, #d) * DataDescriptor(#d) * desc_conf(#d, false) *
-     MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
-  [[ Cell_o(#l, #prop, #d) *
+     Cell_o(#l, #prop; #d) * DataDescriptor(#d;) * desc_conf(#d; false) *
+     MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+  [[ Cell_o(#l, #prop; #d) *
      MetaData(#l, #md) * ((#md, "@class") -> #cls) * (ret == false) ]]
   normal;
 
   [[ (l == #l) * (prop == #prop) * (thrw == true) *
-     Cell_o(#l, #prop, #d) * DataDescriptor(#d) * desc_conf(#d, false) *
-     MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
-  [[ Cell_o(#l, #prop, #d) *
-     MetaData(#l, #md) * ((#md, "@class") -> #cls) * TypeError(ret) ]]
+     Cell_o(#l, #prop; #d) * DataDescriptor(#d;) * desc_conf(#d; false) *
+     MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+  [[ Cell_o(#l, #prop; #d) *
+     MetaData(#l, #md) * ((#md, "@class") -> #cls) * TypeError(ret;) ]]
   error
 
 proc deleteProperty (l, prop, thrw) {
@@ -1807,13 +1807,13 @@ proc canPut (l, prop) {
 spec OP_hasOwnProperty(xsc, vthis, v)
 
   [[ (vthis == #l) * (v == #prop) * types(#l : Obj, #prop : Str) *
-     MetaData(#l, #md) * ((#md, "@class") -> "Object") * Cell_o (#l, #prop, {{ "d", #v, #wr, #en, #co }}) ]]
-  [[ MetaData(#l, #md) * ((#md, "@class") -> "Object") * Cell_o (#l, #prop, {{ "d", #v, #wr, #en, #co }}) * (ret == true) ]]
+     MetaData(#l, #md) * ((#md, "@class") -> "Object") * Cell_o (#l, #prop; {{ "d", #v, #wr, #en, #co }}) ]]
+  [[ MetaData(#l, #md) * ((#md, "@class") -> "Object") * Cell_o (#l, #prop; {{ "d", #v, #wr, #en, #co }}) * (ret == true) ]]
   normal;
 
   [[ (vthis == #l) * (v == #prop) * types(#l : Obj, #prop : Str) *
-     MetaData(#l, #md) * ((#md, "@class") -> "Object") * Cell_o (#l, #prop, none) ]]
-  [[ MetaData(#l, #md) * ((#md, "@class") -> "Object") * Cell_o (#l, #prop, none) * (ret == false) ]]
+     MetaData(#l, #md) * ((#md, "@class") -> "Object") * Cell_o (#l, #prop; none) ]]
+  [[ MetaData(#l, #md) * ((#md, "@class") -> "Object") * Cell_o (#l, #prop; none) * (ret == false) ]]
   normal
 
 proc OP_hasOwnProperty(xsc, vthis, v) {

--- a/Gillian-JS/runtime/JSLogic/javert_internal_functions.jsil
+++ b/Gillian-JS/runtime/JSLogic/javert_internal_functions.jsil
@@ -6,21 +6,21 @@
  **** GENERAL OBJECTS ****
  *************************)
 
-pred JSObject (l:Obj) :
+pred JSObject (l:Obj;) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> $lobj_proto) *
   ((#md, "@class")      -> "Object") *
   ((#md, "@extensible") -> true) *
   empty_fields (#md : -{ "@class", "@extensible", "@proto" }-);
 
-pred JSObjWithProto (+l:Obj, proto) :
+pred JSObjWithProto (l:Obj; proto) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> proto) *
   ((#md, "@class")      -> "Object") *
   ((#md, "@extensible") -> true) *
   empty_fields (#md : -{ "@class", "@extensible", "@proto" }-);
 
-pred JSObjGeneral (+l:Obj, proto, class:Str, ext:Bool) :
+pred JSObjGeneral (l:Obj; proto, class:Str, ext:Bool) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> proto) *
   ((#md, "@class")      -> class) *
@@ -31,7 +31,7 @@ pred JSObjGeneral (+l:Obj, proto, class:Str, ext:Bool) :
  **** FUNCTION OBJECTS ****
  **************************)
 
-pred JSFunctionObject (+l:Obj, fid:Str, sc:List, len:Num, proto:Obj) :
+pred JSFunctionObject (l:Obj; fid:Str, sc:List, len:Num, proto:Obj) :
   ((l, "length")     -> {{ "d", len, false, false, false }}) *
   ((l, "arguments")  -> {{ "a", $lthrw_type_error, $lthrw_type_error, false, false }}) *
   ((l, "caller")     -> {{ "a", $lthrw_type_error, $lthrw_type_error, false, false }}) *
@@ -45,11 +45,11 @@ pred JSFunctionObject (+l:Obj, fid:Str, sc:List, len:Num, proto:Obj) :
   ((#md, "@scope")      -> sc) *
   empty_fields(#md : -{ "@call", "@class", "@construct", "@extensible", "@proto", "@scope" }-);
 
-pred JSFunctionObjectStrong (+l:Obj, fid:Str, sc:List, len:Num, proto:Obj) :
+pred JSFunctionObjectStrong (l:Obj; fid:Str, sc:List, len:Num, proto:Obj) :
   JSFunctionObject (l, fid, sc, len, proto) *
   empty_fields(l : -{ "arguments", "caller", "length", "prototype" }-);
 
-pred JSBIFunction (+l:Obj, fid:Str, len:Num) :
+pred JSBIFunction (l:Obj; fid:Str, len:Num) :
   ((l, "length")     -> {{ "d", len, false, false, false }}) *
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> $lfun_proto) *
@@ -59,7 +59,7 @@ pred JSBIFunction (+l:Obj, fid:Str, len:Num) :
   ((#md, "@scope")      -> empty) *
   empty_fields(#md : -{ "@call", "@class", "@extensible", "@proto", "@scope" }-);
 
-pred BIFunctionObject (+l:Obj, len:Num, proto:Obj, call, construct) :
+pred BIFunctionObject (l:Obj; len:Num, proto:Obj, call, construct) :
   ((l, "length")     -> {{ "d", len, false, false, false }}) *
   ((l, "prototype")  -> {{ "d", proto, false, false, false }}) *
   MetaData(l, #md) * MetaData(#md, null) *
@@ -75,7 +75,7 @@ pred BIFunctionObject (+l:Obj, len:Num, proto:Obj, call, construct) :
  **** BUILT-IN OBJECTS ****
  **************************)
 
-pred JSInternals () :
+pred JSInternals (;) :
     GlobalObject () *
     ObjectPrototype($lobj_proto) *
     FunctionPrototype($lfun_proto) *
@@ -87,7 +87,7 @@ pred JSInternals () :
     DataViewPrototype($ldv_proto) *
     Uint8ArrayPrototype($lui8ar_proto);
 
-pred BooleanObject (+l:Obj, b:Bool) :
+pred BooleanObject (l:Obj; b:Bool) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> $lbool_proto) *
   ((#md, "@class")      -> "Boolean") *
@@ -95,7 +95,7 @@ pred BooleanObject (+l:Obj, b:Bool) :
   ((#md, "@primitiveValue") -> b) *
   empty_fields (#md : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred NumberObject (+l:Obj, n:Num) :
+pred NumberObject (l:Obj; n:Num) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> $lnum_proto) *
   ((#md, "@class")      -> "Number") *
@@ -103,7 +103,7 @@ pred NumberObject (+l:Obj, n:Num) :
   ((#md, "@primitiveValue") -> n) *
   empty_fields (#md : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred BooleanPrototype () :
+pred BooleanPrototype (;) :
   (($lbool_proto, "constructor") -> {{ "d", $lbool, true, false, true }}) *
   MetaData($lbool_proto, #bpmd) * MetaData(#bpmd, null) *
   ((#bpmd, "@proto")          -> $lobj_proto) *
@@ -112,7 +112,7 @@ pred BooleanPrototype () :
   ((#bpmd, "@primitiveValue") -> false) *
   empty_fields (#bpmd : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred NumberPrototype () :
+pred NumberPrototype (;) :
   (($lnum_proto, "constructor") -> {{ "d", $lnum, true, false, true }}) *
   MetaData($lnum_proto, #npmd) * MetaData(#npmd, null) *
   ((#npmd, "@proto")          -> $lobj_proto) *
@@ -121,36 +121,36 @@ pred NumberPrototype () :
   ((#npmd, "@primitiveValue") -> 0) *
   empty_fields (#npmd : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred GlobalObject () :
+pred GlobalObject (;) :
   JSObject ($lg) *
   (($lg, "Error") -> {{ "d", $lerr, true, false, true }}) *
   (($lg, "Object") -> {{ "d", $lobj, true, false, true }}) *
   (($lg, "DataView") -> {{ "d", $ldv, true, false, true }}) *
   (($lg, "undefined") -> {{ "d", undefined, false, false, false }});
 
-pred GlobalVar (+v, val) :
+pred GlobalVar (v; val) :
   (($lg, v) -> {{ "d", val, true, true, false }}) * types(v : Str);
 
-pred BI_ObjectObject () :
+pred BI_ObjectObject (;) :
   BIFunctionObject ($lobj, 0, $lobj_proto, "Object_call", "Object_construct") *
   DataPropGen($lobj, "create", $lobj_create, true, false, true) *
   DataPropGen($lobj, "freeze", $lobj_freeze, true, false, true) *
   JSBIFunction($lobj_create, "Object_create", 2) * empty_fields($lobj_create : -{ "length" }-) *
   JSBIFunction($lobj_freeze, "Object_freeze", 2) * empty_fields($lobj_freeze : -{ "length" }-);
 
-pred ObjectPrototype (+proto) :
+pred ObjectPrototype (proto;) :
   JSObjWithProto (proto, null) * empty_fields (proto : -{ "hasOwnProperty" }-) *
   ((proto, "hasOwnProperty") -> {{ "d", $lop_hasOwnProperty, true, false, true }}) *
   JSBIFunction($lop_hasOwnProperty, "OP_hasOwnProperty", 1) * empty_fields($lop_hasOwnProperty : -{ "length" }-);
 
-pred ObjectPrototypeComplete () :
+pred ObjectPrototypeComplete (;) :
   JSObjWithProto ($lobj_proto, null) * empty_fields ($lobj_proto : -{ "hasOwnProperty", "toString" }-) *
   (($lobj_proto, "hasOwnProperty") -> {{ "d", $lop_hasOwnProperty, true, false, true }}) *
   (($lobj_proto, "toString") -> {{ "d", $lop_toString, true, false, true }}) *
   JSBIFunction($lop_hasOwnProperty, "OP_hasOwnProperty", 1) * empty_fields($lop_hasOwnProperty : -{ "length" }-) *
   JSBIFunction($lop_toString, "OP_toString", 1) * empty_fields($lop_toString : -{ "length" }-);
 
-pred FunctionPrototype (proto) :
+pred FunctionPrototype (proto;) :
   ((proto, "length") -> {{ "d", 0, false, false, false }}) *
   ((proto, "call")   -> {{ "d", $lfp_call, true, false, true }}) *
   empty_fields(proto : -{ "call", "length" }-) *
@@ -162,32 +162,32 @@ pred FunctionPrototype (proto) :
   empty_fields(#mfp : -{ "@proto", "@class", "@extensible", "@scope", "@call" }-) *
   JSBIFunction($lfp_call, "FP_call", 1);
 
-pred BI_ErrorObject () :
+pred BI_ErrorObject (;) :
   BIFunctionObject ($lerr, 1, $lerr_proto, "Error_call", "Error_construct");
 
 (***********************
  **** ERROR OBJECTS ****
  ***********************)
 
-pred ErrorObject (+l:Obj, pr:Obj) :
+pred ErrorObject (l:Obj; pr:Obj) :
   JSObjGeneral(l, pr, "Error", true);
 
-pred ErrorObjectWithMessage (+l:Obj, m:Str) :
+pred ErrorObjectWithMessage (l:Obj; m:Str) :
   MetaData(l, #md) *  MetaData(#md, null) *
   ((l, "message") -> {{"d", m, true, false, true}}) *
   ((#md, "@proto") -> $lerr_proto) * ((#md, "@class") -> "Error") * ((#md, "@extensible") -> true);
 
-pred TypeError(l:Obj) : ErrorObject (l, $lterr_proto);
+pred TypeError(l:Obj;) : ErrorObject (l, $lterr_proto);
 
-pred SyntaxError(l:Obj) : ErrorObject (l, $lserr_proto);
+pred SyntaxError(l:Obj;) : ErrorObject (l, $lserr_proto);
 
-pred ReferenceError(l:Obj) : ErrorObject (l, $lrferr_proto);
+pred ReferenceError(l:Obj;) : ErrorObject (l, $lrferr_proto);
 
 (************************
  ***** INITIAL HEAP *****
  ************************)
 
-pred initialHeapPost (globals) :
+pred initialHeapPost (globals;) :
     types(globals:Set) *
 
     GlobalObject() *
@@ -204,7 +204,7 @@ pred initialHeapPost (globals) :
     (($lerr_proto, "message") -> {{ "d", "", true, false, true }}) *
     empty_fields($lerr_proto : -{ "message" }-);
 
-pred initialHeapPostWeak ( ) :
+pred initialHeapPostWeak (;) :
     GlobalObject() *
 
     ObjectPrototype($lobj_proto) *
@@ -227,19 +227,19 @@ pred initialHeapPostWeak ( ) :
  **** PROPERTIES ****
  ********************)
 
-pred DataProp (+l:Obj, +prop:Str, v) :
+pred DataProp (l:Obj, prop:Str; v) :
   ((l, prop) -> {{ "d", v, true, true, true }}) *
   (! (v == empty)) * (! (v == none)) * (! (typeOf v == List));
 
-pred DataPropGen (+l:Obj, +prop:Str, v, writ:Bool, enum:Bool, conf:Bool) :
+pred DataPropGen (l:Obj, prop:Str; v, writ:Bool, enum:Bool, conf:Bool) :
   ((l, prop) -> {{ "d", v, writ, enum, conf }}) *
   (! (v == empty)) * (! (typeOf v == List));
 
-pred DataPropConst (+l:Obj, +prop:Str, v, enum:Bool) :
+pred DataPropConst (l:Obj, prop:Str; v, enum:Bool) :
   ((l, prop) -> {{ "d", v, false, enum, false }}) *
   (! (v == empty)) * (! (typeOf v == List));
 
-pred readOnlyProperty (+l:Obj, +prop:Str, v) :
+pred readOnlyProperty (l:Obj, prop:Str; v) :
   ((l, prop) -> {{ "d", v, false, true, false }}) *
   (! (v == empty));
 
@@ -253,7 +253,7 @@ pred readOnlyProperty (+l:Obj, +prop:Str, v) :
  * Resource: none
  *
  *)
-pure pred DataDescriptor (d:List) :
+pure pred DataDescriptor (d:List;) :
   (d == {{ "d", #dval, #dwrit, #denum, #dconf }}) *
   types (#dwrit:Bool, #denum:Bool, #dconf:Bool) *
   (! (#dval == empty));
@@ -264,7 +264,7 @@ pure pred DataDescriptor (d:List) :
  * Resource: none
  *
  *)
-pure pred AccessorDescriptor (d:List) :
+pure pred AccessorDescriptor (d:List;) :
   (d == {{ "a", #dget, #dset, #denum, #dconf }}) *
   types (#denum:Bool, #dconf:Bool) *
   (! (#dget == empty)) * (! (#dset == empty));
@@ -275,7 +275,7 @@ pure pred AccessorDescriptor (d:List) :
  * Resource: none
  *
  *)
-pure pred GenericDescriptor (d:List) :
+pure pred GenericDescriptor (d:List;) :
   (d == {{ "g", #genum, #gconf, #gval, #gwrit, #gget, #gset }});
 
 (*
@@ -284,16 +284,16 @@ pure pred GenericDescriptor (d:List) :
  * Resource: none
  *
  *)
-pure pred desc_val (+d:List, v) :
+pure pred desc_val (d:List; v) :
     v == l-nth(d, 1);
 
-pure pred desc_writ (+d:List, v:Bool) :
+pure pred desc_writ (d:List; v:Bool) :
     v == l-nth(d, 2);
 
-pure pred desc_enum (+d:List, v:Bool) :
+pure pred desc_enum (d:List; v:Bool) :
     v == l-nth(d, 3);
 
-pure pred desc_conf (+d:List, v:Bool) :
+pure pred desc_conf (d:List; v:Bool) :
     v == l-nth(d, 4);
 
 (*********************
@@ -307,7 +307,7 @@ pure pred desc_conf (+d:List, v:Bool) :
  *      (l, prop)
  *
  *)
-pred Cell_o (+l:Obj, +prop:Str, d) :
+pred Cell_o (l:Obj, prop:Str; d) :
     ((l, prop) -> d) * (d == none),
     ((l, prop) -> d) * DataDescriptor(d),
     ((l, prop) -> d) * AccessorDescriptor(d);
@@ -323,7 +323,7 @@ pred Cell_o (+l:Obj, +prop:Str, d) :
  *      (l, "@class")
  *
  *)
-pure pred isClass (c:Str, case:Str) :
+pure pred isClass (c:Str, case:Str;) :
   (case == "Array")      * (c == "Array"),
   (case == "String")     * (c == "String"),
   (case == "Non-Array")  * (! (c == "Array")),
@@ -333,7 +333,7 @@ pure pred isClass (c:Str, case:Str) :
  **** PI: PROTOTYPE INHERITANCE ***
  **********************************)
 
-pred Pi (+l:Obj, +prop:Str, d, ls:List, lcls:List, lpv:List) :
+pred Pi (l:Obj, prop:Str; d, ls:List, lcls:List, lpv:List) :
 
     (* Any object, cell exists in the heap *)
     Cell_o (l, prop, d) * types(d : List) *

--- a/Gillian-JS/runtime/JSLogic/javert_internal_functions.jsil
+++ b/Gillian-JS/runtime/JSLogic/javert_internal_functions.jsil
@@ -6,7 +6,7 @@
  **** GENERAL OBJECTS ****
  *************************)
 
-pred JSObject (l:Obj;) :
+pred JSObject (l:Obj) :
   MetaData(l, #md) * MetaData(#md, null) *
   ((#md, "@proto")      -> $lobj_proto) *
   ((#md, "@class")      -> "Object") *
@@ -75,17 +75,17 @@ pred BIFunctionObject (l:Obj; len:Num, proto:Obj, call, construct) :
  **** BUILT-IN OBJECTS ****
  **************************)
 
-pred JSInternals (;) :
-    GlobalObject (;) *
-    ObjectPrototype($lobj_proto;) *
-    FunctionPrototype($lfun_proto;) *
-    ArrayPrototype ($larr_proto;) *
-    ArrayBufferPrototype ($lab_proto;) *
-    BI_ErrorObject (;) *
-    BI_ObjectObject (;) *
-    BI_DataViewObject (;) *
-    DataViewPrototype($ldv_proto;) *
-    Uint8ArrayPrototype($lui8ar_proto;);
+pred JSInternals () :
+    GlobalObject () *
+    ObjectPrototype($lobj_proto) *
+    FunctionPrototype($lfun_proto) *
+    ArrayPrototype ($larr_proto) *
+    ArrayBufferPrototype ($lab_proto) *
+    BI_ErrorObject () *
+    BI_ObjectObject () *
+    BI_DataViewObject () *
+    DataViewPrototype($ldv_proto) *
+    Uint8ArrayPrototype($lui8ar_proto);
 
 pred BooleanObject (l:Obj; b:Bool) :
   MetaData(l, #md) * MetaData(#md, null) *
@@ -103,7 +103,7 @@ pred NumberObject (l:Obj; n:Num) :
   ((#md, "@primitiveValue") -> n) *
   empty_fields (#md : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred BooleanPrototype (;) :
+pred BooleanPrototype () :
   (($lbool_proto, "constructor") -> {{ "d", $lbool, true, false, true }}) *
   MetaData($lbool_proto, #bpmd) * MetaData(#bpmd, null) *
   ((#bpmd, "@proto")          -> $lobj_proto) *
@@ -112,7 +112,7 @@ pred BooleanPrototype (;) :
   ((#bpmd, "@primitiveValue") -> false) *
   empty_fields (#bpmd : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred NumberPrototype (;) :
+pred NumberPrototype () :
   (($lnum_proto, "constructor") -> {{ "d", $lnum, true, false, true }}) *
   MetaData($lnum_proto, #npmd) * MetaData(#npmd, null) *
   ((#npmd, "@proto")          -> $lobj_proto) *
@@ -121,8 +121,8 @@ pred NumberPrototype (;) :
   ((#npmd, "@primitiveValue") -> 0) *
   empty_fields (#npmd : -{ "@class", "@extensible", "@primitiveValue", "@proto" }-);
 
-pred GlobalObject (;) :
-  JSObject ($lg;) *
+pred GlobalObject () :
+  JSObject ($lg) *
   (($lg, "Error") -> {{ "d", $lerr, true, false, true }}) *
   (($lg, "Object") -> {{ "d", $lobj, true, false, true }}) *
   (($lg, "DataView") -> {{ "d", $ldv, true, false, true }}) *
@@ -131,26 +131,26 @@ pred GlobalObject (;) :
 pred GlobalVar (v; val) :
   (($lg, v) -> {{ "d", val, true, true, false }}) * types(v : Str);
 
-pred BI_ObjectObject (;) :
+pred BI_ObjectObject () :
   BIFunctionObject ($lobj; 0, $lobj_proto, "Object_call", "Object_construct") *
   DataPropGen($lobj, "create"; $lobj_create, true, false, true) *
   DataPropGen($lobj, "freeze"; $lobj_freeze, true, false, true) *
   JSBIFunction($lobj_create; "Object_create", 2) * empty_fields($lobj_create : -{ "length" }-) *
   JSBIFunction($lobj_freeze; "Object_freeze", 2) * empty_fields($lobj_freeze : -{ "length" }-);
 
-pred ObjectPrototype (proto;) :
+pred ObjectPrototype (proto) :
   JSObjWithProto (proto; null) * empty_fields (proto : -{ "hasOwnProperty" }-) *
   ((proto, "hasOwnProperty") -> {{ "d", $lop_hasOwnProperty, true, false, true }}) *
   JSBIFunction($lop_hasOwnProperty; "OP_hasOwnProperty", 1) * empty_fields($lop_hasOwnProperty : -{ "length" }-);
 
-pred ObjectPrototypeComplete (;) :
+pred ObjectPrototypeComplete () :
   JSObjWithProto ($lobj_proto; null) * empty_fields ($lobj_proto : -{ "hasOwnProperty", "toString" }-) *
   (($lobj_proto, "hasOwnProperty") -> {{ "d", $lop_hasOwnProperty, true, false, true }}) *
   (($lobj_proto, "toString") -> {{ "d", $lop_toString, true, false, true }}) *
   JSBIFunction($lop_hasOwnProperty; "OP_hasOwnProperty", 1) * empty_fields($lop_hasOwnProperty : -{ "length" }-) *
   JSBIFunction($lop_toString; "OP_toString", 1) * empty_fields($lop_toString : -{ "length" }-);
 
-pred FunctionPrototype (proto;) :
+pred FunctionPrototype (proto) :
   ((proto, "length") -> {{ "d", 0, false, false, false }}) *
   ((proto, "call")   -> {{ "d", $lfp_call, true, false, true }}) *
   empty_fields(proto : -{ "call", "length" }-) *
@@ -162,7 +162,7 @@ pred FunctionPrototype (proto;) :
   empty_fields(#mfp : -{ "@proto", "@class", "@extensible", "@scope", "@call" }-) *
   JSBIFunction($lfp_call; "FP_call", 1);
 
-pred BI_ErrorObject (;) :
+pred BI_ErrorObject () :
   BIFunctionObject ($lerr; 1, $lerr_proto, "Error_call", "Error_construct");
 
 (***********************
@@ -177,47 +177,47 @@ pred ErrorObjectWithMessage (l:Obj; m:Str) :
   ((l, "message") -> {{"d", m, true, false, true}}) *
   ((#md, "@proto") -> $lerr_proto) * ((#md, "@class") -> "Error") * ((#md, "@extensible") -> true);
 
-pred TypeError(l:Obj;) : ErrorObject (l; $lterr_proto);
+pred TypeError(l:Obj) : ErrorObject (l; $lterr_proto);
 
-pred SyntaxError(l:Obj;) : ErrorObject (l; $lserr_proto);
+pred SyntaxError(l:Obj) : ErrorObject (l; $lserr_proto);
 
-pred ReferenceError(l:Obj;) : ErrorObject (l; $lrferr_proto);
+pred ReferenceError(l:Obj) : ErrorObject (l; $lrferr_proto);
 
 (************************
  ***** INITIAL HEAP *****
  ************************)
 
-pred initialHeapPost (globals;) :
+pred initialHeapPost (globals) :
     types(globals:Set) *
 
-    GlobalObject(;) *
+    GlobalObject() *
     empty_fields ($lg : -u- (-{ "Error", "Object", "DataView" }-, globals) ) *
 
-    ObjectPrototype($lobj_proto;) *
-    FunctionPrototype ($lfun_proto;) *
-    BooleanPrototype (;) * empty_fields ($lbool_proto : -{ "constructor" }-) *
-    NumberPrototype (;)  * empty_fields ($lnum_proto : -{ "constructor" }-) *
+    ObjectPrototype($lobj_proto) *
+    FunctionPrototype ($lfun_proto) *
+    BooleanPrototype () * empty_fields ($lbool_proto : -{ "constructor" }-) *
+    NumberPrototype ()  * empty_fields ($lnum_proto : -{ "constructor" }-) *
 
-    BI_ErrorObject (;) * empty_fields($lerr : -{ "length", "prototype" }-) *
+    BI_ErrorObject () * empty_fields($lerr : -{ "length", "prototype" }-) *
 
     JSObjGeneral ($lerr_proto; $lobj_proto, "Error", true) *
     (($lerr_proto, "message") -> {{ "d", "", true, false, true }}) *
     empty_fields($lerr_proto : -{ "message" }-);
 
-pred initialHeapPostWeak (;) :
-    GlobalObject(;) *
+pred initialHeapPostWeak () :
+    GlobalObject() *
 
-    ObjectPrototype($lobj_proto;) *
+    ObjectPrototype($lobj_proto) *
 
-    FunctionPrototype ($lfun_proto;) *
+    FunctionPrototype ($lfun_proto) *
 
-    BooleanPrototype (;) *
+    BooleanPrototype () *
     empty_fields ($lbool_proto : -{ "constructor" }-) *
 
-    NumberPrototype (;) *
+    NumberPrototype () *
     empty_fields ($lnum_proto : -{ "constructor" }-) *
 
-    BI_ErrorObject (;) * empty_fields($lerr : -{ "length", "prototype" }-) *
+    BI_ErrorObject () * empty_fields($lerr : -{ "length", "prototype" }-) *
 
     JSObjGeneral ($lerr_proto; $lobj_proto, "Error", true) *
     (($lerr_proto, "message") -> {{ "d", "", true, false, true }}) *
@@ -253,7 +253,7 @@ pred readOnlyProperty (l:Obj, prop:Str; v) :
  * Resource: none
  *
  *)
-pure pred DataDescriptor (d:List;) :
+pure pred DataDescriptor (d:List) :
   (d == {{ "d", #dval, #dwrit, #denum, #dconf }}) *
   types (#dwrit:Bool, #denum:Bool, #dconf:Bool) *
   (! (#dval == empty));
@@ -264,7 +264,7 @@ pure pred DataDescriptor (d:List;) :
  * Resource: none
  *
  *)
-pure pred AccessorDescriptor (d:List;) :
+pure pred AccessorDescriptor (d:List) :
   (d == {{ "a", #dget, #dset, #denum, #dconf }}) *
   types (#denum:Bool, #dconf:Bool) *
   (! (#dget == empty)) * (! (#dset == empty));
@@ -275,7 +275,7 @@ pure pred AccessorDescriptor (d:List;) :
  * Resource: none
  *
  *)
-pure pred GenericDescriptor (d:List;) :
+pure pred GenericDescriptor (d:List) :
   (d == {{ "g", #genum, #gconf, #gval, #gwrit, #gget, #gset }});
 
 (*
@@ -309,21 +309,21 @@ pure pred desc_conf (d:List; v:Bool) :
  *)
 pred Cell_o (l:Obj, prop:Str; d) :
     ((l, prop) -> d) * (d == none),
-    ((l, prop) -> d) * DataDescriptor(d;),
-    ((l, prop) -> d) * AccessorDescriptor(d;);
+    ((l, prop) -> d) * DataDescriptor(d),
+    ((l, prop) -> d) * AccessorDescriptor(d);
 
 (**************************
  **** CLASS CLASSIFIERS ***
  **************************)
 
 (*
- * Predicate: isClass(c, X;)
+ * Predicate: isClass(c, X)
  *
  * Resource:
  *      (l, "@class")
  *
  *)
-pure pred isClass (c:Str, case:Str;) :
+pure pred isClass (c:Str, case:Str) :
   (case == "Array")      * (c == "Array"),
   (case == "String")     * (c == "String"),
   (case == "Non-Array")  * (! (c == "Array")),
@@ -337,12 +337,12 @@ pred Pi (l:Obj, prop:Str; d, ls:List, lcls:List, lpv:List) :
 
     (* Any object, cell exists in the heap *)
     Cell_o (l, prop; d) * types(d : List) *
-    MetaData(l, #md) * ((#md, "@class") -> #cls) * isClass (#cls, "Non-String";) *
+    MetaData(l, #md) * ((#md, "@class") -> #cls) * isClass (#cls, "Non-String") *
     (ls == {{ l }}) * (lcls == {{ #cls }}) * (lpv == {{ "" }}),
 
     (* Non-string object, cell does not exist in the heap, down the prototype chain *)
     Cell_o (l, prop; none) *
-    MetaData(l, #md) * ((#md, "@class") -> #cls) * isClass (#cls, "Non-String";) * ((#md, "@proto") -> #lp) *
+    MetaData(l, #md) * ((#md, "@class") -> #cls) * isClass (#cls, "Non-String") * ((#md, "@proto") -> #lp) *
     (ls == l :: #lls) * (lcls == #cls :: #lcls) * (lpv == "" :: #lpv) * types(#cls:Str) *
     (#lls == #lp :: #ols) * (#lcls == #pcls :: #ocls) * (#lpv == #ppv :: #otv) *
     types(#lp:Obj, #pcls:Str, #ppv:Str) *
@@ -350,7 +350,7 @@ pred Pi (l:Obj, prop:Str; d, ls:List, lcls:List, lpv:List) :
 
     (* Non-string object, cell does not exist in the heap, end of prototype chain *)
     Cell_o (l, prop; none) * (d == undefined) *
-    MetaData(l, #md) * ((#md, "@class") -> #cls) * isClass (#cls, "Non-String";) *  ((#md, "@proto") -> null) *
+    MetaData(l, #md) * ((#md, "@class") -> #cls) * isClass (#cls, "Non-String") *  ((#md, "@proto") -> null) *
     (ls == {{ l }}) * (lcls == {{ #cls }}) * (lpv == {{ "" }});
 
 (*******************
@@ -409,7 +409,7 @@ proc create_default_object_concrete (l, pr, cl, ext) {
 spec Object_construct (xsc, vthis, l)
 
     [[ (l == #l) * types(#l:Undefined) ]]
-    [[ JSObject(ret;) * empty_fields(ret : -{ }-) ]]
+    [[ JSObject(ret) * empty_fields(ret : -{ }-) ]]
     normal
 
     (* TODO: for Object, Boolean, Number, String *)
@@ -526,7 +526,7 @@ spec create_function_object (xsc, call, construct, params)
       JSFunctionObject(ret; #call, #xsc, #len, #prototype) *
       empty_fields(ret : -{ "arguments", "caller", "length", "prototype" }-) *
       (#len == l-len #params) *
-      JSObject(#prototype;) *
+      JSObject(#prototype) *
       ((#prototype, "constructor") -> {{ "d", ret, true, false, true }}) *
       empty_fields(#prototype : -{ "constructor" }-)
     ]]
@@ -560,7 +560,7 @@ proc create_function_object (xsc, call, construct, params) {
 spec setupInitialHeap ()
 
   [[ emp ]]
-  [[ initialHeapPost( -{ }- ;) * (ret == empty) ]]
+  [[ initialHeapPost( -{ }- ) * (ret == empty) ]]
   normal
 
 proc setupInitialHeap () {
@@ -1426,13 +1426,13 @@ proc o__getOwnProperty (l, prop) {
 spec getOwnProperty (l, prop)
 
     [[ (l == #l) * (prop == #prop) * Cell_o (#l, #prop; none) *
-       MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+       MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
     [[ Cell_o (#l, #prop; none) *
        MetaData(#l, #md) * ((#md, "@class") -> #cls) * (ret == undefined) ]]
     normal;
 
     [[ (l == #l) * (prop == #prop) * Cell_o (#l, #prop; #dx) * types(#dx : List) *
-       MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+       MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
     [[ Cell_o (#l, #prop; #dx) * MetaData(#l, #md) * ((#md, "@class") -> #cls) * (ret == #dx) ]]
     normal *)
 
@@ -1504,7 +1504,7 @@ spec get (l, prop)
     normal;
 
     [[ (l == #l) * (prop == #prop) *
-       Pi (#l, #prop; #d, #ls, #cls, #pv) * DataDescriptor(#d;) ]]
+       Pi (#l, #prop; #d, #ls, #cls, #pv) * DataDescriptor(#d) ]]
     [[ Pi (#l, #prop; #d, #ls, #cls, #pv) * desc_val (#d; ret) ]]
     normal *)
 
@@ -1583,11 +1583,11 @@ spec i__getValue (v)
     normal;
 
     [[ (v == {{ "v", undefined, #field, true }}) * types (#field:Str) ]]
-    [[ ReferenceError(ret;) ]]
+    [[ ReferenceError(ret) ]]
     error;
 
     [[ (v == {{ "o", undefined, #field, true }}) * types (#field:Str) ]]
-    [[ ReferenceError(ret;) ]]
+    [[ ReferenceError(ret) ]]
     error;
 
     [[ (v == {{ "o", #obj, #field, true }}) *
@@ -1596,7 +1596,7 @@ spec i__getValue (v)
     normal;
 
     [[ (v == {{ "o", #obj, #field, true }}) *
-       Pi (#obj, #field; #d, #ls, #lcls, #lpv) * DataDescriptor (#d;)  ]]
+       Pi (#obj, #field; #d, #ls, #lcls, #lpv) * DataDescriptor (#d)  ]]
     [[ Pi (#obj, #field; #d, #ls, #lcls, #lpv) * desc_val (#d; #desc_val) * (ret == #desc_val) ]]
     normal;
 
@@ -1606,7 +1606,7 @@ spec i__getValue (v)
     normal;
 
     [[ (v == {{ "v", $lg, #field, true }}) *
-    Pi ($lg, #field; #d, #ls, #lcls, #lpv) * DataDescriptor (#d;)  ]]
+    Pi ($lg, #field; #d, #ls, #lcls, #lpv) * DataDescriptor (#d)  ]]
     [[ Pi ($lg, #field; #d, #ls, #lcls, #lpv) * desc_val (#d; #desc_val) * (ret == #desc_val) ]]
     normal;
 
@@ -1620,7 +1620,7 @@ spec i__getValue (v)
     [[ Pi($lbool_proto, #field; #d, ($lbool_proto :: #ols), ("Boolean" :: #ocls), ("" :: #opv)) * (ret == undefined) ]]
     normal;
 
-    [[ (v == {{ "o", #b, #field }}) * types(#b:Bool) * Pi($lbool_proto, #field; #d, ($lbool_proto :: #ols), ("Boolean" :: #ocls), ("" :: #opv)) * DataDescriptor(#d;) ]]
+    [[ (v == {{ "o", #b, #field }}) * types(#b:Bool) * Pi($lbool_proto, #field; #d, ($lbool_proto :: #ols), ("Boolean" :: #ocls), ("" :: #opv)) * DataDescriptor(#d) ]]
     [[ Pi($lbool_proto, #field; #d, ($lbool_proto :: #ols), ("Boolean" :: #ocls), ("" :: #opv)) * desc_val(#d; #dval) * (ret == #dval) ]]
     normal;
 
@@ -1628,7 +1628,7 @@ spec i__getValue (v)
     [[ Pi($lnum_proto, #field; #d, ($lnum_proto :: #ols), ("Number" :: #ocls), ("" :: #opv)) * (ret == undefined) ]]
     normal;
 
-    [[ (v == {{ "o", #n, #field }}) * types(#n:Num) * Pi($lnum_proto, #field; #d, ($lnum_proto :: #ols), ("Number" :: #ocls), ("" :: #opv)) * DataDescriptor(#d;) ]]
+    [[ (v == {{ "o", #n, #field }}) * types(#n:Num) * Pi($lnum_proto, #field; #d, ($lnum_proto :: #ols), ("Number" :: #ocls), ("" :: #opv)) * DataDescriptor(#d) ]]
     [[ Pi($lnum_proto, #field; #d, ($lnum_proto :: #ols), ("Number" :: #ocls), ("" :: #opv)) * desc_val(#d; #dval) * (ret == #dval) ]]
     normal *)
 
@@ -1689,7 +1689,7 @@ spec hasProperty (l, prop)
   normal;
 
   [[ (l == #l) * (prop == #prop) *
-     Pi (#l, #prop; #d, #ls, #cls, #pv) * DataDescriptor(#d;) ]]
+     Pi (#l, #prop; #d, #ls, #cls, #pv) * DataDescriptor(#d) ]]
   [[ Pi (#l, #prop; #d, #ls, #cls, #pv) * (ret == true) ]]
   normal *)
 
@@ -1709,30 +1709,30 @@ proc hasProperty (l, prop) {
 spec deleteProperty (l, prop, thrw)
 
     [[ (l == #l) * (prop == #prop) * Cell_o (#l, #prop; none) *
-       MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+       MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
     [[ Cell_o (#l, #prop; none) *
        MetaData(#l, #md) * ((#md, "@class") -> #cls) * (ret == true) ]]
     normal;
 
   [[ (l == #l) * (prop == #prop) *
-     Cell_o(#l, #prop; #d) * DataDescriptor(#d;) * desc_conf(#d; true) *
-     MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+     Cell_o(#l, #prop; #d) * DataDescriptor(#d) * desc_conf(#d; true) *
+     MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
   [[ Cell_o(#l, #prop; none) *
      MetaData(#l, #md) * ((#md, "@class") -> #cls) * (ret == true) ]]
   normal;
 
   [[ (l == #l) * (prop == #prop) * (thrw == false) *
-     Cell_o(#l, #prop; #d) * DataDescriptor(#d;) * desc_conf(#d; false) *
-     MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+     Cell_o(#l, #prop; #d) * DataDescriptor(#d) * desc_conf(#d; false) *
+     MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
   [[ Cell_o(#l, #prop; #d) *
      MetaData(#l, #md) * ((#md, "@class") -> #cls) * (ret == false) ]]
   normal;
 
   [[ (l == #l) * (prop == #prop) * (thrw == true) *
-     Cell_o(#l, #prop; #d) * DataDescriptor(#d;) * desc_conf(#d; false) *
-     MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String";) ]]
+     Cell_o(#l, #prop; #d) * DataDescriptor(#d) * desc_conf(#d; false) *
+     MetaData(#l, #md) * ((#md, "@class") -> #cls) * isClass(#cls, "Non-String") ]]
   [[ Cell_o(#l, #prop; #d) *
-     MetaData(#l, #md) * ((#md, "@class") -> #cls) * TypeError(ret;) ]]
+     MetaData(#l, #md) * ((#md, "@class") -> #cls) * TypeError(ret) ]]
   error
 
 proc deleteProperty (l, prop, thrw) {

--- a/Gillian-JS/runtime/JSLogic/javert_js_predicates.jsil
+++ b/Gillian-JS/runtime/JSLogic/javert_js_predicates.jsil
@@ -12,8 +12,8 @@
  *
  *)
 pred Cell_s (l:Obj, prop:Str; d) :
-    ((l, prop) -> d) * DataDescriptor(d;),
-    ((l, prop) -> d) * AccessorDescriptor(d;);
+    ((l, prop) -> d) * DataDescriptor(d),
+    ((l, prop) -> d) * AccessorDescriptor(d);
  
 
     

--- a/Gillian-JS/runtime/JSLogic/javert_js_predicates.jsil
+++ b/Gillian-JS/runtime/JSLogic/javert_js_predicates.jsil
@@ -5,15 +5,15 @@
  ***************************) 
  
  (*
- * Predicate: Cell_s(l, prop, X)
+ * Predicate: Cell_s(l, prop; X)
  *
  * Resource:
  *      (l, prop)
  *
  *)
 pred Cell_s (l:Obj, prop:Str; d) :
-    ((l, prop) -> d) * DataDescriptor(d),
-    ((l, prop) -> d) * AccessorDescriptor(d);
+    ((l, prop) -> d) * DataDescriptor(d;),
+    ((l, prop) -> d) * AccessorDescriptor(d;);
  
 
     

--- a/Gillian-JS/runtime/JSLogic/javert_js_predicates.jsil
+++ b/Gillian-JS/runtime/JSLogic/javert_js_predicates.jsil
@@ -11,7 +11,7 @@
  *      (l, prop)
  *
  *)
-pred Cell_s (+l:Obj, +prop:Str, d) :
+pred Cell_s (l:Obj, prop:Str; d) :
     ((l, prop) -> d) * DataDescriptor(d),
     ((l, prop) -> d) * AccessorDescriptor(d);
  

--- a/GillianCore/GIL_Syntax/Asrt.ml
+++ b/GillianCore/GIL_Syntax/Asrt.ml
@@ -1,7 +1,7 @@
 (** {b GIL logic assertions}. *)
 type atom = TypeDef__.assertion_atom =
   | Emp  (** Empty heap *)
-  | Pred of string * Expr.t list  (** Predicates *)
+  | Pred of string * Expr.t list * Expr.t list  (** Predicates *)
   | Pure of Expr.t  (** Pure formula *)
   | Types of (Expr.t * Type.t) list  (** Typing assertion *)
   | CorePred of string * Expr.t list * Expr.t list  (** Core assertion *)
@@ -71,7 +71,7 @@ module Set = Set.Make (MyAssertion)
 let map (f_e : Expr.t -> Expr.t) : t -> t =
   List.map (function
     | Emp -> Emp
-    | Pred (s, le) -> Pred (s, List.map f_e le)
+    | Pred (s, ins, outs) -> Pred (s, List.map f_e ins, List.map f_e outs)
     | Pure form -> Pure (f_e form)
     | Types lt -> Types (List.map (fun (exp, typ) -> (f_e exp, typ)) lt)
     | CorePred (x, es1, es2) -> CorePred (x, List.map f_e es1, List.map f_e es2)
@@ -104,7 +104,7 @@ let pred_names : t -> string list =
     object
       inherit [_] Visitors.reduce
       inherit Visitors.Utils.non_ordered_list_monoid
-      method! visit_Pred () name _ = [ name ]
+      method! visit_Pred () name _ _ = [ name ]
     end
   in
   collector#visit_assertion ()
@@ -135,9 +135,10 @@ let make_pure (a : t) : Expr.t =
 let _pp_atom ?(e_pp : Format.formatter -> Expr.t -> unit = Expr.pp) fmt =
   function
   | Emp -> Fmt.string fmt "emp"
-  | Pred (name, params) ->
+  | Pred (name, ins, outs) ->
       let name = Pp_utils.maybe_quote_ident name in
-      Fmt.pf fmt "@[<h>%s(%a)@]" name (Fmt.list ~sep:Fmt.comma e_pp) params
+      let pp_e_l = Fmt.list ~sep:Fmt.comma e_pp in
+      Fmt.pf fmt "@[<h>%s(%a; %a)@]" name pp_e_l ins pp_e_l outs
   | Types tls ->
       let pp_tl f (e, t) = Fmt.pf f "%a : %s" e_pp e (Type.str t) in
       Fmt.pf fmt "types(@[%a@])" (Fmt.list ~sep:Fmt.comma pp_tl) tls

--- a/GillianCore/GIL_Syntax/Gil_syntax.mli
+++ b/GillianCore/GIL_Syntax/Gil_syntax.mli
@@ -448,7 +448,7 @@ module Asrt : sig
 
   type atom =
     | Emp  (** Empty heap *)
-    | Pred of string * Expr.t list  (** Predicates *)
+    | Pred of string * Expr.t list * Expr.t list  (** Predicates *)
     | Pure of Expr.t  (** Pure formula *)
     | Types of (Expr.t * Type.t) list  (** Typing assertion *)
     | CorePred of string * Expr.t list * Expr.t list  (** Core assertion *)
@@ -1330,7 +1330,13 @@ module Visitors : sig
          ; visit_PhiAssignment :
              'c -> 'f Cmd.t -> (string * Expr.t list) list -> 'f Cmd.t
          ; visit_Pi : 'c -> Constant.t -> Constant.t
-         ; visit_Pred : 'c -> Asrt.atom -> string -> Expr.t list -> Asrt.atom
+         ; visit_Pred :
+             'c ->
+             Asrt.atom ->
+             string ->
+             Expr.t list ->
+             Expr.t list ->
+             Asrt.atom
          ; visit_Pure : 'c -> Asrt.atom -> Expr.t -> Asrt.atom
          ; visit_Random : 'c -> Constant.t -> Constant.t
          ; visit_ReturnError : 'c -> 'f Cmd.t -> 'f Cmd.t
@@ -1586,7 +1592,10 @@ module Visitors : sig
       'c -> 'f Cmd.t -> (string * Expr.t list) list -> 'f Cmd.t
 
     method visit_Pi : 'c -> Constant.t -> Constant.t
-    method visit_Pred : 'c -> Asrt.atom -> string -> Expr.t list -> Asrt.atom
+
+    method visit_Pred :
+      'c -> Asrt.atom -> string -> Expr.t list -> Expr.t list -> Asrt.atom
+
     method visit_Pure : 'c -> Asrt.atom -> Expr.t -> Asrt.atom
     method visit_Random : 'c -> Constant.t -> Constant.t
     method visit_ReturnError : 'c -> 'f Cmd.t -> 'f Cmd.t
@@ -1842,7 +1851,7 @@ module Visitors : sig
          ; visit_Pi : 'c -> 'f
          ; visit_IPlus : 'c -> 'f
          ; visit_FPlus : 'c -> 'f
-         ; visit_Pred : 'c -> string -> Expr.t list -> 'f
+         ; visit_Pred : 'c -> string -> Expr.t list -> Expr.t list -> 'f
          ; visit_Pure : 'c -> Expr.t -> 'f
          ; visit_Random : 'c -> 'f
          ; visit_ReturnError : 'c -> 'f
@@ -2060,7 +2069,7 @@ module Visitors : sig
     method visit_Pi : 'c -> 'f
     method visit_IPlus : 'c -> 'f
     method visit_FPlus : 'c -> 'f
-    method visit_Pred : 'c -> string -> Expr.t list -> 'f
+    method visit_Pred : 'c -> string -> Expr.t list -> Expr.t list -> 'f
     method visit_Pure : 'c -> Expr.t -> 'f
     method visit_Random : 'c -> 'f
     method visit_ReturnError : 'c -> 'f
@@ -2279,7 +2288,7 @@ module Visitors : sig
          ; visit_PVar : 'c -> string -> unit
          ; visit_PhiAssignment : 'c -> (string * Expr.t list) list -> unit
          ; visit_Pi : 'c -> unit
-         ; visit_Pred : 'c -> string -> Expr.t list -> unit
+         ; visit_Pred : 'c -> string -> Expr.t list -> Expr.t list -> unit
          ; visit_Pure : 'c -> Expr.t -> unit
          ; visit_Random : 'c -> unit
          ; visit_ReturnError : 'c -> unit
@@ -2498,7 +2507,7 @@ module Visitors : sig
     method visit_PVar : 'c -> string -> unit
     method visit_PhiAssignment : 'c -> (string * Expr.t list) list -> unit
     method visit_Pi : 'c -> unit
-    method visit_Pred : 'c -> string -> Expr.t list -> unit
+    method visit_Pred : 'c -> string -> Expr.t list -> Expr.t list -> unit
     method visit_Pure : 'c -> Expr.t -> unit
     method visit_Random : 'c -> unit
     method visit_ReturnError : 'c -> unit

--- a/GillianCore/GIL_Syntax/Gil_syntax.mli
+++ b/GillianCore/GIL_Syntax/Gil_syntax.mli
@@ -648,7 +648,9 @@ module Pred : sig
     pred_num_params : int;  (** Number of parameters *)
     pred_params : (string * Type.t option) list;
         (** Parameter names and (optional) types *)
-    pred_ins : int list;  (** Ins *)
+    ins_number : int;
+        (** Number of in-parameters: the first [ins_number] parameters are ins,
+            and the remaining ones are outs *)
     pred_definitions : ((string * string list) option * Asrt.t) list;
         (** Predicate definitions *)
     pred_facts : Expr.t list;  (** Facts that hold for every definition *)
@@ -661,6 +663,10 @@ module Pred : sig
 
   (** Populates a Hashtbl from the given predicate list *)
   val init : t list -> (string, t) Hashtbl.t
+
+  (** [ins_indexes p] is the list of in-parameter indices
+      [[0; ...; ins_number - 1]] *)
+  val ins_indexes : t -> int list
 
   (** Returns the sets of in- and out-parameters of a predicate *)
   val ins_and_outs : t -> Utils.Containers.SI.t * Utils.Containers.SI.t

--- a/GillianCore/GIL_Syntax/Pred.ml
+++ b/GillianCore/GIL_Syntax/Pred.ml
@@ -167,7 +167,8 @@ let check_pvars (predicates : (string, t) Hashtbl.t) : unit =
 let extend_asrt_pred_types (preds : (string, t) Hashtbl.t) (a : Asrt.t) :
     (Asrt.t, string) result =
   let f : Asrt.atom -> (Asrt.t, string) result = function
-    | Asrt.Pred (name, les) as a ->
+    | Asrt.Pred (name, ins, outs) as a ->
+        let les = ins @ outs in
         let* pred =
           match Hashtbl.find_opt preds name with
           | Some pred -> Ok pred
@@ -280,7 +281,8 @@ let close_token_call (pred : t) : Asrt.atom =
   let args =
     in_args pred pred.pred_params |> List.map (fun (x, _t) -> Expr.PVar x)
   in
-  Asrt.Pred (name, args)
+  (* The close token is an all-ins predicate. *)
+  Asrt.Pred (name, args, [])
 
 (* Given a name, if it's a close_token name, returns the name of the corresponding predicate,
    otherwise return None. *)

--- a/GillianCore/GIL_Syntax/Pred.ml
+++ b/GillianCore/GIL_Syntax/Pred.ml
@@ -7,7 +7,9 @@ type t = TypeDef__.pred = {
   pred_internal : bool;
   pred_num_params : int;  (** Number of parameters *)
   pred_params : (string * Type.t option) list;  (** Actual parameters *)
-  pred_ins : int list;  (** List of which parameters are ins, by index *)
+  ins_number : int;
+      (** Number of in-parameters: the first [ins_number] parameters are ins,
+          and the remaining ones are outs *)
   pred_definitions : ((string * string list) option * Asrt.t) list;
       (** Predicate definitions *)
   pred_facts : Expr.t list;  (** Facts that hold for every definition *)
@@ -26,65 +28,49 @@ let init (preds : t list) : (string, t) Hashtbl.t =
     preds;
   pred_def_tbl
 
+(** The list of in-parameter indices, i.e. [[0; 1; ...; ins_number - 1]]. Since
+    in-parameters are always the leading parameters, this is fully determined by
+    [ins_number]. *)
+let ins_indexes (pred : t) : int list = List.init pred.ins_number Fun.id
+
 let ins_and_outs (pred : t) : SI.t * SI.t =
-  let ins_set = SI.of_list pred.pred_ins in
-  let _, outs =
-    List.fold_left
-      (fun (i, lst) (_, _) ->
-        if SI.mem i ins_set then (i + 1, lst) else (i + 1, i :: lst))
-      (0, []) pred.pred_params
+  let total = List.length pred.pred_params in
+  let ins_set = SI.of_list (List.init pred.ins_number Fun.id) in
+  let outs_set =
+    SI.of_list
+      (List.init (total - pred.ins_number) (fun i -> i + pred.ins_number))
   in
-  let outs_set = SI.of_list outs in
   (ins_set, outs_set)
 
 let in_params (pred : t) : string list =
-  let ins_set = SI.of_list pred.pred_ins in
-  let _, ins =
-    List.fold_left
-      (fun (i, ins) (x, _) ->
-        if SI.mem i ins_set then (i + 1, x :: ins) else (i + 1, ins))
-      (0, []) pred.pred_params
-  in
-  List.rev ins
+  List.filteri (fun i _ -> i < pred.ins_number) pred.pred_params |> List.map fst
 
 let in_args (pred : t) (args : 'a list) : 'a list =
-  let ins_set = SI.of_list pred.pred_ins in
-  let _, in_args =
-    List.fold_left
-      (fun (i, ins) x ->
-        if SI.mem i ins_set then (i + 1, x :: ins) else (i + 1, ins))
-      (0, []) args
-  in
-  List.rev in_args
+  List.filteri (fun i _ -> i < pred.ins_number) args
 
 let out_params (pred : t) : string list =
-  let ins_set = SI.of_list pred.pred_ins in
-  let _, outs =
-    List.fold_left
-      (fun (i, outs) (x, _) ->
-        if SI.mem i ins_set then (i + 1, outs) else (i + 1, x :: outs))
-      (0, []) pred.pred_params
-  in
-  List.rev outs
+  List.filteri (fun i _ -> i >= pred.ins_number) pred.pred_params
+  |> List.map fst
 
 let out_args (pred : t) (args : 'a list) : 'a list =
-  let ins_set = SI.of_list pred.pred_ins in
-  let _, out_args =
-    List.fold_left
-      (fun (i, outs) x ->
-        if SI.mem i ins_set then (i + 1, outs) else (i + 1, x :: outs))
-      (0, []) args
-  in
-  List.rev out_args
+  List.filteri (fun i _ -> i >= pred.ins_number) args
 
 let pp fmt pred =
-  let show_ins = List.length pred.pred_ins != List.length pred.pred_params in
-  let pp_param fmt' (i, (p, topt)) =
+  let pp_param fmt' (p, topt) =
     let pp_t fmt'' t = Fmt.pf fmt'' " : %s" (Type.str t) in
-    let () = if show_ins && List.mem i pred.pred_ins then Fmt.string fmt' "+" in
     Fmt.pf fmt' "%s%a" p (Fmt.option pp_t) topt
   in
-  let pp_params = Fmt.iter_bindings ~sep:Fmt.comma List.iteri pp_param in
+  (* Prints the parameters as [(in1, ..., ink; out1, ..., outm)], with the
+     in-parameters and out-parameters separated by a semicolon. *)
+  let pp_params fmt' params =
+    let ins = List.filteri (fun i _ -> i < pred.ins_number) params in
+    let outs = List.filteri (fun i _ -> i >= pred.ins_number) params in
+    let pp_out_block fmt'' = function
+      | [] -> ()
+      | outs -> Fmt.pf fmt'' " %a" Fmt.(list ~sep:comma pp_param) outs
+    in
+    Fmt.pf fmt' "%a;%a" Fmt.(list ~sep:comma pp_param) ins pp_out_block outs
+  in
   let pp_id_exs fmt' (id, exs) =
     if List.length exs > 0 then
       Fmt.pf fmt' "[%s: %a] " id (Fmt.list ~sep:(Fmt.any ", ") Fmt.string) exs
@@ -249,46 +235,18 @@ let explicit_param_types (preds : (string, t) Hashtbl.t) (pred : t) :
       pred_facts = pred.pred_facts @ new_facts;
     }
 
-let combine_ins_outs (pred : t) (ins : 'a list) (outs : 'a list) : 'a list =
-  let in_indexes = SI.of_list pred.pred_ins in
-  let max_index = List.length pred.pred_params in
-
-  let rec loop ins outs all cur_index =
-    if cur_index = max_index then all
-    else if SI.mem cur_index in_indexes then
-      match ins with
-      | [] -> raise (Failure "DEATH. combine_ins_outs")
-      | hd :: tl -> loop tl outs (hd :: all) (cur_index + 1)
-    else
-      match outs with
-      | [] -> raise (Failure "DEATH. combine_ins_outs")
-      | hd :: tl -> loop ins tl (hd :: all) (cur_index + 1)
-  in
-  List.rev (loop ins outs [] 0)
+(* In-parameters always come before out-parameters, so combining is just
+   concatenation. *)
+let combine_ins_outs (_pred : t) (ins : 'a list) (outs : 'a list) : 'a list =
+  ins @ outs
 
 let iter_ins_outs
-    (pred : t)
+    (_pred : t)
     (fins : 'a -> unit)
     (fouts : 'b -> unit)
     ((ins, outs) : 'a list * 'b list) : unit =
-  let in_indexes = SI.of_list pred.pred_ins in
-  let max_index = List.length pred.pred_params in
-  let rec loop ins outs cur_index =
-    if cur_index = max_index then ()
-    else if SI.mem cur_index in_indexes then (
-      match ins with
-      | [] -> raise (Failure "DEATH. iter_ins_outs")
-      | hd :: tl ->
-          fins hd;
-          loop tl outs (cur_index + 1))
-    else
-      match outs with
-      | [] -> raise (Failure "DEATH. iter_ins_outs")
-      | hd :: tl ->
-          fouts hd;
-          loop ins tl (cur_index + 1)
-  in
-  loop ins outs 0
+  List.iter fins ins;
+  List.iter fouts outs
 
 let pp_ins_outs (pred : t) pp_in pp_out =
   let pp_iter2 iter pp_a pp_b ppf v =

--- a/GillianCore/GIL_Syntax/Pred.ml
+++ b/GillianCore/GIL_Syntax/Pred.ml
@@ -67,9 +67,9 @@ let pp fmt pred =
     let outs = List.filteri (fun i _ -> i >= pred.ins_number) params in
     let pp_out_block fmt'' = function
       | [] -> ()
-      | outs -> Fmt.pf fmt'' " %a" Fmt.(list ~sep:comma pp_param) outs
+      | outs -> Fmt.pf fmt'' "; %a" Fmt.(list ~sep:comma pp_param) outs
     in
-    Fmt.pf fmt' "%a;%a" Fmt.(list ~sep:comma pp_param) ins pp_out_block outs
+    Fmt.pf fmt' "%a%a" Fmt.(list ~sep:comma pp_param) ins pp_out_block outs
   in
   let pp_id_exs fmt' (id, exs) =
     if List.length exs > 0 then

--- a/GillianCore/GIL_Syntax/TypeDef__.ml
+++ b/GillianCore/GIL_Syntax/TypeDef__.ml
@@ -155,7 +155,7 @@ and expr =
 
 and assertion_atom =
   | Emp
-  | Pred of string * expr list
+  | Pred of string * expr list * expr list
   | Pure of expr
   | Types of (expr * typ) list
   | CorePred of string * expr list * expr list

--- a/GillianCore/GIL_Syntax/TypeDef__.ml
+++ b/GillianCore/GIL_Syntax/TypeDef__.ml
@@ -220,7 +220,7 @@ and pred = {
   pred_internal : bool;
   pred_num_params : int;
   pred_params : (string * typ option) list;
-  pred_ins : int list;
+  ins_number : int;
   pred_definitions : ((string * string list) option * assertion) list;
   pred_facts : expr list;
   pred_guard : assertion option;

--- a/GillianCore/command_line/verification_console.ml
+++ b/GillianCore/command_line/verification_console.ml
@@ -86,7 +86,7 @@ module Make
 
   let verify files already_compiled outfile_opt no_unfold incremental =
     Gillian_result.try_ @@ fun () ->
-    Verification.start_time := Sys.time ();
+    Verification.start_time := Unix.gettimeofday ();
     Fmt.pr "Parsing and compiling...\n@?";
     let* e_prog, init_data, source_files_opt =
       parse_eprog files already_compiled

--- a/GillianCore/command_line/wpst_console.ml
+++ b/GillianCore/command_line/wpst_console.ml
@@ -18,7 +18,7 @@ module Make
   module Common_args = Common_args.Make (PC)
   open Common_args
 
-  let start_time = ref (Sys.time ())
+  let start_time = ref (Unix.gettimeofday ())
 
   let json_ui =
     let doc = "Output some of the UI in JSON." in
@@ -95,7 +95,7 @@ module Make
         else result_before_leak_check
       in
       Printf.printf "Total time (Compilation + Symbolic testing): %fs\n"
-        (Sys.time () -. !start_time);
+        (Unix.gettimeofday () -. !start_time);
       print_json_results all_results;
       let first_error =
         List.find_map
@@ -194,7 +194,7 @@ module Make
       (e_prog, init_data, None)
 
   let process_files files already_compiled outfile_opt incremental =
-    let t = Sys.time () in
+    let t = Unix.gettimeofday () in
     let* e_prog, init_data, source_files_opt =
       parse_eprog files already_compiled
     in
@@ -215,7 +215,7 @@ module Make
     let () =
       L.normal (fun m -> m "\n*** Stage 2: DONE transforming the program.\n")
     in
-    Printf.printf "Compilation time: %fs\n" (Sys.time () -. t);
+    Printf.printf "Compilation time: %fs\n" (Unix.gettimeofday () -. t);
     let () = L.normal (fun m -> m "*** Stage 3: Symbolic Execution.\n") in
     let prog' = MP.init_prog prog in
     run prog' init_data incremental source_files_opt

--- a/GillianCore/debugging/utils/match_map.ml
+++ b/GillianCore/debugging/utils/match_map.ml
@@ -76,7 +76,7 @@ functor
             L.Report_id.pp child_id L.Report_id.pp id type_ Content_type.match_;
         let p =
           match asrt_report.step with
-          | Pred (p, _), _ -> p
+          | Pred (p, _, _), _ -> p
           | _ -> assertion
         in
         { id = child_id; kind = Fold p; result = result_of_id child_id }

--- a/GillianCore/engine/Abstraction/LogicPreprocessing.ml
+++ b/GillianCore/engine/Abstraction/LogicPreprocessing.ml
@@ -631,7 +631,6 @@ let add_closing_tokens preds =
       let pred_name = Pred.close_token_name pred in
       let pred_params = Pred.in_args pred pred.pred_params in
       let pred_num_params = List.length pred_params in
-      let pred_ins = List.init pred_num_params Fun.id in
       let close_token =
         Pred.
           {
@@ -641,7 +640,7 @@ let add_closing_tokens preds =
             pred_internal = false;
             pred_num_params;
             pred_params;
-            pred_ins;
+            ins_number = pred_num_params;
             pred_facts = [];
             pred_definitions = [];
             pred_guard = None;

--- a/GillianCore/engine/Abstraction/LogicPreprocessing.ml
+++ b/GillianCore/engine/Abstraction/LogicPreprocessing.ml
@@ -20,13 +20,14 @@ let rec auto_unfold
            - Recursive predicates (except in some very specific cases)
            - predicates marked with no-unfold
            - predicates with a guard *)
-       | Asrt.Pred (name, _) as asrt
+       | Asrt.Pred (name, _, _) as asrt
          when (Hashtbl.find rec_tbl name && not unfold_rec_predicates)
               ||
               let pred = Hashtbl.find predicates name in
               pred.pred_nounfold || Option.is_some pred.pred_guard ->
            [ [ asrt ] ]
-       | Pred (name, args) when Hashtbl.mem unfolded_preds name ->
+       | Pred (name, ins, outs) when Hashtbl.mem unfolded_preds name ->
+           let args = ins @ outs in
            L.verbose (fun fmt ->
                fmt "Unfolding predicate: %s with nounfold %b" name
                  (Hashtbl.find predicates name).pred_nounfold);
@@ -52,11 +53,12 @@ let rec auto_unfold
            in
            L.tmi (fun m ->
                m "%a ->\n%a" Asrt.pp_atom
-                 (Asrt.Pred (name, args))
+                 (Asrt.Pred (name, ins, outs))
                  (Fmt.list ~sep:(Fmt.any "\n;\n") Asrt.pp)
                  asrts);
            asrts
-       | Pred (name, args) as asrt -> (
+       | Pred (name, ins, outs) as asrt -> (
+           let args = ins @ outs in
            try
              L.tmi (fun fmt -> fmt "AutoUnfold: %a : %s" Asrt.pp_atom asrt name);
              let pred : Pred.t = Hashtbl.find predicates name in

--- a/GillianCore/engine/Abstraction/MP.ml
+++ b/GillianCore/engine/Abstraction/MP.ml
@@ -529,16 +529,9 @@ let ins_outs_assertion
   | Emp -> []
   | Pure form -> ins_outs_formula kb form
   | CorePred (_, lie, loe) -> ins_and_outs_from_lists kb lie loe
-  | Pred (p_name, args) ->
-      let p_ins = get_pred_ins p_name in
-      let _, lie, loe =
-        List.fold_left
-          (fun (i, lie, loe) arg ->
-            if List.mem i p_ins then (i + 1, lie @ [ arg ], loe)
-            else (i + 1, lie, loe @ [ arg ]))
-          (0, [], []) args
-      in
-      ins_and_outs_from_lists kb lie loe
+  | Pred (_p_name, ins, outs) ->
+      (* The in/out split is carried by the assertion's syntax (the [;]). *)
+      ins_and_outs_from_lists kb ins outs
   (* The types assertion has no outs and requires all ins *)
   | Types [ (e, _) ] ->
       let ins = simple_ins_expr e in
@@ -939,15 +932,17 @@ let pp_asrt
     (fmt : Format.formatter)
     (a : Asrt.t) =
   let pp_atom_asrt fmt = function
-    | Asrt.Pred (name, args) -> (
+    | Asrt.Pred (name, ins, outs) -> (
+        let args = ins @ outs in
         match preds_printer with
         | Some pp_pred -> (Fmt.hbox pp_pred) fmt (name, args)
         | None -> (
             try
               let pred = get_pred_def preds name in
+              (* The in/out split is carried by the assertion itself. *)
               let out_params = Pred.out_params pred.pred in
-              let out_args = Pred.out_args pred.pred args in
-              let in_args = Pred.in_args pred.pred args in
+              let out_args = outs in
+              let in_args = ins in
               let out_params_args = List.combine out_params out_args in
               let pp_out_params_args fmt (x, e) =
                 Fmt.pf fmt "@[<h>%s: %a@]" x Expr.pp e

--- a/GillianCore/engine/Abstraction/MP.ml
+++ b/GillianCore/engine/Abstraction/MP.ml
@@ -825,7 +825,7 @@ let init_preds (preds : (string, Pred.t) Hashtbl.t) :
   let pred_ins =
     Hashtbl.fold
       (fun name (pred : Pred.t) pred_ins ->
-        Hashtbl.add pred_ins name pred.pred_ins;
+        Hashtbl.add pred_ins name (Pred.ins_indexes pred);
         pred_ins)
       preds
       (Hashtbl.create Config.medium_tbl_size)
@@ -840,7 +840,7 @@ let init_preds (preds : (string, Pred.t) Hashtbl.t) :
                (fun i ->
                  let param, _ = List.nth pred.pred_params i in
                  Expr.PVar param)
-               pred.pred_ins)
+               (Pred.ins_indexes pred))
         in
 
         let defs =
@@ -892,7 +892,7 @@ let init_prog ?preds_tbl (prog : ('a, int) Prog.t) : 'a prog =
     let pred_ins =
       Hashtbl.fold
         (fun name (pred : pred) pred_ins ->
-          Hashtbl.add pred_ins name pred.pred.pred_ins;
+          Hashtbl.add pred_ins name (Pred.ins_indexes pred.pred);
           pred_ins)
         preds
         (Hashtbl.create Config.medium_tbl_size)
@@ -1018,7 +1018,7 @@ let add_spec (prog : 'a prog) (spec : Spec.t) : unit =
   let pred_ins =
     Hashtbl.fold
       (fun name (pred : pred) pred_ins ->
-        Hashtbl.add pred_ins name pred.pred.pred_ins;
+        Hashtbl.add pred_ins name (Pred.ins_indexes pred.pred);
         pred_ins)
       prog.preds
       (Hashtbl.create Config.medium_tbl_size)

--- a/GillianCore/engine/Abstraction/Matcher.ml
+++ b/GillianCore/engine/Abstraction/Matcher.ml
@@ -594,8 +594,9 @@ module Make (State : SState.S) :
         match state' with
         | None -> []
         | Some _ -> [ Ok { state; preds; wands; pred_defs } ])
-    | Pred (pname, les) ->
+    | Pred (pname, ins, outs) ->
         L.verbose (fun fmt -> fmt "Predicate assertion.");
+        let les = ins @ outs in
         let vs = List.map (subst_in_expr subst) les in
         let pred_def = Hashtbl.find pred_defs pname in
         let++ { state; preds; wands; pred_defs } =
@@ -1261,18 +1262,17 @@ module Make (State : SState.S) :
                     let error = StateErr.EAsrt ([], fail_pf) in
                     Res_list.error_with error
                 | Vanish -> Res_list.vanish)
-          | Pred (pname, les) ->
+          | Pred (pname, ins, outs) ->
+              let les = ins @ outs in
               L.verbose (fun m -> m "Matching predicate assertion");
               (* Perform substitution in all predicate parameters *)
               L.verbose (fun fmt ->
                   fmt "ARGS: %a" Fmt.(list ~sep:comma Expr.pp) les);
               L.verbose (fun fmt -> fmt "SUBST:\n%a" SVal.SESubst.pp subst);
               let vs = List.map (subst_in_expr_opt astate subst) les in
-              (* Get the ins of the predicate *)
-              let pred = MP.get_pred_def pred_defs pname in
-              let pred_def = pred.pred in
-              let vs_ins = Pred.in_args pred_def vs in
-              let les_outs = Pred.out_args pred_def les in
+              (* The in/out split is carried by the assertion's syntax. *)
+              let vs_ins = List.map (subst_in_expr_opt astate subst) ins in
+              let les_outs = outs in
               (* All of which must have survived substitution *)
               let failure = List.exists (fun x -> x = None) vs_ins in
               if failure then (
@@ -1854,7 +1854,12 @@ module Make (State : SState.S) :
 
     let get_defs (pred : Pred.t) largs =
       if pred.pred_abstract || Option.is_some pred.pred_guard then
-        [ [ Asrt.Pred (pred.pred_name, largs) ] ]
+        [
+          [
+            Asrt.Pred
+              (pred.pred_name, Pred.in_args pred largs, Pred.out_args pred largs);
+          ];
+        ]
       else
         let unfolded_pred =
           Hashtbl.find_opt LogicPreprocessing.unfolded_preds pred.pred_name
@@ -1942,7 +1947,7 @@ module Make (State : SState.S) :
         split_answer option =
       let open Syntaxes.Option in
       match (step, errs) with
-      | (Pred (name, args), _), _ ->
+      | (Pred (name, ins, outs), _), _ ->
           let MP.{ pred; def_mp; _ } = MP.get_pred_def astate.pred_defs name in
           let* () =
             if pred.pred_abstract || Option.is_some pred.pred_guard then None
@@ -1951,8 +1956,9 @@ module Make (State : SState.S) :
           let in_params =
             Pred.in_params pred |> List.map (fun x -> Expr.PVar x)
           in
+          (* The in/out split is carried by the assertion's syntax. *)
           let in_args =
-            Pred.in_args pred args
+            ins
             |> List.map (SVal.SESubst.subst_in_expr_opt subst)
             |> List.map Option.get
           in
@@ -1960,7 +1966,7 @@ module Make (State : SState.S) :
             List.combine in_params in_args |> SVal.SESubst.init
           in
           let out_params = Pred.out_params pred in
-          let out_args = Pred.out_args pred args in
+          let out_args = outs in
           Some
             {
               mp = def_mp;

--- a/GillianCore/engine/Abstraction/Matcher.ml
+++ b/GillianCore/engine/Abstraction/Matcher.ml
@@ -1034,7 +1034,7 @@ module Make (State : SState.S) :
     (* we attempt to consume the pred as-is from our state. *)
     match
       Preds.consume_pred ~maintain:pred_pure preds pname vs
-        (Containers.SI.of_list pred_def.pred_ins)
+        (Containers.SI.of_list (Pred.ins_indexes pred_def))
         (State.equals state)
     with
     | Some (_, vs) -> (
@@ -1905,7 +1905,8 @@ module Make (State : SState.S) :
     let make_pred_ins_table pred_tbl =
       let tbl = Hashtbl.create (Hashtbl.length pred_tbl) in
       Hashtbl.iter
-        (fun pname pred -> Hashtbl.add tbl pname pred.MP.pred.pred_ins)
+        (fun pname pred ->
+          Hashtbl.add tbl pname (Pred.ins_indexes pred.MP.pred))
         pred_tbl;
       tbl
 

--- a/GillianCore/engine/Abstraction/Normaliser.ml
+++ b/GillianCore/engine/Abstraction/Normaliser.ml
@@ -498,8 +498,8 @@ module Make (SPState : PState.S) = struct
             (core_asrts, pure, types, preds, Wands.{ lhs; rhs } :: wands)
         | Emp -> (core_asrts, pure, types, preds, wands)
         | Types lst -> (core_asrts, pure, lst @ types, preds, wands)
-        | Pred (name, params) ->
-            (core_asrts, pure, types, (name, params) :: preds, wands)
+        | Pred (name, ins, outs) ->
+            (core_asrts, pure, types, (name, ins @ outs) :: preds, wands)
         | Pure f -> (core_asrts, f :: pure, types, preds, wands))
       ([], [], [], [], []) a
 

--- a/GillianCore/engine/Abstraction/PState.ml
+++ b/GillianCore/engine/Abstraction/PState.ml
@@ -267,9 +267,13 @@ module Make (State : SState.S) :
     |> SS.union (Wands.get_lvars wands)
 
   let to_assertions ?(to_keep : SS.t option) (astate : t) : Asrt.t =
-    let { state; preds; wands; _ } = astate in
+    let { state; preds; wands; pred_defs; _ } = astate in
     let s_asrts = State.to_assertions ?to_keep state in
-    let p_asrts = Preds.to_assertions preds in
+    let split_ins_outs name args =
+      let pred = (MP.get_pred_def pred_defs name).pred in
+      (Pred.in_args pred args, Pred.out_args pred args)
+    in
+    let p_asrts = Preds.to_assertions ~split_ins_outs preds in
     let w_asrts = Wands.to_assertions wands in
     List.sort Asrt.compare (p_asrts @ s_asrts @ w_asrts)
 

--- a/GillianCore/engine/Abstraction/PState.ml
+++ b/GillianCore/engine/Abstraction/PState.ml
@@ -444,7 +444,7 @@ module Make (State : SState.S) :
     let pred_ins =
       Hashtbl.fold
         (fun name (pred : Pred.t) pred_ins ->
-          Hashtbl.add pred_ins name pred.pred_ins;
+          Hashtbl.add pred_ins name (Pred.ins_indexes pred);
           pred_ins)
         prog.prog.preds
         (Hashtbl.create Config.medium_tbl_size)
@@ -618,7 +618,7 @@ module Make (State : SState.S) :
     let pred_ins =
       Hashtbl.fold
         (fun name (pred : Pred.t) pred_ins ->
-          Hashtbl.add pred_ins name pred.pred_ins;
+          Hashtbl.add pred_ins name (Pred.ins_indexes pred);
           pred_ins)
         prog.prog.preds
         (Hashtbl.create Config.medium_tbl_size)
@@ -949,7 +949,7 @@ module Make (State : SState.S) :
           let pred_ins =
             Hashtbl.fold
               (fun name (pred : Pred.t) pred_ins ->
-                Hashtbl.add pred_ins name pred.pred_ins;
+                Hashtbl.add pred_ins name (Pred.ins_indexes pred);
                 pred_ins)
               prog.prog.preds
               (Hashtbl.create Config.medium_tbl_size)

--- a/GillianCore/engine/Abstraction/Preds.ml
+++ b/GillianCore/engine/Abstraction/Preds.ml
@@ -225,7 +225,12 @@ let substitution_in_place (subst : st) (preds : t) : unit =
   let pred_substitution subst (s, vs) = (s, List.map (subst_in_val subst) vs) in
   preds := List.map (pred_substitution subst) !preds
 
-let to_assertions (preds : t) : Asrt.atom list =
+let to_assertions
+    ~(split_ins_outs : string -> vt list -> vt list * vt list)
+    (preds : t) : Asrt.atom list =
   let preds = to_list preds in
-  let pred_to_assert (n, args) = Asrt.Pred (n, args) in
+  let pred_to_assert (n, args) =
+    let ins, outs = split_ins_outs n args in
+    Asrt.Pred (n, ins, outs)
+  in
   List.sort Asrt.compare (List.map pred_to_assert preds)

--- a/GillianCore/engine/Abstraction/Preds.mli
+++ b/GillianCore/engine/Abstraction/Preds.mli
@@ -39,5 +39,10 @@ val find : t -> (abs_t -> bool) -> abs_t option
 val get_all : maintain:bool -> (abs_t -> bool) -> t -> abs_t list
 val substitution_in_place : SVal.SESubst.t -> t -> unit
 
-(** Turns a predicate set into a list of assertions *)
-val to_assertions : t -> Asrt.t
+(** Turns a predicate set into a list of assertions. [split_ins_outs name args]
+    splits the (flat) argument list of a predicate instance into its in- and
+    out-arguments, so the resulting [Pred] atoms carry the proper separation. *)
+val to_assertions :
+  split_ins_outs:(string -> Expr.t list -> Expr.t list * Expr.t list) ->
+  t ->
+  Asrt.t

--- a/GillianCore/engine/Abstraction/Verifier.ml
+++ b/GillianCore/engine/Abstraction/Verifier.ml
@@ -683,7 +683,7 @@ struct
     object
       inherit [_] Visitors.reduce
       inherit Visitors.Utils.ss_monoid
-      method! visit_Pred _ pred_name _ = SS.singleton pred_name
+      method! visit_Pred _ pred_name _ _ = SS.singleton pred_name
       method! visit_Fold _ pred_name _ _ = SS.singleton pred_name
       method! visit_Unfold _ pred_name _ _ _ = SS.singleton pred_name
       method! visit_GUnfold _ pred_name = SS.singleton pred_name

--- a/GillianCore/engine/Abstraction/Verifier.ml
+++ b/GillianCore/engine/Abstraction/Verifier.ml
@@ -775,7 +775,7 @@ struct
         let pred_ins =
           Hashtbl.fold
             (fun name (pred : MP.pred) pred_ins ->
-              Hashtbl.add pred_ins name pred.pred.pred_ins;
+              Hashtbl.add pred_ins name (Pred.ins_indexes pred.pred);
               pred_ins)
             preds
             (Hashtbl.create Config.medium_tbl_size)
@@ -1024,7 +1024,7 @@ struct
       let pred_ins =
         Hashtbl.fold
           (fun name (pred : MP.pred) pred_ins ->
-            Hashtbl.add pred_ins name pred.pred.pred_ins;
+            Hashtbl.add pred_ins name (Pred.ins_indexes pred.pred);
             pred_ins)
           preds
           (Hashtbl.create Config.medium_tbl_size)

--- a/GillianCore/engine/Abstraction/Verifier.ml
+++ b/GillianCore/engine/Abstraction/Verifier.ml
@@ -120,7 +120,7 @@ struct
       |> List.map (fun (name, test) -> `List [ `String name; to_yojson test ]))
 
   let global_results = VerificationResults.make ()
-  let start_time = ref 0.
+  let start_time = ref (Unix.gettimeofday ())
 
   let reset () =
     VerificationResults.reset global_results;
@@ -867,7 +867,7 @@ struct
       get_tests_to_verify ~init_data prog pnames_to_verify lnames_to_verify
     in
     (* STEP 6: Run the symbolic tests *)
-    let cur_time = Sys.time () in
+    let cur_time = Unix.gettimeofday () in
     Printf.printf "Running symbolic tests: %f\n" (cur_time -. !start_time);
     let result =
       let rec aux = function
@@ -879,7 +879,7 @@ struct
       in
       aux (tests' @ tests, Ok ())
     in
-    let end_time = Sys.time () in
+    let end_time = Unix.gettimeofday () in
     let cur_verified = SS.union pnames_to_verify lnames_to_verify in
     let success =
       Result.is_ok result && check_previously_verified prev_results cur_verified

--- a/GillianCore/engine/BiAbduction/Abductor.ml
+++ b/GillianCore/engine/BiAbduction/Abductor.ml
@@ -303,13 +303,13 @@ struct
           in
           L.verbose (fun m -> m "Running bi-abduction on %s\n" test.name);
           Fmt.pr "Testing %s... @?" test.name;
-          let start_time = Sys.time () in
+          let start_time = Unix.gettimeofday () in
           let rets =
             run_test
               (process_sym_exec_result prog test.name test.params test.state)
               prog test
           in
-          let end_time = Sys.time () in
+          let end_time = Unix.gettimeofday () in
           let stats =
             get_stats test.name (fun () ->
                 match Hashtbl.find_opt prog.prog.procs test.name with
@@ -352,7 +352,7 @@ struct
           String.compare name1 name2)
     in
 
-    Fmt.pr "Ok 3 - %f@." (Sys.time ());
+    Fmt.pr "Ok 3 - %f@." (Unix.gettimeofday ());
     if !Config.specs_to_stdout then (
       let bug_specs_txt =
         Format.asprintf "@[<v 2>BUG SPECS:@\n%a@]@\n"

--- a/GillianCore/engine/FOLogic/FOSolver.ml
+++ b/GillianCore/engine/FOLogic/FOSolver.ml
@@ -78,7 +78,7 @@ let check_satisfiability
     ?relevant_info
     (fs : Expr.t list)
     (gamma : Type_env.t) : bool =
-  (* let t = if time = "" then 0. else Sys.time () in *)
+  (* let t = if time = "" then 0. else Unix.gettimeofday () in *)
   L.verbose (fun m -> m "Entering FOSolver.check_satisfiability");
   let fs, gamma, _ = simplify_pfs_and_gamma ?relevant_info ~matching fs gamma in
   let axioms = get_axioms fs gamma in
@@ -93,7 +93,7 @@ let check_satisfiability
     in
     (* if time <> "" then
        Utils.Statistics.update_statistics ("FOS: CheckSat: " ^ time)
-         (Sys.time () -. t); *)
+         (Unix.gettimeofday () -. t); *)
     result
 
 let sat ~matching ~pfs ~gamma formula : bool =
@@ -135,7 +135,7 @@ let check_entailment
   (* SOUNDNESS !!DANGER!!: call to simplify_implication       *)
   (* Simplify maximally the implication to be checked         *)
   (* Remove from the typing environment the unused variables  *)
-  (* let t = Sys.time () in *)
+  (* let t = Unix.gettimeofday () in *)
   let left_fs = PFS.copy left_fs in
   let gamma = Type_env.copy gamma in
   let right_fs = PFS.of_list right_fs in
@@ -210,11 +210,11 @@ let check_entailment
                L.tmi (fun m -> m "Here's the model:\n%a" Smt.pp_sexp model))
       in
       (* Utils.Statistics.update_statistics "FOS: CheckEntailment"
-         (Sys.time () -. t); *)
+         (Unix.gettimeofday () -. t); *)
       ret
 
 let is_equal ?matching ~pfs ~gamma e1 e2 =
-  (* let t = Sys.time () in *)
+  (* let t = Unix.gettimeofday () in *)
   let feq =
     Reduction.reduce_lexpr ?matching ~gamma ~pfs (BinOp (e1, Equal, e2))
   in
@@ -229,11 +229,11 @@ let is_equal ?matching ~pfs ~gamma e1 e2 =
              ("Equality reduced to something unexpected: "
              ^ (Fmt.to_to_string Expr.pp) feq))
   in
-  (* Utils.Statistics.update_statistics "FOS: is_equal" (Sys.time () -. t); *)
+  (* Utils.Statistics.update_statistics "FOS: is_equal" (Unix.gettimeofday () -. t); *)
   result
 
 let is_different ~pfs ~gamma e1 e2 =
-  (* let t = Sys.time () in *)
+  (* let t = Unix.gettimeofday () in *)
   let feq =
     Reduction.reduce_lexpr ~gamma ~pfs (UnOp (Not, BinOp (e1, Equal, e2)))
   in
@@ -247,7 +247,7 @@ let is_different ~pfs ~gamma e1 e2 =
              ("Inequality reduced to something unexpected: "
              ^ (Fmt.to_to_string Expr.pp) feq))
   in
-  (* Utils.Statistics.update_statistics "FOS: is different" (Sys.time () -. t); *)
+  (* Utils.Statistics.update_statistics "FOS: is different" (Unix.gettimeofday () -. t); *)
   result
 
 let num_is_less_or_equal ~pfs ~gamma e1 e2 =

--- a/GillianCore/engine/FOLogic/Reduction.ml
+++ b/GillianCore/engine/FOLogic/Reduction.ml
@@ -2316,9 +2316,9 @@ and reduce_lexpr
     ?(pfs = PFS.init ())
     ?(gamma = Type_env.init ())
     (le : Expr.t) =
-  (* let t = Sys.time () in *)
+  (* let t = Unix.gettimeofday () in *)
   let result = reduce_lexpr_loop ~matching ~reduce_lvars pfs gamma le in
-  (* Utils.Statistics.update_statistics "Reduce Expression" (Sys.time () -. t); *)
+  (* Utils.Statistics.update_statistics "Reduce Expression" (Unix.gettimeofday () -. t); *)
   if not @@ Expr.equal le result then
     Logging.normal (fun f ->
         f "reduce_lexpr: @[%a -> %a@]" Expr.pp le Expr.pp result);

--- a/GillianCore/engine/FOLogic/Reduction.ml
+++ b/GillianCore/engine/FOLogic/Reduction.ml
@@ -2882,7 +2882,8 @@ let reduce_assertion_loop
             };
         ]
     (* Predicates *)
-    | Pred (name, les) -> [ Pred (name, List.map fe les) ]
+    | Pred (name, ins, outs) ->
+        [ Pred (name, List.map fe ins, List.map fe outs) ]
     (* Pure assertions *)
     | Pure (Lit (Bool true)) -> []
     | Pure (BinOp (f1, BinOp.And, f2)) -> [ Pure f1; Pure f2 ]

--- a/GillianCore/engine/FOLogic/Simplifications.ml
+++ b/GillianCore/engine/FOLogic/Simplifications.ml
@@ -311,7 +311,7 @@ let simplify_pfs_and_gamma
     (lpfs : PFS.t)
     ?(rpfs : PFS.t option)
     (gamma : Type_env.t) : SESubst.t * SS.t =
-  (* let t = Sys.time () in *)
+  (* let t = Unix.gettimeofday () in *)
   let rpfs : PFS.t = Option.value ~default:(PFS.init ()) rpfs in
   let existentials : SS.t ref =
     ref (Option.value ~default:SS.empty existentials)
@@ -935,7 +935,7 @@ let simplify_pfs_and_gamma
       Hashtbl.replace simplification_cache key cached_simplification;
 
       (* Utils.Statistics.update_statistics "FOS: SimplifyPFSandGamma"
-         (Sys.time () -. t); *)
+         (Unix.gettimeofday () -. t); *)
 
       (* Step 5 - Sort ALoc transitivity *)
       let rec find_loc_all_the_way aloc res =
@@ -971,7 +971,7 @@ let simplify_implication
     (lpfs : PFS.t)
     (rpfs : PFS.t)
     (gamma : Type_env.t) =
-  (* let t = Sys.time () in *)
+  (* let t = Unix.gettimeofday () in *)
   List.iter
     (fun (pf : Expr.t) ->
       match pf with
@@ -1011,7 +1011,7 @@ let simplify_implication
           (Fmt.iter ~sep:Fmt.comma SS.iter Fmt.string)
           exists PFS.pp lpfs PFS.pp rpfs Type_env.pp gamma));
   (* Utils.Statistics.update_statistics "FOS: SimplifyImplication"
-     (Sys.time () -. t); *)
+     (Unix.gettimeofday () -. t); *)
   exists
 
 let admissible_assertion (a : Asrt.t) : bool =

--- a/GillianCore/engine/general_semantics/general/g_interpreter.ml
+++ b/GillianCore/engine/general_semantics/general/g_interpreter.ml
@@ -311,8 +311,8 @@ struct
             State.pp_by_need pvars lvars locs
       in
       ConfigReport.log state_printer
-        (ConfigReport.make ~proc_name ~proc_line:i ~time:(Sys.time ()) ~cmd
-           ~callstack:cs ~annot ~branching:b_counter ~state ?branch_case ())
+        (ConfigReport.make ~proc_name ~proc_line:i ~time:(Unix.gettimeofday ())
+           ~cmd ~callstack:cs ~annot ~branching:b_counter ~state ?branch_case ())
 
     let print_lconfiguration
         (lcmd : LCmd.t)
@@ -328,7 +328,8 @@ struct
              @\n\
              %a@\n\
              ------------------------------------------------------@]@\n"
-            (Sys.time ()) LCmd.pp lcmd Location.pp_log_opt loc State.pp state)
+            (Unix.gettimeofday ()) LCmd.pp lcmd Location.pp_log_opt loc State.pp
+            state)
 
     let pp_err = Exec_err.pp Val.pp State.pp_err
     let pp_single_result ft res = Exec_res.pp State.pp Val.pp pp_err ft res

--- a/GillianCore/gil_parser/GIL_Parser.mly
+++ b/GillianCore/gil_parser/GIL_Parser.mly
@@ -813,8 +813,8 @@ top_level_g_assertion_target:
   a = g_assertion_target; EOF { a }
 
 predicate_call:
-  name = proc_name; LBRACE; params = separated_list(COMMA, expr_target); RBRACE
-  { (name, params) }
+  name = proc_name; LBRACE; ins = separated_list(COMMA, expr_target); SCOLON; outs = separated_list(COMMA, expr_target); RBRACE
+  { (name, ins, outs) }
 
 g_assertion_target:
 (* (pure) /\ (pure) *)
@@ -828,7 +828,8 @@ g_assertion_target:
   | left_ass=g_assertion_target; FTIMES; right_ass=g_assertion_target
     { left_ass @ right_ass } %prec separating_conjunction
   | lhs = predicate_call; WAND; rhs = predicate_call
-    { [ Asrt.Wand {lhs; rhs } ] }
+    { let (ln, li, lo) = lhs and (rn, ri, ro) = rhs in
+      [ Asrt.Wand {lhs = (ln, li @ lo); rhs = (rn, ri @ ro) } ] }
 (* <CorePred>(es; es) *)
   | FLT; v=VAR; FGT; LBRACE; es1=separated_list(COMMA, expr_target); SCOLON; es2=separated_list(COMMA, expr_target); RBRACE
     { [ Asrt.CorePred (v, es1, es2) ] }
@@ -838,8 +839,8 @@ g_assertion_target:
 (* x(e1, ..., en) *)
   | pcall = predicate_call
     {
-      let (name, params) = pcall in
-      [ Asrt.Pred (name, params) ]
+      let (name, ins, outs) = pcall in
+      [ Asrt.Pred (name, ins, outs) ]
     }
 (* types (type_pairs) *)
   | LTYPES; LBRACE; type_pairs = separated_list(COMMA, type_env_pair_target); RBRACE
@@ -878,7 +879,8 @@ g_logic_cmd_target:
     { LCmd.SL (Unfold (name, les, unfold_info, true)) }
 
   | PACKAGE; LBRACE; lhs = predicate_call; WAND; rhs = predicate_call; RBRACE;
-    { LCmd.SL (Package { lhs; rhs })}
+    { let (ln, li, lo) = lhs and (rn, ri, ro) = rhs in
+      LCmd.SL (Package { lhs = (ln, li @ lo); rhs = (rn, ri @ ro) })}
 
 (* unfold_all x *)
   | UNFOLDALL; name = proc_name

--- a/GillianCore/gil_parser/GIL_Parser.mly
+++ b/GillianCore/gil_parser/GIL_Parser.mly
@@ -353,11 +353,12 @@ pred_param_target:
 
 (* Predicate parameters: in-parameters and out-parameters, separated by a
    semicolon. E.g. [(in1, in2; out1, out2)], [(in1, in2;)] for all-ins,
-   [(;out1, out2)] for all-outs. *)
+   [(;out1, out2)] for all-outs.
+   No semicolon implies all-ins.*)
 pred_head_target:
   name = proc_name; LBRACE;
-    ins = separated_list(COMMA, pred_param_target); SCOLON;
-    outs = separated_list(COMMA, pred_param_target);
+    ins = separated_list(COMMA, pred_param_target);
+    outs = outs(pred_param_target);
   RBRACE;
   { let params = ins @ outs in
     let num_params = List.length params in
@@ -813,7 +814,10 @@ top_level_g_assertion_target:
   a = g_assertion_target; EOF { a }
 
 predicate_call:
-  name = proc_name; LBRACE; ins = separated_list(COMMA, expr_target); SCOLON; outs = separated_list(COMMA, expr_target); RBRACE
+  name = proc_name; LBRACE;
+  ins = separated_list(COMMA, expr_target);
+  outs = outs(expr_target);
+  RBRACE
   { (name, ins, outs) }
 
 g_assertion_target:
@@ -831,7 +835,7 @@ g_assertion_target:
     { let (ln, li, lo) = lhs and (rn, ri, ro) = rhs in
       [ Asrt.Wand {lhs = (ln, li @ lo); rhs = (rn, ri @ ro) } ] }
 (* <CorePred>(es; es) *)
-  | FLT; v=VAR; FGT; LBRACE; es1=separated_list(COMMA, expr_target); SCOLON; es2=separated_list(COMMA, expr_target); RBRACE
+  | FLT; v=VAR; FGT; LBRACE; es1=separated_list(COMMA, expr_target); es2=outs(expr_target); RBRACE
     { [ Asrt.CorePred (v, es1, es2) ] }
 (* emp *)
   | LEMP;
@@ -1264,3 +1268,12 @@ type_target:
   | TYPETYPELIT  { Type.TypeType }
   | SETTYPELIT   { Type.SetType }
 ;
+
+%inline outs(X):
+  xs = option_preceded_separated_list(SCOLON, COMMA, X)
+  { xs }
+
+%inline option_preceded_separated_list(PREC, SEP, X):
+  | PREC; xs = separated_list(SEP, X) { xs }
+  | { [] }
+

--- a/GillianCore/gil_parser/GIL_Parser.mly
+++ b/GillianCore/gil_parser/GIL_Parser.mly
@@ -346,23 +346,23 @@ assertion_id_target:
 ;
 
 pred_param_target:
-  (* Program variable with in-parameter status and optional type *)
-  | in_param = option(FPLUS); v = VAR; t = option(preceded(COLON, type_target))
-    { let in_param = Option.fold ~some:(fun _ -> true) ~none:false in_param in
-      (v, t), in_param }
+  (* Program variable with optional type *)
+  | v = VAR; t = option(preceded(COLON, type_target))
+    { (v, t) }
 ;
 
+(* Predicate parameters: in-parameters and out-parameters, separated by a
+   semicolon. E.g. [(in1, in2; out1, out2)], [(in1, in2;)] for all-ins,
+   [(;out1, out2)] for all-outs. *)
 pred_head_target:
-  name = proc_name; LBRACE; params = separated_list(COMMA, pred_param_target); RBRACE;
-  { (* Register the predicate declaration in the syntax checker *)
+  name = proc_name; LBRACE;
+    ins = separated_list(COMMA, pred_param_target); SCOLON;
+    outs = separated_list(COMMA, pred_param_target);
+  RBRACE;
+  { let params = ins @ outs in
     let num_params = List.length params in
-    let params, ins = List.split params in
-    let param_names, _ = List.split params in
-    let ins = List.map Option.get (List.filter (fun x -> x <> None) (List.mapi (fun i is_in -> if is_in then Some i else None) ins)) in
-    let ins = if (List.length ins > 0) then ins else (List.mapi (fun i _ -> i) param_names) in
-    (* register_predicate name num_params; *)
-    (* enter_predicate params; *)
-    (name, num_params, params, ins)
+    let ins_number = List.length ins in
+    (name, num_params, params, ins_number)
   }
 ;
 
@@ -975,7 +975,7 @@ g_pred_target:
     let pred_abstract = Option.is_some abstract in
     let pred_pure = Option.is_some pure in
     let pred_nounfold = pred_abstract || Option.is_some nounfold in
-    let (pred_name, pred_num_params, pred_params, pred_ins) = pred_head in
+    let (pred_name, pred_num_params, pred_params, ins_number) = pred_head in
     let pred_definitions = Option.value ~default:[] pred_definitions in
     let () = if (pred_abstract <> (pred_definitions = [])) then
       raise (Failure (Format.asprintf "Malformed predicate %s: either abstract with definition or non-abstract without definition." pred_name))
@@ -1000,7 +1000,7 @@ g_pred_target:
         pred_internal = Option.is_some internal;
         pred_num_params;
         pred_params;
-        pred_ins;
+        ins_number;
         pred_definitions;
         pred_facts;
         pred_guard;

--- a/GillianCore/logging/report_builder.ml
+++ b/GillianCore/logging/report_builder.ml
@@ -62,7 +62,7 @@ let make
     {
       id = Report_id.next ();
       title;
-      elapsed_time = Sys.time ();
+      elapsed_time = Unix.gettimeofday ();
       previous = get_previous ();
       parent = get_parent ();
       content;

--- a/GillianCore/smt/smt.ml
+++ b/GillianCore/smt/smt.ml
@@ -16,7 +16,7 @@ let z3_config =
     ("proof", "false");
     ("unsat_core", "false");
     ("auto_config", "true");
-    ("timeout", "30000");
+    ("timeout", try Sys.getenv "SMT_TIMEOUT" with Not_found -> "30000");
   ]
 
 let () = Sys.(set_signal sigpipe Signal_ignore)
@@ -24,8 +24,60 @@ let () = Sys.(set_signal sigpipe Signal_ignore)
 exception SMT_unknown
 
 let pp_sexp = Sexplib.Sexp.pp_hum
-let init_decls : sexp list ref = ref []
-let builtin_funcs : sexp list ref = ref []
+
+(** {2 Tracking the declarations a query depends on}
+
+    The solver is reset before every query (see [reset_solver]), so each query
+    must (re-)send the datatype and function declarations it relies on. At
+    encoding time, we keep track of the necessary dependencies of the assertion
+    being encoded through [Require_definition]. *)
+
+type definition = {
+  id : int;
+  decls : sexp list;  (** the SMT commands declaring this definition *)
+  depends_on : definition list;  (** definitions that must be emitted first *)
+}
+
+let make_definition =
+  let counter = ref 0 in
+  fun ?(depends_on = []) decls ->
+    incr counter;
+    { id = !counter; decls; depends_on }
+
+type _ Effect.t += Require_definition : definition -> unit Effect.t
+
+let require_definition d = Effect.perform (Require_definition d)
+
+(** Run [f], returning its result together with the set of definitions it
+    required (keyed by id), closed under the [depends_on] relation. *)
+let with_necessary_definitions (f : unit -> 'a) :
+    'a * (int, definition) Hashtbl.t =
+  let needed = Hashtbl.create 17 in
+  let rec add d =
+    if not (Hashtbl.mem needed d.id) then (
+      Hashtbl.replace needed d.id d;
+      List.iter add d.depends_on)
+  in
+  let result =
+    match f () with
+    | x -> x
+    | effect Require_definition d, k ->
+        add d;
+        Effect.Deep.continue k ()
+  in
+  (result, needed)
+
+(** Send each required definition through [emit], preceded by the definitions it
+    depends on (so declarations always come before their uses). *)
+let emit_definitions ~emit (needed : (int, definition) Hashtbl.t) =
+  let emitted = Hashtbl.create (Hashtbl.length needed) in
+  let rec go d =
+    if not (Hashtbl.mem emitted d.id) then (
+      Hashtbl.replace emitted d.id ();
+      List.iter go d.depends_on;
+      List.iter emit d.decls)
+  in
+  Hashtbl.iter (fun _ d -> go d) needed
 
 let solver =
   ref
@@ -38,18 +90,16 @@ let solver =
     }
 
 let cmd s = ack_command !solver s
+let reset = list [ atom "reset" ]
 
 let rec init_solver () =
   let z3 = new_solver z3 in
   let command = protected_command z3 in
   let () = solver := { z3 with command } in
-  (* Config, initial decls *)
+  (* Configuration *)
   let () =
     z3_config |> List.iter (fun (k, v) -> cmd (set_option (":" ^ k) v))
   in
-  let decls = List.rev !init_decls in
-  let () = decls |> List.iter cmd in
-  let () = cmd (push 1) in
   ()
 
 and protected_command solver s =
@@ -88,7 +138,8 @@ let sexps_to_yojson sexps =
 
 let pp_typenv = Fmt.(Dump.hashtbl string (Fmt.of_to_string Type.str))
 
-let encoding_cache : (Expr.Set.t, sexp list) Hashtbl.t =
+let encoding_cache :
+    (Expr.Set.t, sexp list * (int, definition) Hashtbl.t) Hashtbl.t =
   Hashtbl.create Config.big_tbl_size
 
 let sat_cache : (Expr.Set.t, sexp option) Hashtbl.t =
@@ -192,7 +243,15 @@ let declare_recognizer ~name ~constructor ~typ =
     t_bool
     (list [ atom "_"; atom "is"; atom constructor ] <| atom "x")
 
-let mk_datatype name type_params (variants : (module Variant.S) list) =
+(* Builds a datatype declaration together with its recognizers, and returns
+   both the type's atom and a {!definition} that can be required during
+   encoding. [depends_on] lists the datatypes this one refers to in its fields,
+   which must therefore be declared first. *)
+let mk_datatype
+    ?depends_on
+    name
+    type_params
+    (variants : (module Variant.S) list) =
   let constructors, recognizer_defs =
     variants
     |> List.map (fun v ->
@@ -206,13 +265,11 @@ let mk_datatype name type_params (variants : (module Variant.S) list) =
     |> List.split
   in
   let decl = declare_datatype name type_params constructors in
-  let () = init_decls := recognizer_defs @ (decl :: !init_decls) in
-  atom name
+  (atom name, make_definition ?depends_on (decl :: recognizer_defs))
 
-let mk_fun_decl name param_types result_type =
+let mk_fun_decl ?depends_on name param_types result_type =
   let decl = declare_fun name param_types result_type in
-  let () = builtin_funcs := decl :: !builtin_funcs in
-  atom name
+  (atom name, make_definition ?depends_on [ decl ])
 
 module Type_operations = struct
   open Variant
@@ -229,7 +286,7 @@ module Type_operations = struct
   module Type = (val nul "TypeType" : Nullary)
   module Set = (val nul "SetType" : Nullary)
 
-  let t_gil_type =
+  let t_gil_type, def_gil_type =
     mk_datatype "GIL_Type" []
       [
         (module Undefined : Variant.S);
@@ -248,6 +305,7 @@ module Type_operations = struct
 end
 
 let t_gil_type = Type_operations.t_gil_type
+let def_gil_type = Type_operations.def_gil_type
 
 module Lit_operations = struct
   open Variant
@@ -267,32 +325,37 @@ module Lit_operations = struct
   module List = (val un "List" "listValue" (t_seq t_gil_literal) : Unary)
   module None = (val nul "None" : Nullary)
 
-  let _ =
-    mk_datatype gil_literal_name []
-      [
-        (module Undefined : Variant.S);
-        (module Null : Variant.S);
-        (module Empty : Variant.S);
-        (module Bool : Variant.S);
-        (module Int : Variant.S);
-        (module Num : Variant.S);
-        (module String : Variant.S);
-        (module Loc : Variant.S);
-        (module Type : Variant.S);
-        (module List : Variant.S);
-        (module None : Variant.S);
-      ]
+  let def_gil_literal =
+    snd
+    @@ mk_datatype ~depends_on:[ def_gil_type ] gil_literal_name []
+         [
+           (module Undefined : Variant.S);
+           (module Null : Variant.S);
+           (module Empty : Variant.S);
+           (module Bool : Variant.S);
+           (module Int : Variant.S);
+           (module Num : Variant.S);
+           (module String : Variant.S);
+           (module Loc : Variant.S);
+           (module Type : Variant.S);
+           (module List : Variant.S);
+           (module None : Variant.S);
+         ]
 end
 
 let t_gil_literal = Lit_operations.t_gil_literal
+let def_gil_literal = Lit_operations.def_gil_literal
 let t_gil_literal_list = t_seq t_gil_literal
 let t_gil_literal_set = t_set t_gil_literal
 
-let seq_of ~typ = function
+let seq_of ~typ xs =
+  require_definition def_gil_literal;
+  match xs with
   | [] -> as_type (atom "seq.empty") typ
   | xs -> xs |> List.map seq_unit |> seq_concat
 
 let set_of xs =
+  require_definition def_gil_literal;
   let rec aux acc = function
     | [] -> acc
     | x :: xs -> aux (set_insert Z3 x acc) xs
@@ -307,22 +370,30 @@ module Ext_lit_operations = struct
 
   module Gil_set = (val un "Set" "setElem" t_gil_literal_set : Unary)
 
-  let t_gil_ext_literal =
-    mk_datatype "Extended_GIL_Literal" []
+  let t_gil_ext_literal, def_gil_ext_literal =
+    mk_datatype ~depends_on:[ def_gil_literal ] "Extended_GIL_Literal" []
       [ (module Gil_sing_elem : Variant.S); (module Gil_set : Variant.S) ]
 end
 
 module Axiomatised_operations = struct
-  let slen = mk_fun_decl "s-len" [ t_int ] t_real
-  let llen = mk_fun_decl "l-len" [ t_gil_literal_list ] t_int
-  let num2str = mk_fun_decl "num2str" [ t_real ] t_int
-  let str2num = mk_fun_decl "str2num" [ t_int ] t_real
-  let num2int = mk_fun_decl "num2int" [ t_real ] t_real
-  let snth = mk_fun_decl "s-nth" [ t_int; t_real ] t_int
-  let lrev = mk_fun_decl "l-rev" [ t_gil_literal_list ] t_gil_literal_list
+  let slen, def_slen = mk_fun_decl "s-len" [ t_int ] t_real
+
+  let llen, def_llen =
+    mk_fun_decl ~depends_on:[ def_gil_literal ] "l-len" [ t_gil_literal_list ]
+      t_int
+
+  let num2str, def_num2str = mk_fun_decl "num2str" [ t_real ] t_int
+  let str2num, def_str2num = mk_fun_decl "str2num" [ t_int ] t_real
+  let num2int, def_num2int = mk_fun_decl "num2int" [ t_real ] t_real
+  let snth, def_snth = mk_fun_decl "s-nth" [ t_int; t_real ] t_int
+
+  let lrev, def_lrev =
+    mk_fun_decl ~depends_on:[ def_gil_literal ] "l-rev" [ t_gil_literal_list ]
+      t_gil_literal_list
 end
 
 let t_gil_ext_literal = Ext_lit_operations.t_gil_ext_literal
+let def_gil_ext_literal = Ext_lit_operations.def_gil_ext_literal
 let str_codes = Hashtbl.create 1000
 let str_codes_inv = Hashtbl.create 1000
 let str_counter = ref 0
@@ -340,6 +411,7 @@ let encode_string s =
       code
 
 let encode_type (t : Type.t) =
+  require_definition def_gil_type;
   try
     match t with
     | UndefinedType -> Type_operations.Undefined.construct
@@ -367,12 +439,20 @@ module Encoding = struct
     let open Type in
     function
     | IntType | StringType | ObjectType -> t_int
-    | ListType -> t_gil_literal_list
+    | ListType ->
+        require_definition def_gil_literal;
+        t_gil_literal_list
     | BooleanType -> t_bool
     | NumberType -> t_real
-    | UndefinedType | NoneType | EmptyType | NullType -> t_gil_literal
-    | SetType -> t_gil_literal_set
-    | TypeType -> t_gil_type
+    | UndefinedType | NoneType | EmptyType | NullType ->
+        require_definition def_gil_literal;
+        t_gil_literal
+    | SetType ->
+        require_definition def_gil_literal;
+        t_gil_literal_set
+    | TypeType ->
+        require_definition def_gil_type;
+        t_gil_type
 
   type t = {
     consts : (string * sexp) Hashset.t; [@default Hashset.empty ()]
@@ -429,17 +509,23 @@ module Encoding = struct
        it should be already type checked *)
     match kind with
     | Native _ -> expr
-    | Simple_wrapped -> accessor expr
+    | Simple_wrapped ->
+        require_definition def_gil_literal;
+        accessor expr
     | Extended_wrapped ->
+        require_definition def_gil_ext_literal;
         accessor (Ext_lit_operations.Gil_sing_elem.access expr)
 
-  let simply_wrapped = make ~kind:Simple_wrapped
+  let simply_wrapped expr =
+    require_definition def_gil_literal;
+    make ~kind:Simple_wrapped expr
 
   (** Takes a value either natively encoded or simply wrapped and returns a
       value simply wrapped. Careful: do not use wrap with a a set, as they
       cannot be simply wrapped *)
   let simple_wrap { expr; kind; _ } =
     let open Lit_operations in
+    require_definition def_gil_literal;
     match kind with
     | Simple_wrapped -> expr
     | Native typ ->
@@ -460,6 +546,7 @@ module Encoding = struct
     | Extended_wrapped -> Ext_lit_operations.Gil_sing_elem.access expr
 
   let extend_wrap e =
+    require_definition def_gil_ext_literal;
     match e.kind with
     | Extended_wrapped -> e.expr
     | Native SetType -> Ext_lit_operations.Gil_set.construct (simple_wrap e)
@@ -472,14 +559,19 @@ module Encoding = struct
 
   let get_set { kind; expr; _ } =
     match kind with
-    | Native SetType -> expr
-    | Extended_wrapped -> Ext_lit_operations.Gil_set.access expr
+    | Native SetType ->
+        require_definition def_gil_literal;
+        expr
+    | Extended_wrapped ->
+        require_definition def_gil_ext_literal;
+        Ext_lit_operations.Gil_set.access expr
     | _ -> exceptf "wrong encoding of set"
 
   let get_string = get_native ~accessor:Lit_operations.String.access
 end
 
 let typeof_simple e =
+  require_definition def_gil_literal;
   let open Type in
   let guards =
     Lit_operations.
@@ -503,6 +595,7 @@ let typeof_simple e =
     guards
 
 let typeof_extended e =
+  require_definition def_gil_ext_literal;
   let open Ext_lit_operations in
   let guard = Gil_set.recognize e in
   let typeof_simple = e |> Gil_sing_elem.access |> typeof_simple in
@@ -551,10 +644,14 @@ let rec encode_lit (lit : Literal.t) : Encoding.t =
   let open Encoding in
   try
     match lit with
-    | Undefined -> undefined_encoding
-    | Null -> null_encoding
-    | Empty -> empty_encoding
-    | Nono -> none_encoding
+    | Undefined | Null | Empty | Nono -> (
+        (* These encode directly to GIL_Literal constructors. *)
+        require_definition def_gil_literal;
+        match lit with
+        | Undefined -> undefined_encoding
+        | Null -> null_encoding
+        | Empty -> empty_encoding
+        | _ -> none_encoding)
     | Bool b -> bool_k b >- BooleanType
     | Int i -> int_zk i >- IntType
     | Num n -> real_k (Q.of_float n) >- NumberType
@@ -562,6 +659,7 @@ let rec encode_lit (lit : Literal.t) : Encoding.t =
     | Loc l -> encode_string l >- ObjectType
     | Type t -> encode_type t >- TypeType
     | LList lits ->
+        require_definition def_gil_literal;
         let args = List.map (fun lit -> simple_wrap (encode_lit lit)) lits in
         list args >- ListType
     | Constant _ -> raise (Exceptions.Unsupported "Z3 encoding: constants")
@@ -630,6 +728,7 @@ let encode_binop (op : BinOp.t) (p1 : Encoding.t) (p2 : Encoding.t) : Encoding.t
       let n = get_int p2 in
       RepeatCache.get x n
   | StrNth ->
+      require_definition Axiomatised_operations.def_snth;
       let str' = get_string p1 in
       let index' = get_num p2 in
       let res = Axiomatised_operations.snth $$ [ str'; index' ] in
@@ -671,14 +770,24 @@ let encode_unop ~llen_lvars ~e (op : UnOp.t) le =
       (* If we only use an LVar as an argument to llen, then encode it as an uninterpreted function. *)
       let enc =
         match e with
-        | Expr.LVar l when SS.mem l llen_lvars -> llen <| get_list le
+        | Expr.LVar l when SS.mem l llen_lvars ->
+            require_definition def_llen;
+            llen <| get_list le
         | _ -> seq_len (get_list le)
       in
       enc >- IntType
-  | StrLen -> slen <| get_string le >- NumberType
-  | ToStringOp -> Axiomatised_operations.num2str <| get_num le >- StringType
-  | ToNumberOp -> Axiomatised_operations.str2num <| get_string le >- NumberType
-  | ToIntOp -> Axiomatised_operations.num2int <| get_num le >- NumberType
+  | StrLen ->
+      require_definition def_slen;
+      slen <| get_string le >- NumberType
+  | ToStringOp ->
+      require_definition def_num2str;
+      Axiomatised_operations.num2str <| get_num le >- StringType
+  | ToNumberOp ->
+      require_definition def_str2num;
+      Axiomatised_operations.str2num <| get_string le >- NumberType
+  | ToIntOp ->
+      require_definition def_num2int;
+      Axiomatised_operations.num2int <| get_num le >- NumberType
   | Not -> bool_not (get_bool le) >- BooleanType
   | Cdr ->
       let list = get_list le in
@@ -686,7 +795,9 @@ let encode_unop ~llen_lvars ~e (op : UnOp.t) le =
   | Car -> seq_nth (get_list le) (int_k 0) |> simply_wrapped
   | TypeOf -> typeof_expression le >- TypeType
   | ToUint32Op -> get_num le |> real_to_int |> int_to_real >- NumberType
-  | LstRev -> Axiomatised_operations.lrev <| get_list le >- ListType
+  | LstRev ->
+      require_definition def_lrev;
+      Axiomatised_operations.lrev <| get_list le >- ListType
   | NumToInt -> get_num le |> real_to_int >- IntType
   | IntToNum -> get_int le |> int_to_real >- NumberType
   | IsInt ->
@@ -791,8 +902,12 @@ let rec encode_logical_expression
         match Hashtbl.find_opt gamma var with
         | Some typ -> (Native typ, native_sort_of_type typ)
         | None ->
-            if SS.mem var list_elem_vars then (Simple_wrapped, t_gil_literal)
-            else (Extended_wrapped, t_gil_ext_literal)
+            if SS.mem var list_elem_vars then (
+              require_definition def_gil_literal;
+              (Simple_wrapped, t_gil_literal))
+            else (
+              require_definition def_gil_ext_literal;
+              (Extended_wrapped, t_gil_ext_literal))
       in
       make_const ~typ kind var
   | ALoc var -> native_const ObjectType var
@@ -909,9 +1024,9 @@ let lvars_as_list_elements (assertions : Expr.Set.t) : SS.t =
       SS.union new_lvars acc)
     assertions SS.empty
 
-let encode_assertions (fs : Expr.Set.t) (gamma : typenv) : sexp list =
+let encode_assertions_needs_handler (fs : Expr.Set.t) (gamma : typenv) :
+    sexp list =
   let open Encoding in
-  let- () = Hashtbl.find_opt encoding_cache fs in
   let llen_lvars = lvars_only_in_llen fs in
   let list_elem_vars = lvars_as_list_elements fs in
   let encoded =
@@ -928,9 +1043,21 @@ let encode_assertions (fs : Expr.Set.t) (gamma : typenv) : sexp list =
     let encoded_asrts = List.map (fun e -> e.expr) encoded in
     List.map assume (extra_asrts @ encoded_asrts)
   in
-  let encoded = consts @ asrts in
-  let () = Hashtbl.replace encoding_cache fs encoded in
-  encoded
+  consts @ asrts
+
+(* Returns the SMT commands for [fs] together with the set of prelude
+   definitions they depend on (collected via the [Require_definition] effect
+   while encoding). Both are cached, so the dependency set survives a cache
+   hit -- it cannot be recomputed from the encoded terms without re-encoding. *)
+let encode_assertions (fs : Expr.Set.t) (gamma : typenv) :
+    sexp list * (int, definition) Hashtbl.t =
+  let- () = Hashtbl.find_opt encoding_cache fs in
+  let result =
+    with_necessary_definitions @@ fun () ->
+    encode_assertions_needs_handler fs gamma
+  in
+  let () = Hashtbl.replace encoding_cache fs result in
+  result
 
 module Dump = struct
   let counter = ref 0
@@ -972,10 +1099,15 @@ module Dump = struct
           cmds)
 end
 
+(* We never use the solver incrementally: every query starts by fully
+   resetting it. Z3 keeps the options that were set with [set-option] across a
+   [(reset)], so there is nothing to re-send here. Working in this one-shot
+   mode is important for reliability: when used incrementally (push/pop) Z3 can
+   non-deterministically answer [unknown] on queries -- notably ones involving
+   the sequence theory -- that it decides immediately in a fresh context. *)
 let reset_solver () =
-  let () = cmd (pop 1) in
+  let () = cmd reset in
   let () = RepeatCache.clear () in
-  let () = cmd (push 1) in
   ()
 
 let exec_sat' (fs : Expr.Set.t) (gamma : typenv) : sexp option =
@@ -986,9 +1118,9 @@ let exec_sat' (fs : Expr.Set.t) (gamma : typenv) : sexp option =
           fs pp_typenv gamma)
   in
   let () = reset_solver () in
-  let encoded_assertions = encode_assertions fs gamma in
+  let encoded_assertions, necessary_definitions = encode_assertions fs gamma in
   let () = if !Config.dump_smt then Dump.dump fs gamma encoded_assertions in
-  let () = List.iter cmd !builtin_funcs in
+  let () = emit_definitions ~emit:cmd necessary_definitions in
   let () = List.iter cmd encoded_assertions in
   L.verbose (fun fmt -> fmt "Reached SMT.");
   let result = check !solver in

--- a/transformers/bin/example.gil
+++ b/transformers/bin/example.gil
@@ -8,11 +8,11 @@ pred sll(x; vs: List) :
     (* non-empty list *)
     (x == #h) * (vs == l+ ({{ #v }}, #vs)) *
     <ex>(#h; #v) * <ex>(#h i+ 1i; #next) *
-    sll(#next, #vs);
+    sll(#next; #vs);
 
 spec alloc_node(v)
     [[ v == #v ]]
-    [[ sll(ret, {{ #v }}) ]]
+    [[ sll(ret; {{ #v }}) ]]
     normal
 proc alloc_node(v) {
     c1 := [alloc]();
@@ -26,8 +26,8 @@ proc alloc_node(v) {
 };
 
 spec append(h, v)
-    [[ (h == #h) * (v == #v) * sll(#h, #vs) ]]
-    [[ (ret == #h2) * sll(#h2, l+ (#vs, {{ #v }})) ]]
+    [[ (h == #h) * (v == #v) * sll(#h; #vs) ]]
+    [[ (ret == #h2) * sll(#h2; l+ (#vs, {{ #v }})) ]]
     normal
 proc append(h, v) {
     goto [h = null] then0 else0;
@@ -48,8 +48,8 @@ end:
 };
 
 spec prepend(h, v)
-    [[ (h == #h) * (v == #v) * sll(#h, #vs) ]]
-    [[ (ret == #h2) * sll(#h2, l+ ({{ #v }}, #vs)) ]]
+    [[ (h == #h) * (v == #v) * sll(#h; #vs) ]]
+    [[ (ret == #h2) * sll(#h2; l+ ({{ #v }}, #vs)) ]]
     normal
 proc prepend(h, v) {
     ret := "alloc_node"(v);
@@ -58,8 +58,8 @@ proc prepend(h, v) {
 };
 
 spec length(h)
-    [[ (h == #h) * sll(#h, #vs) ]]
-    [[ (ret == (l-len #vs)) * sll(#h, #vs) ]]
+    [[ (h == #h) * sll(#h; #vs) ]]
+    [[ (ret == (l-len #vs)) * sll(#h; #vs) ]]
     normal
 proc length(h) {
     goto [h = null] then0 else0;
@@ -80,8 +80,8 @@ end:
 };
 
 spec concat(h1, h2)
-    [[ (h1 == #h1) * (h2 == #h2) * sll(#h1, #vs1) * sll(#h2, #vs2) ]]
-    [[ (ret == #h3) * sll(#h3, l+ (#vs1, #vs2)) ]]
+    [[ (h1 == #h1) * (h2 == #h2) * sll(#h1; #vs1) * sll(#h2; #vs2) ]]
+    [[ (ret == #h3) * sll(#h3; l+ (#vs1, #vs2)) ]]
     normal
 proc concat(h1, h2) {
     goto [h1 = null] then0 else0;
@@ -103,12 +103,12 @@ end:
 
 pred sll_member(vs : List, v; r : Bool) :
     (vs == {{  }}) * (r == false), (* empty list *)
-    (vs == l+ ({{  v  }}, #vs2)) *   (r == true) * sll_member(#vs2, v, #etc), (* found a match *)
-    (vs == l+ ({{ #v2 }}, #vs2)) * (!(v == #v2)) * sll_member(#vs2, v, r); (* no match yet *)
+    (vs == l+ ({{  v  }}, #vs2)) *   (r == true) * sll_member(#vs2, v; #etc), (* found a match *)
+    (vs == l+ ({{ #v2 }}, #vs2)) * (!(v == #v2)) * sll_member(#vs2, v; r); (* no match yet *)
 
 spec member(h, v)
-    [[ (h == #h) * (v == #v) * sll(#h, #vs) * sll_member(#vs, #v, #r) ]]
-    [[ (ret == #r) * sll(#h, #vs) * sll_member(#vs, #v, #r) ]]
+    [[ (h == #h) * (v == #v) * sll(#h; #vs) * sll_member(#vs, #v; #r) ]]
+    [[ (ret == #r) * sll(#h; #vs) * sll_member(#vs, #v; #r) ]]
     normal
 proc member(h, v) {
     goto [h = null] then0 else0;
@@ -152,7 +152,7 @@ end:
 
 
 spec free_list(h)
-     [[ (h == #h) * sll(#h, #vs) ]]
+     [[ (h == #h) * sll(#h; #vs) ]]
     [[ (ret == null) ]]
     normal
 proc free_list(h) {

--- a/transformers/bin/example.gil
+++ b/transformers/bin/example.gil
@@ -2,7 +2,7 @@
    To verify this code, use the following transformer stack:
    OpenPMap (IntegerIndex) (Freeable (Exclusive)) *)
 
-pred sll(+x, vs: List) :
+pred sll(x; vs: List) :
     (* empty list *)
     (x == null) * (vs == {{  }}),
     (* non-empty list *)
@@ -101,7 +101,7 @@ end:
     return
 };
 
-pred sll_member(+vs : List, +v, r : Bool) :
+pred sll_member(vs : List, v; r : Bool) :
     (vs == {{  }}) * (r == false), (* empty list *)
     (vs == l+ ({{  v  }}, #vs2)) *   (r == true) * sll_member(#vs2, v, #etc), (* found a match *)
     (vs == l+ ({{ #v2 }}, #vs2)) * (!(v == #v2)) * sll_member(#vs2, v, r); (* no match yet *)

--- a/wisl/examples/DLL_recursive.wisl
+++ b/wisl/examples/DLL_recursive.wisl
@@ -1,11 +1,11 @@
 // Doubly-linked list segment, unfolding from the left
-predicate dlsegl(+x, +y, +v, +w, alpha : List, llen : Int) {
+predicate dlsegl(x, y, v, w; alpha : List, llen : Int) {
   (x == y) * (v == w) * (alpha == nil) * (llen == 0);
   (x -> #a, #z, w) * (alpha == #a :: #beta) * dlsegl(#z, y, v, x, #beta, #_llen) * (llen == 1 + #_llen)
 }
 
 // Doubly-linked list segment, unfolding from the right
-predicate dlsegr(+x, +y, +v, +w, alpha : List, llen : Int) {
+predicate dlsegr(x, y, v, w; alpha : List, llen : Int) {
   (x == y) * (v == w) * (alpha == nil) * (llen == 0);
   (v -> #a, y, #z) * (alpha == #beta @ [#a]) * dlsegr(x, v, #z, w, #beta, #_llen) * (llen == 1 + #_llen)
 }
@@ -89,7 +89,7 @@ lemma dlseg_r_to_l {
 }
 
 // Doubly-linked list
-predicate dlist(+x, +y, alpha, llen) {
+predicate dlist(x, y; alpha, llen) {
   dlsegl(x, null, y, null, alpha, llen)
 }
 

--- a/wisl/examples/DLL_recursive.wisl
+++ b/wisl/examples/DLL_recursive.wisl
@@ -1,20 +1,20 @@
 // Doubly-linked list segment, unfolding from the left
 predicate dlsegl(x, y, v, w; alpha : List, llen : Int) {
   (x == y) * (v == w) * (alpha == nil) * (llen == 0);
-  (x -> #a, #z, w) * (alpha == #a :: #beta) * dlsegl(#z, y, v, x, #beta, #_llen) * (llen == 1 + #_llen)
+  (x -> #a, #z, w) * (alpha == #a :: #beta) * dlsegl(#z, y, v, x; #beta, #_llen) * (llen == 1 + #_llen)
 }
 
 // Doubly-linked list segment, unfolding from the right
 predicate dlsegr(x, y, v, w; alpha : List, llen : Int) {
   (x == y) * (v == w) * (alpha == nil) * (llen == 0);
-  (v -> #a, y, #z) * (alpha == #beta @ [#a]) * dlsegr(x, v, #z, w, #beta, #_llen) * (llen == 1 + #_llen)
+  (v -> #a, y, #z) * (alpha == #beta @ [#a]) * dlsegr(x, v, #z, w; #beta, #_llen) * (llen == 1 + #_llen)
 }
 
 // Appending an element from the right to the left-unfolding dlseg
 lemma dlsegl_append_right {
   statement:
     forall x, v, z, w, alpha, llen, a, y.
-      dlsegl(x, v, z, w, alpha, llen) * (v -> a, y, z) |- dlsegl(x, y, v, w, alpha @ [ a ], 1 + llen)
+      dlsegl(x, v, z, w; alpha, llen) * (v -> a, y, z) |- dlsegl(x, y, v, w; alpha @ [ a ], 1 + llen)
 
   variant: len alpha
 
@@ -24,7 +24,7 @@ lemma dlsegl_append_right {
       fold dlsegl(y, y, v, v, [], 0);
       fold dlsegl(x, y, v, w, a :: alpha, 1 + llen)
     } else {
-      assert {bind: #b, #l, #beta, #_llen} (alpha == #b :: #beta) * (x -> #b, #l, w) * dlsegl(#l, v, z, x, #beta, #_llen);
+      assert {bind: #b, #l, #beta, #_llen} (alpha == #b :: #beta) * (x -> #b, #l, w) * dlsegl(#l, v, z, x; #beta, #_llen);
       apply dlsegl_append_right(#l, v, z, x, #beta, #_llen, a, y);
       fold dlsegl(x, y, v, w, alpha @ [ a ], 1 + llen)
     }
@@ -34,7 +34,7 @@ lemma dlsegl_append_right {
 lemma dlsegr_append_left {
   statement:
     forall x, a, z, w, y, v, alpha, llen.
-      (x -> a, z, w) * dlsegr(z, y, v, x, alpha, llen) |- dlsegr(x, y, v, w, a :: alpha, 1 + llen)
+      (x -> a, z, w) * dlsegr(z, y, v, x; alpha, llen) |- dlsegr(x, y, v, w; a :: alpha, 1 + llen)
 
   variant: len alpha
 
@@ -44,7 +44,7 @@ lemma dlsegr_append_left {
       fold dlsegr(x, x, w, w, [], 0);
       fold dlsegr(x, y, v, w, a :: alpha, 1 + llen)
     } else {
-      assert {bind: #b, #l, #beta, #_llen} (alpha == #beta @ [#b]) * (v -> #b, y, #l) * dlsegr(z, v, #l, x, #beta, #_llen);
+      assert {bind: #b, #l, #beta, #_llen} (alpha == #beta @ [#b]) * (v -> #b, y, #l) * dlsegr(z, v, #l, x; #beta, #_llen);
       apply dlsegr_append_left(x, a, z, w, v, #l, #beta, #_llen);
       fold dlsegr(x, y, v, w, a :: alpha, 1 + llen)
     }
@@ -54,7 +54,7 @@ lemma dlsegr_append_left {
 lemma dlseg_l_to_r {
   statement:
     forall x, y, v, w, alpha, llen.
-      dlsegl(x, y, v, w, alpha, llen) |- dlsegr(x, y, v, w, alpha, llen)
+      dlsegl(x, y, v, w; alpha, llen) |- dlsegr(x, y, v, w; alpha, llen)
 
   variant: len alpha
 
@@ -63,7 +63,7 @@ lemma dlseg_l_to_r {
     if (alpha == nil) {
       fold dlsegr(x, y, v, w, alpha, llen)
     } else {
-      assert {bind: #a, #z, #beta, #_llen} (x -> #a, #z, w) * dlsegl(#z, y, v, x, #beta, #_llen);
+      assert {bind: #a, #z, #beta, #_llen} (x -> #a, #z, w) * dlsegl(#z, y, v, x; #beta, #_llen);
       apply dlseg_l_to_r(#z, y, v, x, #beta, #_llen);
       apply dlsegr_append_left(x, #a, #z, w, y, v, #beta, #_llen)
     }
@@ -73,7 +73,7 @@ lemma dlseg_l_to_r {
 lemma dlseg_r_to_l {
   statement:
     forall x, y, v, w, alpha, llen.
-      dlsegr(x, y, v, w, alpha, llen) |- dlsegl(x, y, v, w, alpha, llen)
+      dlsegr(x, y, v, w; alpha, llen) |- dlsegl(x, y, v, w; alpha, llen)
 
   variant: len alpha
 
@@ -82,7 +82,7 @@ lemma dlseg_r_to_l {
     if (alpha == nil) {
       fold dlsegl(x, y, v, w, alpha, llen)
     } else {
-      assert {bind: #a, #z, #beta, #_llen} (v -> #a, y, #z) * dlsegr(x, v, #z, w, #beta, #_llen);
+      assert {bind: #a, #z, #beta, #_llen} (v -> #a, y, #z) * dlsegr(x, v, #z, w; #beta, #_llen);
       apply dlseg_r_to_l(x, v, #z, w, #beta, #_llen);
       apply dlsegl_append_right(x, v, #z, w, #beta, #_llen, #a, y)
     }
@@ -90,20 +90,20 @@ lemma dlseg_r_to_l {
 
 // Doubly-linked list
 predicate dlist(x, y; alpha, llen) {
-  dlsegl(x, null, y, null, alpha, llen)
+  dlsegl(x, null, y, null; alpha, llen)
 }
 
 // Concatenation of two dlsegs
 lemma dlseg_concat {
   statement:
     forall x_a, v_a, w_a, alpha, llena, x_b, y_b, v_b, beta, llenb.
-      dlsegl(x_a, x_b, v_a, w_a, alpha, llena) * dlsegl(x_b, y_b, v_b, v_a, beta, llenb)
-        |- dlsegl(x_a, y_b, v_b, w_a, (alpha @ beta), llena + llenb)
+      dlsegl(x_a, x_b, v_a, w_a; alpha, llena) * dlsegl(x_b, y_b, v_b, v_a; beta, llenb)
+        |- dlsegl(x_a, y_b, v_b, w_a; (alpha @ beta), llena + llenb)
 
   proof:
     unfold dlsegl(x_a, x_b, v_a, w_a, alpha, llena);
     if (alpha != []) {
-      assert {bind: #a, #z_a, #gamma, #_llena} (x_a -> #a, #z_a, w_a) * dlsegl(#z_a, x_b, v_a, x_a, #gamma, #_llena);
+      assert {bind: #a, #z_a, #gamma, #_llena} (x_a -> #a, #z_a, w_a) * dlsegl(#z_a, x_b, v_a, x_a; #gamma, #_llena);
       apply dlseg_concat(#z_a, v_a, x_a, #gamma, #_llena, x_b, y_b, v_b, beta, llenb);
       fold dlsegl(x_a, y_b, v_b, w_a, (alpha @ beta), llena + llenb)
     }
@@ -111,7 +111,7 @@ lemma dlseg_concat {
 
 // List concatenation
 { (x_a == #x_a) * (v_a == #v_a) * (x_b == #x_b) * (v_b == #v_b) *
-  dlist(#x_a, #v_a, #alpha, #llena) * dlist(#x_b, #v_b, #beta, #llenb) }
+  dlist(#x_a, #v_a; #alpha, #llena) * dlist(#x_b, #v_b; #beta, #llenb) }
 function concat(x_a, v_a, x_b, v_b) {
   r := new(2);
   if (x_a == null) {
@@ -133,5 +133,5 @@ function concat(x_a, v_a, x_b, v_b) {
   };
   return r
 }
-{ (ret -> #h, #t) * dlist(#h, #t, #alpha @ #beta, #llena + #llenb) }
+{ (ret -> #h, #t) * dlist(#h, #t; #alpha @ #beta, #llena + #llenb) }
 

--- a/wisl/examples/SLL_ex_complete.wisl
+++ b/wisl/examples/SLL_ex_complete.wisl
@@ -5,7 +5,7 @@ predicate SLL(x; vs) {
   // Empty SLL
   (x == null) * (vs == []);
   // One SLL node and the rest
-  (x -b> #v, #next) * SLL(#next, #vs) *
+  (x -b> #v, #next) * SLL(#next; #vs) *
   (vs == #v :: #vs)
 }
 
@@ -14,8 +14,8 @@ predicate SLL(x; vs) {
 //
 predicate list_member(vs, v; r : Bool){
   (vs == []) * (r == false);
-  (vs == v :: #rest) * (r == true) * list_member(#rest, v, #mem);
-  (vs == #v :: #rest) * (! (#v == v)) * list_member(#rest, v, r)
+  (vs == v :: #rest) * (r == true) * list_member(#rest, v; #mem);
+  (vs == #v :: #rest) * (! (#v == v)) * list_member(#rest, v; r)
 }
 
 //
@@ -24,13 +24,13 @@ predicate list_member(vs, v; r : Bool){
 lemma list_member_append {
   statement:
     forall vs, v, r, w.
-      list_member(vs, v, r) |- list_member(vs @ [ w ], v, (r || (w == v)))
+      list_member(vs, v; r) |- list_member(vs @ [ w ], v; (r || (w == v)))
 
   proof:
     if (w == v) {} else {}; // FIXME: THIS IS HORRIFIC
     unfold list_member(vs, v, r);
     if (vs != []) {
-      assert {bind: #nv, #nvs, #nr} (vs == #nv :: #nvs) * list_member(#nvs, #v, #nr);
+      assert {bind: #nv, #nvs, #nr} (vs == #nv :: #nvs) * list_member(#nvs, #v; #nr);
       apply list_member_append(#nvs, v, #nr, w)
     }
 }
@@ -41,12 +41,12 @@ lemma list_member_append {
 lemma list_member_concat {
   statement:
     forall vs1, vs2, v.
-      list_member(vs1, v, #r1) * list_member(vs2, v, #r2) |- list_member(vs1 @ vs2, v, (#r1 || #r2))
+      list_member(vs1, v; #r1) * list_member(vs2, v; #r2) |- list_member(vs1 @ vs2, v; (#r1 || #r2))
 
   proof:
     unfold list_member(vs1, v, #r1);
     if (vs1 != []) {
-      assert {bind: #nv1, #nvs1, #nr1} (vs1 == #nv1 :: #nvs1) * list_member(#nvs1, v, #nr1);
+      assert {bind: #nv1, #nvs1, #nr1} (vs1 == #nv1 :: #nvs1) * list_member(#nvs1, v; #nr1);
       apply list_member_concat(#nvs1, vs2, v)
     }
 }
@@ -58,7 +58,7 @@ function SLL_allocate_node(v){
   [t] := v;
   return t
 }
-{ SLL(ret, [ #v ]) }
+{ SLL(ret; [ #v ]) }
 
 
 //
@@ -66,16 +66,16 @@ function SLL_allocate_node(v){
 //
 
 // 01. Prepending a given value to a given SLL
-{ (x == #x) * (k == #k) * SLL(#x, #vs) }
+{ (x == #x) * (k == #k) * SLL(#x; #vs) }
 function SLL_prepend(x, k){
     z := SLL_allocate_node(k);
     [z + 1] := x;
     return z
 }
-{ SLL(ret, #k :: #vs) }
+{ SLL(ret; #k :: #vs) }
 
 // 02. Appending a given value to a given SLL
-{ (x == #x) * (k == #k) * SLL(#x, #vs) }
+{ (x == #x) * (k == #k) * SLL(#x; #vs) }
 function SLL_append(x, k){
   if (x == null) {
     x := SLL_allocate_node(k)
@@ -86,10 +86,10 @@ function SLL_append(x, k){
   };
   return x
 }
-{ SLL(ret,  #vs @ [#k]) }
+{ SLL(ret;  #vs @ [#k]) }
 
 // 03. Appending a given SLL node to a given SLL
-{ (x == #x) * (y == #y) * SLL(#x, #vs) * SLL(#y, [#vy]) }
+{ (x == #x) * (y == #y) * SLL(#x; #vs) * SLL(#y; [#vy]) }
 function SLL_append_node(x, y) {
   if (x == null) {
     x := y
@@ -100,10 +100,10 @@ function SLL_append_node(x, y) {
   };
   return x
 }
-{ SLL(ret, #vs @ [#vy]) }
+{ SLL(ret; #vs @ [#vy]) }
 
 // 04. Concatenating two lists
-{(x == #x) * (y == #y) * SLL(#x, #vx) * SLL(#y, #vy) }
+{(x == #x) * (y == #y) * SLL(#x; #vx) * SLL(#y; #vy) }
 function SLL_concat(x, y) {
   if (x == null){
     x := y
@@ -114,10 +114,10 @@ function SLL_concat(x, y) {
   };
   return x
 }
-{ SLL(ret,  #vx @ #vy) }
+{ SLL(ret;  #vx @ #vy) }
 
 // 05. Copying a given SLL
-{ (x == #x) * SLL(#x, #vs) }
+{ (x == #x) * SLL(#x; #vs) }
 function SLL_copy(x){
   y := null;
   if (x != null) {
@@ -131,10 +131,10 @@ function SLL_copy(x){
   };
   return y
 }
-{ SLL(#x, #vs) * SLL(ret, #vs) }
+{ SLL(#x; #vs) * SLL(ret; #vs) }
 
 // 06. Calculating the length of a given SLL
-{ (x == #x) *  SLL(#x, #vs) }
+{ (x == #x) *  SLL(#x; #vs) }
 function SLL_length(x) {
   n := 0;
   if (x == null){
@@ -149,7 +149,7 @@ function SLL_length(x) {
 { (ret == len(#vs)) }
 
 // 07. Reversing a given SLL
-{ (x == #x) *  SLL(#x, #vs) }
+{ (x == #x) *  SLL(#x; #vs) }
 function SLL_reverse(x){
   if (x != null) {
     t := [x + 1];
@@ -161,10 +161,10 @@ function SLL_reverse(x){
   };
   return y
 }
-{ SLL(ret,rev #vs) }
+{ SLL(ret;rev #vs) }
 
 // 08. Checking if a given value is in a given SLL
-{ (x == #x) * (k == #k) * SLL(#x, #vs) * list_member(#vs, #k, #r) }
+{ (x == #x) * (k == #k) * SLL(#x; #vs) * list_member(#vs, #k; #r) }
 function SLL_member(x, k){
   found := false;
   if (x == null){
@@ -180,10 +180,10 @@ function SLL_member(x, k){
   };
   return found
 }
-{ SLL(#x, #vs) * list_member(#vs, #k, #r) * (ret == #r) }
+{ SLL(#x; #vs) * list_member(#vs, #k; #r) * (ret == #r) }
 
 // 09. Removing a given value from a given SLL
-{ (x == #x) * (k == #k) * SLL(#x, #vs) * list_member(#vs, #k, #mem) }
+{ (x == #x) * (k == #k) * SLL(#x; #vs) * list_member(#vs, #k; #mem) }
 function SLL_remove(x, k) {
   if (x == null) {
     skip
@@ -201,10 +201,10 @@ function SLL_remove(x, k) {
   [[ fold list_member([], #k, false) ]];
   return x
 }
-{ SLL(ret, #nvs) * list_member(#nvs, #k, false) }
+{ SLL(ret; #nvs) * list_member(#nvs, #k; false) }
 
 // 10. Freeing a given SLL
-{ (x == #x) * SLL(#x, #vs) }
+{ (x == #x) * SLL(#x; #vs) }
 function SLL_free(x){
   if (x == null) {
     skip
@@ -226,7 +226,7 @@ function SLL_free(x){
 //
 predicate SLLseg(x; y, vs) {
   (x == y) * (vs == []);
-  (x -b> #v, #next) * SLLseg(#next, y, #vs) * (vs == #v :: #vs)
+  (x -b> #v, #next) * SLLseg(#next; y, #vs) * (vs == #v :: #vs)
 }
 
 //
@@ -235,13 +235,13 @@ predicate SLLseg(x; y, vs) {
 lemma SLLseg_append {
   statement:
     forall x, vs, v, z.
-      SLLseg(x, #y, vs) * (#y -b> v, z) |- SLLseg(x, z, vs @ [ v ])
+      SLLseg(x; #y, vs) * (#y -b> v, z) |- SLLseg(x; z, vs @ [ v ])
 
   proof:
     unfold SLLseg(x, #y, vs);
     if (x != #y) {
       assert {bind: #nv, #nnext, #nvs}
-        (x -b> #nv, #nnext) * SLLseg(#nnext, #y, #nvs) *
+        (x -b> #nv, #nnext) * SLLseg(#nnext; #y, #nvs) *
         (vs == #nv :: #nvs);
       apply SLLseg_append(#nnext, #nvs, v, z);
       fold SLLseg(x, z, vs @ [ v ])
@@ -256,7 +256,7 @@ lemma SLLseg_append {
 lemma SLLseg_concat_SLL {
   statement:
     forall x, y.
-      SLLseg(x, y, #vx) * SLL(y, #vy) |- SLL (x, #vx @ #vy)
+      SLLseg(x; y, #vx) * SLL(y; #vy) |- SLL (x; #vx @ #vy)
 
   proof:
     unfold SLLseg(x, y, #vx);
@@ -272,7 +272,7 @@ lemma SLLseg_concat_SLL {
 lemma SLLseg_to_SLL {
   statement:
     forall x.
-      SLLseg(x, null, #vx) |- SLL(x, #vx)
+      SLLseg(x; null, #vx) |- SLL(x; #vx)
 
   proof:
     unfold SLLseg(x, null, #vx);
@@ -283,7 +283,7 @@ lemma SLLseg_to_SLL {
 }
 
 // 02. Appending a given value to a given SLL
-{ (x == #x) * (k == #k) * SLL(#x, #vx) }
+{ (x == #x) * (k == #k) * SLL(#x; #vx) }
 function SLL_append_iter(x, k){
   y := SLL_allocate_node(k);
   if (x == null) {
@@ -293,7 +293,7 @@ function SLL_append_iter(x, k){
     prev := head;
     next := [x + 1];
     [[ invariant {bind: prev, next, #vs1, #vs2, #v}
-          SLLseg(head, prev, #vs1) * (prev -b> #v, next) * SLL(next,  #vs2) *
+          SLLseg(head; prev, #vs1) * (prev -b> #v, next) * SLL(next;  #vs2) *
            (#vx == #vs1 @ (#v :: #vs2)) ]];
     while(next != null){
       [[ assert {bind: #prev} (prev == #prev) ]];
@@ -302,17 +302,17 @@ function SLL_append_iter(x, k){
       [[ apply SLLseg_append(head,  #vs1, #v, prev) ]]
     };
     [prev + 1] := y;
-    [[ assert {bind: #svs, #sv} SLLseg(head, prev, #svs) * (prev -b> #sv, y) ]];
+    [[ assert {bind: #svs, #sv} SLLseg(head; prev, #svs) * (prev -b> #sv, y) ]];
     [[ apply SLLseg_append(head, #svs, #sv, y) ]];
-    [[ assert (SLLseg(head, y, #vx)) ]];
+    [[ assert (SLLseg(head; y, #vx)) ]];
     [[ apply SLLseg_concat_SLL(head, y) ]]
   };
   return x
 }
-{ SLL(ret, #vx @ [ #k ]) }
+{ SLL(ret; #vx @ [ #k ]) }
 
 // 03. Appending a given node to a given SLL
-{ (x == #x) * (y == #y) * SLL(#x, #vs) * SLL(#y, [#vy]) }
+{ (x == #x) * (y == #y) * SLL(#x; #vs) * SLL(#y; [#vy]) }
 function SLL_append_node_iter(x, y){
   if (x == null) {
     x := y
@@ -321,7 +321,7 @@ function SLL_append_node_iter(x, y){
     prev := head;
     next := [x + 1];
     [[ invariant {bind: prev, next, #vs1, #vs2, #v}
-          SLLseg(head, prev, #vs1) * (prev -b> #v, next) * SLL(next,  #vs2) *
+          SLLseg(head; prev, #vs1) * (prev -b> #v, next) * SLL(next;  #vs2) *
            (#vx == #vs1 @ (#v :: #vs2)) ]];
     while(next != null){
       [[ assert {bind: #prev} (prev == #prev) ]];
@@ -330,17 +330,17 @@ function SLL_append_node_iter(x, y){
       [[ apply SLLseg_append(head,  #vs1, #v, prev) ]]
     };
     [prev + 1] := y;
-    [[ assert {bind: #svs, #sv} SLLseg(head, prev, #svs) * (prev -b> #sv, y) ]];
+    [[ assert {bind: #svs, #sv} SLLseg(head; prev, #svs) * (prev -b> #sv, y) ]];
     [[ apply SLLseg_append(head, #svs, #sv, y) ]];
-    [[ assert (SLLseg(head, y, #vs)) ]]; // <-- add deliberate bug to #vx
+    [[ assert (SLLseg(head; y, #vs)) ]]; // <-- add deliberate bug to #vx
     [[ apply SLLseg_concat_SLL(head, y) ]]
   };
   return x
 }
-{ SLL(ret, #vs @ [#vy]) }
+{ SLL(ret; #vs @ [#vy]) }
 
 // 04. Concatenating two lists
-{(x == #x) * (y == #y) * SLL(#x, #vx) * SLL(#y, #vy) }
+{(x == #x) * (y == #y) * SLL(#x; #vx) * SLL(#y; #vy) }
 function SLL_concat_iter(x, y){
   if (x == null) {
     head := y
@@ -349,7 +349,7 @@ function SLL_concat_iter(x, y){
     prev := head;
     next := [x + 1];
     [[ invariant {bind: prev, next, #vs1, #vs2, #v}
-          SLLseg(head, prev, #vs1) * (prev -b> #v, next) * SLL(next,  #vs2) *
+          SLLseg(head; prev, #vs1) * (prev -b> #v, next) * SLL(next;  #vs2) *
            (#vx == #vs1 @ (#v :: #vs2)) ]];
     while (next != null) {
         [[ assert {bind: #prev} (prev == #prev) ]];
@@ -358,16 +358,16 @@ function SLL_concat_iter(x, y){
         [[ apply SLLseg_append(head,  #vs1, #v, prev) ]]
     };
     [prev + 1] := y;
-    [[ assert {bind:#svs, #sv} SLLseg(head, prev, #svs) * (prev -b> #sv, y) ]];
+    [[ assert {bind:#svs, #sv} SLLseg(head; prev, #svs) * (prev -b> #sv, y) ]];
     [[ apply SLLseg_append(head, #svs, #sv, y) ]];
     [[ apply SLLseg_concat_SLL(head, y) ]]
   };
   return head
 }
-{ SLL(ret, #vx @ #vy) }
+{ SLL(ret; #vx @ #vy) }
 
 // 05. Copying a given SLL
-{ (x == #x) * SLL(#x, #alpha) }
+{ (x == #x) * SLL(#x; #alpha) }
 function SLL_copy_iter(x){
     y := null;
     if (x == null){
@@ -381,8 +381,8 @@ function SLL_copy_iter(x){
         [[ fold SLLseg(x, t, [v]) ]];
         [[ fold SLLseg(y, p, []) ]];
         [[ invariant {bind: c, v, t, p, #alpha1, #alpha2, #alpha3, #a}
-          SLLseg(x, t, #alpha1) * SLL(t, #alpha2) * (v == #a) *
-            (#alpha == (#alpha1 @ #alpha2)) * SLLseg(y, p, #alpha3) * (p -b> #a, null) *
+          SLLseg(x; t, #alpha1) * SLL(t; #alpha2) * (v == #a) *
+            (#alpha == (#alpha1 @ #alpha2)) * SLLseg(y; p, #alpha3) * (p -b> #a, null) *
                 (#alpha1 == (#alpha3 @ [#a])) ]];
         while (t != null){
             [[ assert {bind: #t, #p} (t == #t) * (p == #p) ]];
@@ -395,22 +395,22 @@ function SLL_copy_iter(x){
             [[ apply SLLseg_append(x, #alpha1, v, t) ]];
             [[ apply SLLseg_append(y, #alpha3, #a, p) ]]
         };
-        [[ assert {bind: #alpha3} SLLseg(y, p, #alpha3) ]];
+        [[ assert {bind: #alpha3} SLLseg(y; p, #alpha3) ]];
         [[ apply SLLseg_append(y, #alpha3, v, null) ]];
         [[ apply SLLseg_to_SLL(x) ]];
         [[ apply SLLseg_to_SLL(y) ]]
     };
     return y
 }
-{ SLL(#x, #alpha) * SLL(ret, #alpha) }
+{ SLL(#x; #alpha) * SLL(ret; #alpha) }
 
 // 06. Calculating the length of a given SLL
-{ (x == #x) * SLL(x, #vx) }
+{ (x == #x) * SLL(x; #vx) }
 function SLL_length_iter(x) {
   y := x;
   n := 0;
   [[invariant {bind: n, y, #nvx,  #nvy}
-      SLLseg(x, y,  #nvx) * SLL(y, #nvy) *
+      SLLseg(x; y,  #nvx) * SLL(y; #nvy) *
          (#vx == (#nvx@#nvy)) * (n == len #nvx) ]];
   while (y != null) {
     [[ assert {bind: #y} (y == #y) ]];
@@ -423,14 +423,14 @@ function SLL_length_iter(x) {
   [[ apply SLLseg_to_SLL(x) ]];
   return n
 }
-{ SLL(#x, #vx) * (ret == len(#vx)) }
+{ SLL(#x; #vx) * (ret == len(#vx)) }
 
 // 07. Reversing a given SLL
-// { (x == #x) * SLL(#x, #vx) }
+// { (x == #x) * SLL(#x; #vx) }
 // function SLL_reverse_iter(x) {
 //    y := null;
 //    [[ invariant {bind: x, y, z, #nvx, #nvy}
-//        SLL(x, #nvx) * SLL(y, #nvy) * (#vx == ((rev #nvy) @ #nvx)) ]];
+//        SLL(x; #nvx) * SLL(y; #nvy) * (#vx == ((rev #nvy) @ #nvx)) ]];
 //    while (x != null) {
 //        z := [x + 1];
 //        [x + 1] := y;
@@ -439,17 +439,17 @@ function SLL_length_iter(x) {
 //    };
 //    return y
 //}
-//{ SLL(ret, rev #vx) }
+//{ SLL(ret; rev #vx) }
 
 // 08. Checking if a given value is in a given SLL
-{ (x == #x) * (k == #k) * SLL(#x, #alpha) * list_member(#alpha, #k, #r) }
+{ (x == #x) * (k == #k) * SLL(#x; #alpha) * list_member(#alpha, #k; #r) }
 function SLL_member_iter(x, k) {
   found := false;
   next := x;
   [[ invariant {bind: found, next, #beta, #gamma, #rg}
-       SLLseg(x, next, #beta) * SLL(next, #gamma) *
+       SLLseg(x; next, #beta) * SLL(next; #gamma) *
          (#alpha == (#beta @ #gamma)) * (#r == (found || #rg)) *
-           list_member(#beta, k, found) * list_member(#gamma, k, #rg) ]];
+           list_member(#beta, k; found) * list_member(#gamma, k; #rg) ]];
   while ((found == false) && (next != null)){
     [[ assert (found == false) ]];
     [[ assert {bind: #next} (next == #next) ]];
@@ -462,18 +462,18 @@ function SLL_member_iter(x, k) {
     [[ apply list_member_append(#beta, k, false, #v) ]]
   };
   [[ if (found == false) { apply SLLseg_to_SLL(#x); unfold list_member([], #k, false) } else {
-      assert {bind: #beta, #gamma} SLLseg(#x, next, #beta) * SLL(next, #gamma);
+      assert {bind: #beta, #gamma} SLLseg(#x; next, #beta) * SLL(next; #gamma);
       apply list_member_concat(#beta, #gamma, #k);
       apply SLLseg_concat_SLL(#x, next)
      } ]];
   return found
 }
-{ SLL(#x, #alpha) * list_member(#alpha, #k, #r) * (ret == #r) }
+{ SLL(#x; #alpha) * list_member(#alpha, #k; #r) * (ret == #r) }
 
 // 10. Freeing a given SLL
-{ (x == #x) * SLL(#x, #vs) }
+{ (x == #x) * SLL(#x; #vs) }
 function SLL_free_iter(x) {
-  [[ invariant {bind: x, #rvs} SLL(x, #rvs) ]];
+  [[ invariant {bind: x, #rvs} SLL(x; #rvs) ]];
   while (x != null) {
     y := x;
     x := [x + 1];

--- a/wisl/examples/SLL_ex_complete.wisl
+++ b/wisl/examples/SLL_ex_complete.wisl
@@ -1,7 +1,7 @@
 //
 // Standard over-approximating SLL predicate with contents
 //
-predicate SLL(+x, vs) {
+predicate SLL(x; vs) {
   // Empty SLL
   (x == null) * (vs == []);
   // One SLL node and the rest
@@ -12,7 +12,7 @@ predicate SLL(+x, vs) {
 //
 // Pure predicate for list membership
 //
-predicate list_member(+vs, +v, r : Bool){
+predicate list_member(vs, v; r : Bool){
   (vs == []) * (r == false);
   (vs == v :: #rest) * (r == true) * list_member(#rest, v, #mem);
   (vs == #v :: #rest) * (! (#v == v)) * list_member(#rest, v, r)
@@ -224,7 +224,7 @@ function SLL_free(x){
 //
 // Standard over-approximating SLL segment predicate with contents
 //
-predicate SLLseg(+x, y, vs) {
+predicate SLLseg(x; y, vs) {
   (x == y) * (vs == []);
   (x -b> #v, #next) * SLLseg(#next, y, #vs) * (vs == #v :: #vs)
 }

--- a/wisl/examples/SLL_ex_ongoing.wisl
+++ b/wisl/examples/SLL_ex_ongoing.wisl
@@ -230,7 +230,7 @@ function SLL_allocate_node(v){
 //
 
 // General pre-condition
-predicate SLL_prepend_pre(def, +x, xs, vs, n) {
+predicate SLL_prepend_pre(+x, def, xs, vs, n) {
     (def == 0) * SLL_addrs_incl(x, xs) * (vs == []) * (n == 0);
     (def == 2) * SLL_vals(x, vs) * (xs == []) * (n == 0);
     (def == 3) * SLL_incl(x, xs, vs) * (n == 0);
@@ -246,7 +246,7 @@ predicate SLL_prepend_post(+def, +x, +xs, +k, +vs, +n, +retval) {
 }
 
 // Specified algorithm
-{ (x == #x) * (k == #k) * SLL_prepend_pre(#def, #x, #xs, #vs, #n) }
+{ (x == #x) * (k == #k) * SLL_prepend_pre(#x, #def, #xs, #vs, #n) }
 function SLL_prepend(x, k){
     z := SLL_allocate_node(k);
     [z + 1] := x;
@@ -259,7 +259,7 @@ function SLL_prepend(x, k){
 //
 
 // General pre-condition
-predicate SLL_length_pre(def, +x, var : Int) {
+predicate SLL_length_pre(+x, def, var : Int) {
     (def == 0) * SLL_addrs_incl(x, #xs) * (var == len #xs);
     (def == 1) * SLL_addrs_excl(x, #xs) * (var == len #xs);
     (def == 2) * SLL_vals(x, #vs) * (var == len #vs);
@@ -279,7 +279,7 @@ predicate SLL_length_post(+def, +x, +retval) {
 }
 
 // Specified algorithm
-{ (x == #x) * SLL_length_pre(#def, #x, #var) } with variant: #var
+{ (x == #x) * SLL_length_pre(#x, #def, #var) } with variant: #var
 function SLL_length(x) {
   if (x == null){
     n := 0
@@ -319,7 +319,7 @@ function SLL_length_iter(x) {
 //
 
 // General pre-condition
-predicate SLL_concat_pre(def, +x, +y, xx, xy, vx, vy, nx, ny, var : Int) {
+predicate SLL_concat_pre(+x, +y, def, xx, xy, vx, vy, nx, ny, var : Int) {
     (def == 0) * SLL_addrs_incl(x, xx) * SLL_addrs_incl(y, xy) * (vx == []) * (vy == []) * (nx == 0) * (ny == 0) * (var == len xx);
     (def == 2) * SLL_vals(x, vx) * SLL_vals(y, vy) * (xx == []) * (xy == []) * (nx == 0) * (ny == 0) * (var == len vx);
     (def == 3) * SLL_incl(x, xx, vx) * SLL_incl(y, xy, vy) * (nx == 0) * (ny == 0) * (var == len vx);
@@ -335,7 +335,7 @@ predicate SLL_concat_post(+def, +x, +y, +xx, +xy, +vx, +vy, +nx, +ny, +retval) {
 }
 
 // Specified algorithm
-{(x == #x) * (y == #y) * SLL_concat_pre(#def, #x, #y, #xx, #xy, #vx, #vy, #nx, #ny, #var) } with variant: #var
+{(x == #x) * (y == #y) * SLL_concat_pre(#x, #y, #def, #xx, #xy, #vx, #vy, #nx, #ny, #var) } with variant: #var
 function SLL_concat(x, y) {
   if (x == null){
     x := y
@@ -382,7 +382,7 @@ function SLL_concat_iter(x, y){
 //
 
 // General pre-condition
-predicate SLL_reverse_pre(def, +x, xs, vs, n, var) {
+predicate SLL_reverse_pre(+x, def, xs, vs, n, var) {
     (def == 0) * SLL_addrs_incl(x, xs) * (vs == []) * (n == 0) * (var == len xs);
     (def == 2) * SLL_vals(x, vs) * (xs == []) * (n == 0) * (var == len vs);
     (def == 3) * SLL_incl(x, xs, vs) * (n == 0) * (var == len xs);
@@ -398,7 +398,7 @@ predicate SLL_reverse_post(+def, +x, +xs, +vs, +n, +retval) {
 }
 
 // Specified algorithm
-{ (x == #x) * SLL_reverse_pre(#def, #x, #xs, #vs, #n, #var) } with variant: #var
+{ (x == #x) * SLL_reverse_pre(#x, #def, #xs, #vs, #n, #var) } with variant: #var
 function SLL_reverse(x){
   if (x != null) {
     t := [x + 1];
@@ -417,7 +417,7 @@ function SLL_reverse(x){
 //
 
 // General pre-condition
-predicate SLL_member_pre(def, +x, vs, var : Int) {
+predicate SLL_member_pre(+x, def, vs, var : Int) {
     (def == 2) * SLL_vals(x, vs) * (var == len vs);
     (def == 3) * SLL_incl(x, #xs, vs) * (var == len vs);
     (def == 4) * SLL_excl(x, #xs, vs) * (var == len vs)
@@ -430,7 +430,7 @@ predicate nounfold SLL_member_post(+def, +x, +vs) {
 }
 
 // Specified algorithm
-{ (x == #x) * (k == #k) * SLL_member_pre(#def, #x, #vs, #var) * list_member(#vs, #k, #r) } with variant: #var
+{ (x == #x) * (k == #k) * SLL_member_pre(#x, #def, #vs, #var) * list_member(#vs, #k, #r) } with variant: #var
 function SLL_member(x, k){
   found := false;
   if (x == null){
@@ -488,7 +488,7 @@ function SLL_member_iter(x, k) {
 //
 
 // General pre-condition
-predicate SLL_free_pre(def, +x, xs, var : Int) {
+predicate SLL_free_pre(+x, def, xs, var : Int) {
     (def == 0) * SLL_addrs_incl(x, xs) * (var == len xs);
     (def == 1) * SLL_addrs_excl(x, xs) * (var == len xs);
     (def == 3) * SLL_incl(x, xs, #vs) * (var == len xs);
@@ -504,7 +504,7 @@ predicate SLL_free_post(+def, +x, +xs) {
 }
 
 // Specified algorithm
-{ (x == #x) * SLL_free_pre(#def, #x, #xs, #var) } with variant: #var
+{ (x == #x) * SLL_free_pre(#x, #def, #xs, #var) } with variant: #var
 function SLL_free(x){
   if (x == null) {
     skip

--- a/wisl/examples/SLL_ex_ongoing.wisl
+++ b/wisl/examples/SLL_ex_ongoing.wisl
@@ -7,7 +7,7 @@ predicate SLL_addrs_incl(x; xs : List) {
   // Empty SLL
   (x == null) * (xs == []);
   // One SLL node and the rest
-  (x -b> #v, #y) * SLL_addrs_incl(#y, #xs) * (xs == x :: #xs)
+  (x -b> #v, #y) * SLL_addrs_incl(#y; #xs) * (xs == x :: #xs)
 }
 
 // With addresses, excluding first
@@ -15,7 +15,7 @@ predicate SLL_addrs_excl(x; xs : List) {
   // Empty SLL
   (x == null) * (xs == []);
   // One SLL node and the rest
-  (x -b> #v, #y) * SLL_addrs_excl(#y, #xs) * (xs == #y :: #xs)
+  (x -b> #v, #y) * SLL_addrs_excl(#y; #xs) * (xs == #y :: #xs)
 }
 
 // With values
@@ -23,7 +23,7 @@ predicate SLL_vals(x; vs : List) {
   // Empty SLL
   (x == null) * (vs == []);
   // One SLL node and the rest
-  (x -b> #v, #y) * SLL_vals(#y, #vs) * (vs == #v :: #vs)
+  (x -b> #v, #y) * SLL_vals(#y; #vs) * (vs == #v :: #vs)
 }
 
 // With addresses, including first, and values
@@ -31,7 +31,7 @@ predicate SLL_incl(x; xs : List, vs : List) {
   // Empty SLL
   (x == null) * (xs == []) * (vs == []);
   // One SLL node and the rest
-  (x -b> #v, #y) * SLL_incl(#y, #xs, #vs) * (xs == x :: #xs) * (vs == #v :: #vs)
+  (x -b> #v, #y) * SLL_incl(#y; #xs, #vs) * (xs == x :: #xs) * (vs == #v :: #vs)
 }
 
 // With addresses, excluding first, and values
@@ -39,7 +39,7 @@ predicate SLL_excl(x; xs : List, vs : List) {
   // Empty SLL
   (x == null) * (xs == []) * (vs == []);
   // One SLL node and the rest
-  (x -b> #v, #y) * SLL_excl(#y, #xs, #vs) * (xs == #y :: #xs) * (vs == #v :: #vs)
+  (x -b> #v, #y) * SLL_excl(#y; #xs, #vs) * (xs == #y :: #xs) * (vs == #v :: #vs)
 }
 
 // With length
@@ -47,7 +47,7 @@ predicate SLL_len(x; n : Int) {
   // Empty SLL
   (x == null) * (n == 0);
   // One SLL node and the rest
-  (x -b> #v, #y) * SLL_len(#y, n - 1)
+  (x -b> #v, #y) * SLL_len(#y; n - 1)
 }
 
 //
@@ -57,13 +57,13 @@ predicate SLL_len(x; n : Int) {
 // With length
 predicate SLLseg_len(x; y, n : Int) {
   (x == y) * (n == 0);
-  (x -b> #v, #z) * SLLseg_len(#z, y, n - 1) * (0 < n)
+  (x -b> #v, #z) * SLLseg_len(#z; y, n - 1) * (0 < n)
 }
 
 // With values
 predicate SLLseg_vals(x; y, vs) {
   (x == y) * (vs == []);
-  (x -b> #v, #next) * SLLseg_vals(#next, y, #vs) * (vs == #v :: #vs)
+  (x -b> #v, #next) * SLLseg_vals(#next; y, #vs) * (vs == #v :: #vs)
 }
 
 //
@@ -72,8 +72,8 @@ predicate SLLseg_vals(x; y, vs) {
 
 predicate list_member(vs, v; r : Bool) {
   (vs == []) * (r == false);
-  (vs == v :: #rest) * (r == true) * list_member(#rest, v, #mem);
-  (vs == #v :: #rest) * (! (#v == v)) * list_member(#rest, v, r)
+  (vs == v :: #rest) * (r == true) * list_member(#rest, v; #mem);
+  (vs == #v :: #rest) * (! (#v == v)) * list_member(#rest, v; r)
 }
 
 //
@@ -81,7 +81,7 @@ predicate list_member(vs, v; r : Bool) {
 //
 predicate freed_nodes(xs;) {
     (xs == [ null ]);
-    (xs == #x :: #xs) * freed(#x) * freed_nodes(#xs)
+    (xs == #x :: #xs) * freed(#x;) * freed_nodes(#xs;)
 }
 
 //
@@ -94,7 +94,7 @@ predicate freed_nodes(xs;) {
 lemma SLLseg_vals_append {
   statement:
     forall x.
-      SLLseg_vals(#x, #y, #vs) * (#y -b> #v, #z) |- SLLseg_vals(#x, #z, #vs @ [ #v ])
+      SLLseg_vals(#x; #y, #vs) * (#y -b> #v, #z) |- SLLseg_vals(#x; #z, #vs @ [ #v ])
 
   variant: (len #vs)
 
@@ -113,7 +113,7 @@ lemma SLLseg_vals_append {
 lemma SLLseg_vals_concat_SLL_vals {
   statement:
     forall x.
-      SLLseg_vals(#x, #y, #vx) * SLL_vals(#y, #vy) |- SLL_vals (#x, #vx @ #vy)
+      SLLseg_vals(#x; #y, #vx) * SLL_vals(#y; #vy) |- SLL_vals (#x; #vx @ #vy)
 
   variant: (len #vx)
 
@@ -129,7 +129,7 @@ lemma SLLseg_vals_concat_SLL_vals {
 lemma SLLseg_vals_to_SLL_vals {
   statement:
     forall x.
-      SLLseg_vals(#x, null, #vs) |- SLL_vals(#x, #vs)
+      SLLseg_vals(#x; null, #vs) |- SLL_vals(#x; #vs)
 
   variant: len #vs
 
@@ -146,7 +146,7 @@ lemma SLLseg_vals_to_SLL_vals {
 lemma SLLseg_len_append_lr {
   statement:
     forall x.
-      SLLseg_len(#x, #y, #n) * (#y -b> #v, #z) |- SLLseg_len(#x, #z, #n + 1) * (0 <= #n)
+      SLLseg_len(#x; #y, #n) * (#y -b> #v, #z) |- SLLseg_len(#x; #z, #n + 1) * (0 <= #n)
 
   variant: #n
 
@@ -163,7 +163,7 @@ lemma SLLseg_len_append_lr {
 lemma SLLseg_len_append_rl {
   statement:
     forall x.
-      SLLseg_len(#x, #z, #n + 1) * (0 <= #n) |- SLLseg_len(#x, #y, #n) * (#y -b> #v, #z)
+      SLLseg_len(#x; #z, #n + 1) * (0 <= #n) |- SLLseg_len(#x; #y, #n) * (#y -b> #v, #z)
 
   variant: #n
 
@@ -172,7 +172,7 @@ lemma SLLseg_len_append_rl {
     assert {bind: #nnext} (#x + 1 -> #nnext);
     if (#n != 0) {
         apply SLLseg_len_append_rl(#nnext);
-        assert {bind: #y} SLLseg_len(#nnext, #y, #n - 1);
+        assert {bind: #y} SLLseg_len(#nnext; #y, #n - 1);
         fold SLLseg_len(#x, #y, #n)
     }
 }
@@ -181,7 +181,7 @@ lemma SLLseg_len_append_rl {
 lemma SLLseg_len_to_SLL_len {
   statement:
     forall x.
-      SLLseg_len(#x, null, #n) |- SLL_len(#x, #n)
+      SLLseg_len(#x; null, #n) |- SLL_len(#x; #n)
 
   variant: #n
 
@@ -198,14 +198,14 @@ lemma SLLseg_len_to_SLL_len {
 lemma list_member_concat {
   statement:
     forall vs1, vs2, v.
-      list_member(#vs1, #v, #r1) * list_member(#vs2, #v, #r2) |- list_member(#vs1 @ #vs2, #v, (#r1 || #r2))
+      list_member(#vs1, #v; #r1) * list_member(#vs2, #v; #r2) |- list_member(#vs1 @ #vs2, #v; (#r1 || #r2))
 
   variant: len #vs1
 
   proof:
     unfold list_member(#vs1, #v, #r1);
     if (#vs1 != []) {
-      assert {bind: #nv1, #nvs1, #nr1} (#vs1 == #nv1 :: #nvs1) * list_member(#nvs1, v, #nr1);
+      assert {bind: #nv1, #nvs1, #nr1} (#vs1 == #nv1 :: #nvs1) * list_member(#nvs1, v; #nr1);
       apply list_member_concat(#nvs1, #vs2, #v)
     }
 }
@@ -231,28 +231,28 @@ function SLL_allocate_node(v){
 
 // General pre-condition
 predicate SLL_prepend_pre(x; def, xs, vs, n) {
-    (def == 0) * SLL_addrs_incl(x, xs) * (vs == []) * (n == 0);
-    (def == 2) * SLL_vals(x, vs) * (xs == []) * (n == 0);
-    (def == 3) * SLL_incl(x, xs, vs) * (n == 0);
-    (def == 5) * SLL_len(x, n) * (xs == []) * (vs == [])
+    (def == 0) * SLL_addrs_incl(x; xs) * (vs == []) * (n == 0);
+    (def == 2) * SLL_vals(x; vs) * (xs == []) * (n == 0);
+    (def == 3) * SLL_incl(x; xs, vs) * (n == 0);
+    (def == 5) * SLL_len(x; n) * (xs == []) * (vs == [])
 }
 
 // General post-condition
 predicate SLL_prepend_post(def, x, xs, k, vs, n, retval;) {
-    (def == 0) * SLL_addrs_incl(retval, retval :: xs);
-    (def == 2) * SLL_vals(retval, k :: vs);
-    (def == 3) * SLL_incl(retval, retval :: xs, k :: vs);
-    (def == 5) * SLL_len(retval, n + 1) * (xs == [])
+    (def == 0) * SLL_addrs_incl(retval; retval :: xs);
+    (def == 2) * SLL_vals(retval; k :: vs);
+    (def == 3) * SLL_incl(retval; retval :: xs, k :: vs);
+    (def == 5) * SLL_len(retval; n + 1) * (xs == [])
 }
 
 // Specified algorithm
-{ (x == #x) * (k == #k) * SLL_prepend_pre(#x, #def, #xs, #vs, #n) }
+{ (x == #x) * (k == #k) * SLL_prepend_pre(#x; #def, #xs, #vs, #n) }
 function SLL_prepend(x, k){
     z := SLL_allocate_node(k);
     [z + 1] := x;
     return z
 }
-{ SLL_prepend_post(#def, #x, #xs, #k, #vs, #n, ret) }
+{ SLL_prepend_post(#def, #x, #xs, #k, #vs, #n, ret;) }
 
 //
 // 02r. List length
@@ -260,26 +260,26 @@ function SLL_prepend(x, k){
 
 // General pre-condition
 predicate SLL_length_pre(x; def, var : Int) {
-    (def == 0) * SLL_addrs_incl(x, #xs) * (var == len #xs);
-    (def == 1) * SLL_addrs_excl(x, #xs) * (var == len #xs);
-    (def == 2) * SLL_vals(x, #vs) * (var == len #vs);
-    (def == 3) * SLL_incl(x, #xs, #vs) * (var == len #xs);
-    (def == 4) * SLL_excl(x, #xs, #vs) * (var == len #xs);
-    (def == 5) * SLL_len(x, #n) * (var == #n)
+    (def == 0) * SLL_addrs_incl(x; #xs) * (var == len #xs);
+    (def == 1) * SLL_addrs_excl(x; #xs) * (var == len #xs);
+    (def == 2) * SLL_vals(x; #vs) * (var == len #vs);
+    (def == 3) * SLL_incl(x; #xs, #vs) * (var == len #xs);
+    (def == 4) * SLL_excl(x; #xs, #vs) * (var == len #xs);
+    (def == 5) * SLL_len(x; #n) * (var == #n)
 }
 
 // General post-condition
 predicate SLL_length_post(def, x, retval;) {
-    (def == 0) * SLL_addrs_incl(x, #xs) * (retval == len #xs);
-    (def == 1) * SLL_addrs_excl(x, #xs) * (retval == len #xs);
-    (def == 2) * SLL_vals(x, #vs) * (retval == len #vs);
-    (def == 3) * SLL_incl(x, #xs, #vs) * (retval == len #xs);
-    (def == 4) * SLL_excl(x, #xs, #vs) * (retval == len #xs);
-    (def == 5) * SLL_len(x, retval)
+    (def == 0) * SLL_addrs_incl(x; #xs) * (retval == len #xs);
+    (def == 1) * SLL_addrs_excl(x; #xs) * (retval == len #xs);
+    (def == 2) * SLL_vals(x; #vs) * (retval == len #vs);
+    (def == 3) * SLL_incl(x; #xs, #vs) * (retval == len #xs);
+    (def == 4) * SLL_excl(x; #xs, #vs) * (retval == len #xs);
+    (def == 5) * SLL_len(x; retval)
 }
 
 // Specified algorithm
-{ (x == #x) * SLL_length_pre(#x, #def, #var) } with variant: #var
+{ (x == #x) * SLL_length_pre(#x; #def, #var) } with variant: #var
 function SLL_length(x) {
   if (x == null){
     n := 0
@@ -290,19 +290,19 @@ function SLL_length(x) {
   };
   return n
 }
-{ SLL_length_post(#def, #x, ret) }
+{ SLL_length_post(#def, #x, ret;) }
 
 //
 // 02i. List Length
 //
 
 // Specified algorithm
-{ (x == #x) * SLL_len(x, #n) }
+{ (x == #x) * SLL_len(x; #n) }
 function SLL_length_iter(x) {
   y := x;
   n := 0;
   [[ invariant {bind: n, y, #ny}
-        SLLseg_len(x, y, n) * SLL_len(y, #ny) * (#n == n + #ny)
+        SLLseg_len(x; y, n) * SLL_len(y; #ny) * (#n == n + #ny)
         with variant: #ny ]];
   while (y != null) {
     y := [y + 1];
@@ -312,7 +312,7 @@ function SLL_length_iter(x) {
   [[ apply SLLseg_len_to_SLL_len(x) ]];
   return n
 }
-{ SLL_len(#x, #n) * (ret == n) }
+{ SLL_len(#x; #n) * (ret == n) }
 
 //
 // 03r. List concatenation
@@ -320,22 +320,22 @@ function SLL_length_iter(x) {
 
 // General pre-condition
 predicate SLL_concat_pre(x, y; def, xx, xy, vx, vy, nx, ny, var : Int) {
-    (def == 0) * SLL_addrs_incl(x, xx) * SLL_addrs_incl(y, xy) * (vx == []) * (vy == []) * (nx == 0) * (ny == 0) * (var == len xx);
-    (def == 2) * SLL_vals(x, vx) * SLL_vals(y, vy) * (xx == []) * (xy == []) * (nx == 0) * (ny == 0) * (var == len vx);
-    (def == 3) * SLL_incl(x, xx, vx) * SLL_incl(y, xy, vy) * (nx == 0) * (ny == 0) * (var == len vx);
-    (def == 5) * SLL_len(x, nx) * SLL_len(y, ny) * (xx == []) * (xy == []) * (vx == []) * (vy == []) * (var == nx)
+    (def == 0) * SLL_addrs_incl(x; xx) * SLL_addrs_incl(y; xy) * (vx == []) * (vy == []) * (nx == 0) * (ny == 0) * (var == len xx);
+    (def == 2) * SLL_vals(x; vx) * SLL_vals(y; vy) * (xx == []) * (xy == []) * (nx == 0) * (ny == 0) * (var == len vx);
+    (def == 3) * SLL_incl(x; xx, vx) * SLL_incl(y; xy, vy) * (nx == 0) * (ny == 0) * (var == len vx);
+    (def == 5) * SLL_len(x; nx) * SLL_len(y; ny) * (xx == []) * (xy == []) * (vx == []) * (vy == []) * (var == nx)
 }
 
 // General post-condition
 predicate SLL_concat_post(def, x, y, xx, xy, vx, vy, nx, ny, retval;) {
-    (def == 0) * SLL_addrs_incl(retval, xx @ xy);
-    (def == 2) * SLL_vals(retval, vx @ vy);
-    (def == 3) * SLL_incl(retval, xx @ xy, vx @ vy);
-    (def == 5) * SLL_len(retval, nx + ny)
+    (def == 0) * SLL_addrs_incl(retval; xx @ xy);
+    (def == 2) * SLL_vals(retval; vx @ vy);
+    (def == 3) * SLL_incl(retval; xx @ xy, vx @ vy);
+    (def == 5) * SLL_len(retval; nx + ny)
 }
 
 // Specified algorithm
-{(x == #x) * (y == #y) * SLL_concat_pre(#x, #y, #def, #xx, #xy, #vx, #vy, #nx, #ny, #var) } with variant: #var
+{(x == #x) * (y == #y) * SLL_concat_pre(#x, #y; #def, #xx, #xy, #vx, #vy, #nx, #ny, #var) } with variant: #var
 function SLL_concat(x, y) {
   if (x == null){
     x := y
@@ -346,14 +346,14 @@ function SLL_concat(x, y) {
   };
   return x
 }
-{ SLL_concat_post(#def, #x, #y, #xx, #xy, #vx, #vy, #nx, #ny, ret) }
+{ SLL_concat_post(#def, #x, #y, #xx, #xy, #vx, #vy, #nx, #ny, ret;) }
 
 //
 // 03i. List concatenation
 //
 
 // Specified algorithm
-{(x == #x) * (y == #y) * SLL_vals(#x, #vx) * SLL_vals(#y, #vy) }
+{(x == #x) * (y == #y) * SLL_vals(#x; #vx) * SLL_vals(#y; #vy) }
 function SLL_concat_iter(x, y){
   if (x == null) {
     head := y
@@ -362,7 +362,7 @@ function SLL_concat_iter(x, y){
     prev := head;
     next := [x + 1];
     [[ invariant {bind: prev, next, #vs1, #vs2, #v}
-          SLLseg_vals(head, prev, #vs1) * (prev -b> #v, next) * SLL_vals(next, #vs2) *
+          SLLseg_vals(head; prev, #vs1) * (prev -b> #v, next) * SLL_vals(next; #vs2) *
           (#vx == #vs1 @ (#v :: #vs2)) with variant: (len #vs2) ]];
     while (next != null) {
         prev := next;
@@ -375,7 +375,7 @@ function SLL_concat_iter(x, y){
   };
   return head
 }
-{ SLL_vals(ret, #vx @ #vy) }
+{ SLL_vals(ret; #vx @ #vy) }
 
 //
 // 04r. Reversing a given SLL
@@ -383,22 +383,22 @@ function SLL_concat_iter(x, y){
 
 // General pre-condition
 predicate SLL_reverse_pre(x; def, xs, vs, n, var) {
-    (def == 0) * SLL_addrs_incl(x, xs) * (vs == []) * (n == 0) * (var == len xs);
-    (def == 2) * SLL_vals(x, vs) * (xs == []) * (n == 0) * (var == len vs);
-    (def == 3) * SLL_incl(x, xs, vs) * (n == 0) * (var == len xs);
-    (def == 5) * SLL_len(x, n) * (xs == []) * (vs == []) * (var == n)
+    (def == 0) * SLL_addrs_incl(x; xs) * (vs == []) * (n == 0) * (var == len xs);
+    (def == 2) * SLL_vals(x; vs) * (xs == []) * (n == 0) * (var == len vs);
+    (def == 3) * SLL_incl(x; xs, vs) * (n == 0) * (var == len xs);
+    (def == 5) * SLL_len(x; n) * (xs == []) * (vs == []) * (var == n)
 }
 
 // General post-condition
 predicate SLL_reverse_post(def, x, xs, vs, n, retval;) {
-    (def == 0) * SLL_addrs_incl(retval, rev xs) * (vs == []) * (n == 0);
-    (def == 2) * SLL_vals(retval, rev vs) * (xs == []) * (n == 0);
-    (def == 3) * SLL_incl(retval, rev xs, rev vs) * (n == 0);
-    (def == 5) * SLL_len(retval, n) * (xs == []) * (vs == [])
+    (def == 0) * SLL_addrs_incl(retval; rev xs) * (vs == []) * (n == 0);
+    (def == 2) * SLL_vals(retval; rev vs) * (xs == []) * (n == 0);
+    (def == 3) * SLL_incl(retval; rev xs, rev vs) * (n == 0);
+    (def == 5) * SLL_len(retval; n) * (xs == []) * (vs == [])
 }
 
 // Specified algorithm
-{ (x == #x) * SLL_reverse_pre(#x, #def, #xs, #vs, #n, #var) } with variant: #var
+{ (x == #x) * SLL_reverse_pre(#x; #def, #xs, #vs, #n, #var) } with variant: #var
 function SLL_reverse(x){
   if (x != null) {
     t := [x + 1];
@@ -410,7 +410,7 @@ function SLL_reverse(x){
   };
   return y
 }
-{ SLL_reverse_post(#def, #x, #xs, #vs, #n, ret) }
+{ SLL_reverse_post(#def, #x, #xs, #vs, #n, ret;) }
 
 //
 // 05r. List Membership
@@ -418,19 +418,19 @@ function SLL_reverse(x){
 
 // General pre-condition
 predicate SLL_member_pre(x; def, vs, var : Int) {
-    (def == 2) * SLL_vals(x, vs) * (var == len vs);
-    (def == 3) * SLL_incl(x, #xs, vs) * (var == len vs);
-    (def == 4) * SLL_excl(x, #xs, vs) * (var == len vs)
+    (def == 2) * SLL_vals(x; vs) * (var == len vs);
+    (def == 3) * SLL_incl(x; #xs, vs) * (var == len vs);
+    (def == 4) * SLL_excl(x; #xs, vs) * (var == len vs)
 }
 
 predicate nounfold SLL_member_post(def, x, vs;) {
-    (def == 2) * SLL_vals(x, vs);
-    (def == 3) * SLL_incl(x, #xs, vs);
-    (def == 4) * SLL_excl(x, #xs, vs)
+    (def == 2) * SLL_vals(x; vs);
+    (def == 3) * SLL_incl(x; #xs, vs);
+    (def == 4) * SLL_excl(x; #xs, vs)
 }
 
 // Specified algorithm
-{ (x == #x) * (k == #k) * SLL_member_pre(#x, #def, #vs, #var) * list_member(#vs, #k, #r) } with variant: #var
+{ (x == #x) * (k == #k) * SLL_member_pre(#x; #def, #vs, #var) * list_member(#vs, #k; #r) } with variant: #var
 function SLL_member(x, k){
   found := false;
   if (x == null){
@@ -446,19 +446,19 @@ function SLL_member(x, k){
   };
   return found
 }
-{ SLL_member_post(#def, #x, #vs) * list_member(#vs, #k, #r) * (ret == #r) }
+{ SLL_member_post(#def, #x, #vs;) * list_member(#vs, #k; #r) * (ret == #r) }
 
 //
 // 05i. List membership
 //
-{ (x == #x) * (k == #k) * SLL_vals(#x, #vs) * list_member(#vs, #k, #r) }
+{ (x == #x) * (k == #k) * SLL_vals(#x; #vs) * list_member(#vs, #k; #r) }
 function SLL_member_iter(x, k) {
   found := false;
   next := x;
   [[ invariant {bind: found, next, #beta, #gamma, #rg}
-       SLLseg_vals(x, next, #beta) * SLL_vals(next, #gamma) *
+       SLLseg_vals(x; next, #beta) * SLL_vals(next; #gamma) *
          (#alpha == (#beta @ #gamma)) * (#r == (found || #rg)) *
-           list_member(#beta, k, found) * list_member(#gamma, k, #rg)
+           list_member(#beta, k; found) * list_member(#gamma, k; #rg)
      with variant: (len #gamma) ]] ;
   while ((found == false) && (next != null)) {
     [[ assert (found == false) ]];
@@ -474,14 +474,14 @@ function SLL_member_iter(x, k) {
      if (found == false) {
        apply SLLseg_vals_to_SLL_vals(#x)
      } else {
-       assert {bind: #beta, #gamma} SLLseg_vals(#x, next, #beta) * SLL_vals(next, #gamma);
+       assert {bind: #beta, #gamma} SLLseg_vals(#x; next, #beta) * SLL_vals(next; #gamma);
        apply list_member_concat(#beta, #gamma, #k);
        apply SLLseg_vals_concat_SLL_vals(#x)
      }
   ]];
   return found
 }
-{ SLL_vals(#x, #vs) * list_member(#vs, #k, #r) * (ret == #r) }
+{ SLL_vals(#x; #vs) * list_member(#vs, #k; #r) * (ret == #r) }
 
 //
 // 06r. Freeing a given SLL
@@ -489,22 +489,22 @@ function SLL_member_iter(x, k) {
 
 // General pre-condition
 predicate SLL_free_pre(x; def, xs, var : Int) {
-    (def == 0) * SLL_addrs_incl(x, xs) * (var == len xs);
-    (def == 1) * SLL_addrs_excl(x, xs) * (var == len xs);
-    (def == 3) * SLL_incl(x, xs, #vs) * (var == len xs);
-    (def == 4) * SLL_excl(x, xs, #vs) * (var == len xs)
+    (def == 0) * SLL_addrs_incl(x; xs) * (var == len xs);
+    (def == 1) * SLL_addrs_excl(x; xs) * (var == len xs);
+    (def == 3) * SLL_incl(x; xs, #vs) * (var == len xs);
+    (def == 4) * SLL_excl(x; xs, #vs) * (var == len xs)
 }
 
 // General post-condition
 predicate SLL_free_post(def, x, xs;) {
-    (def == 0) * freed_nodes(xs @ [ null ]);
-    (def == 1) * freed_nodes(x :: xs);
-    (def == 3) * freed_nodes(xs @ [ null ]);
-    (def == 4) * freed_nodes(x :: xs)
+    (def == 0) * freed_nodes(xs @ [ null ];);
+    (def == 1) * freed_nodes(x :: xs;);
+    (def == 3) * freed_nodes(xs @ [ null ];);
+    (def == 4) * freed_nodes(x :: xs;)
 }
 
 // Specified algorithm
-{ (x == #x) * SLL_free_pre(#x, #def, #xs, #var) } with variant: #var
+{ (x == #x) * SLL_free_pre(#x; #def, #xs, #var) } with variant: #var
 function SLL_free(x){
   if (x == null) {
     skip
@@ -515,4 +515,4 @@ function SLL_free(x){
   };
   return null
 }
-{ (ret == null) * SLL_free_post(#def, #x, #xs)}
+{ (ret == null) * SLL_free_post(#def, #x, #xs;)}

--- a/wisl/examples/SLL_ex_ongoing.wisl
+++ b/wisl/examples/SLL_ex_ongoing.wisl
@@ -79,9 +79,9 @@ predicate list_member(vs, v; r : Bool) {
 //
 // Predicate for freed list nodes
 //
-predicate freed_nodes(xs;) {
+predicate freed_nodes(xs) {
     (xs == [ null ]);
-    (xs == #x :: #xs) * freed(#x;) * freed_nodes(#xs;)
+    (xs == #x :: #xs) * freed(#x) * freed_nodes(#xs)
 }
 
 //
@@ -238,7 +238,7 @@ predicate SLL_prepend_pre(x; def, xs, vs, n) {
 }
 
 // General post-condition
-predicate SLL_prepend_post(def, x, xs, k, vs, n, retval;) {
+predicate SLL_prepend_post(def, x, xs, k, vs, n, retval) {
     (def == 0) * SLL_addrs_incl(retval; retval :: xs);
     (def == 2) * SLL_vals(retval; k :: vs);
     (def == 3) * SLL_incl(retval; retval :: xs, k :: vs);
@@ -252,7 +252,7 @@ function SLL_prepend(x, k){
     [z + 1] := x;
     return z
 }
-{ SLL_prepend_post(#def, #x, #xs, #k, #vs, #n, ret;) }
+{ SLL_prepend_post(#def, #x, #xs, #k, #vs, #n, ret) }
 
 //
 // 02r. List length
@@ -269,7 +269,7 @@ predicate SLL_length_pre(x; def, var : Int) {
 }
 
 // General post-condition
-predicate SLL_length_post(def, x, retval;) {
+predicate SLL_length_post(def, x, retval) {
     (def == 0) * SLL_addrs_incl(x; #xs) * (retval == len #xs);
     (def == 1) * SLL_addrs_excl(x; #xs) * (retval == len #xs);
     (def == 2) * SLL_vals(x; #vs) * (retval == len #vs);
@@ -290,7 +290,7 @@ function SLL_length(x) {
   };
   return n
 }
-{ SLL_length_post(#def, #x, ret;) }
+{ SLL_length_post(#def, #x, ret) }
 
 //
 // 02i. List Length
@@ -327,7 +327,7 @@ predicate SLL_concat_pre(x, y; def, xx, xy, vx, vy, nx, ny, var : Int) {
 }
 
 // General post-condition
-predicate SLL_concat_post(def, x, y, xx, xy, vx, vy, nx, ny, retval;) {
+predicate SLL_concat_post(def, x, y, xx, xy, vx, vy, nx, ny, retval) {
     (def == 0) * SLL_addrs_incl(retval; xx @ xy);
     (def == 2) * SLL_vals(retval; vx @ vy);
     (def == 3) * SLL_incl(retval; xx @ xy, vx @ vy);
@@ -346,7 +346,7 @@ function SLL_concat(x, y) {
   };
   return x
 }
-{ SLL_concat_post(#def, #x, #y, #xx, #xy, #vx, #vy, #nx, #ny, ret;) }
+{ SLL_concat_post(#def, #x, #y, #xx, #xy, #vx, #vy, #nx, #ny, ret) }
 
 //
 // 03i. List concatenation
@@ -390,7 +390,7 @@ predicate SLL_reverse_pre(x; def, xs, vs, n, var) {
 }
 
 // General post-condition
-predicate SLL_reverse_post(def, x, xs, vs, n, retval;) {
+predicate SLL_reverse_post(def, x, xs, vs, n, retval) {
     (def == 0) * SLL_addrs_incl(retval; rev xs) * (vs == []) * (n == 0);
     (def == 2) * SLL_vals(retval; rev vs) * (xs == []) * (n == 0);
     (def == 3) * SLL_incl(retval; rev xs, rev vs) * (n == 0);
@@ -410,7 +410,7 @@ function SLL_reverse(x){
   };
   return y
 }
-{ SLL_reverse_post(#def, #x, #xs, #vs, #n, ret;) }
+{ SLL_reverse_post(#def, #x, #xs, #vs, #n, ret) }
 
 //
 // 05r. List Membership
@@ -423,7 +423,7 @@ predicate SLL_member_pre(x; def, vs, var : Int) {
     (def == 4) * SLL_excl(x; #xs, vs) * (var == len vs)
 }
 
-predicate nounfold SLL_member_post(def, x, vs;) {
+predicate nounfold SLL_member_post(def, x, vs) {
     (def == 2) * SLL_vals(x; vs);
     (def == 3) * SLL_incl(x; #xs, vs);
     (def == 4) * SLL_excl(x; #xs, vs)
@@ -446,7 +446,7 @@ function SLL_member(x, k){
   };
   return found
 }
-{ SLL_member_post(#def, #x, #vs;) * list_member(#vs, #k; #r) * (ret == #r) }
+{ SLL_member_post(#def, #x, #vs) * list_member(#vs, #k; #r) * (ret == #r) }
 
 //
 // 05i. List membership
@@ -496,11 +496,11 @@ predicate SLL_free_pre(x; def, xs, var : Int) {
 }
 
 // General post-condition
-predicate SLL_free_post(def, x, xs;) {
-    (def == 0) * freed_nodes(xs @ [ null ];);
-    (def == 1) * freed_nodes(x :: xs;);
-    (def == 3) * freed_nodes(xs @ [ null ];);
-    (def == 4) * freed_nodes(x :: xs;)
+predicate SLL_free_post(def, x, xs) {
+    (def == 0) * freed_nodes(xs @ [ null ]);
+    (def == 1) * freed_nodes(x :: xs);
+    (def == 3) * freed_nodes(xs @ [ null ]);
+    (def == 4) * freed_nodes(x :: xs)
 }
 
 // Specified algorithm
@@ -515,4 +515,4 @@ function SLL_free(x){
   };
   return null
 }
-{ (ret == null) * SLL_free_post(#def, #x, #xs;)}
+{ (ret == null) * SLL_free_post(#def, #x, #xs)}

--- a/wisl/examples/SLL_ex_ongoing.wisl
+++ b/wisl/examples/SLL_ex_ongoing.wisl
@@ -3,7 +3,7 @@
 //
 
 // With addresses, including first
-predicate SLL_addrs_incl(+x, xs : List) {
+predicate SLL_addrs_incl(x; xs : List) {
   // Empty SLL
   (x == null) * (xs == []);
   // One SLL node and the rest
@@ -11,7 +11,7 @@ predicate SLL_addrs_incl(+x, xs : List) {
 }
 
 // With addresses, excluding first
-predicate SLL_addrs_excl(+x, xs : List) {
+predicate SLL_addrs_excl(x; xs : List) {
   // Empty SLL
   (x == null) * (xs == []);
   // One SLL node and the rest
@@ -19,7 +19,7 @@ predicate SLL_addrs_excl(+x, xs : List) {
 }
 
 // With values
-predicate SLL_vals(+x, vs : List) {
+predicate SLL_vals(x; vs : List) {
   // Empty SLL
   (x == null) * (vs == []);
   // One SLL node and the rest
@@ -27,7 +27,7 @@ predicate SLL_vals(+x, vs : List) {
 }
 
 // With addresses, including first, and values
-predicate SLL_incl(+x, xs : List, vs : List) {
+predicate SLL_incl(x; xs : List, vs : List) {
   // Empty SLL
   (x == null) * (xs == []) * (vs == []);
   // One SLL node and the rest
@@ -35,7 +35,7 @@ predicate SLL_incl(+x, xs : List, vs : List) {
 }
 
 // With addresses, excluding first, and values
-predicate SLL_excl(+x, xs : List, vs : List) {
+predicate SLL_excl(x; xs : List, vs : List) {
   // Empty SLL
   (x == null) * (xs == []) * (vs == []);
   // One SLL node and the rest
@@ -43,7 +43,7 @@ predicate SLL_excl(+x, xs : List, vs : List) {
 }
 
 // With length
-predicate SLL_len(+x, n : Int) {
+predicate SLL_len(x; n : Int) {
   // Empty SLL
   (x == null) * (n == 0);
   // One SLL node and the rest
@@ -55,13 +55,13 @@ predicate SLL_len(+x, n : Int) {
 //
 
 // With length
-predicate SLLseg_len(+x, y, n : Int) {
+predicate SLLseg_len(x; y, n : Int) {
   (x == y) * (n == 0);
   (x -b> #v, #z) * SLLseg_len(#z, y, n - 1) * (0 < n)
 }
 
 // With values
-predicate SLLseg_vals(+x, y, vs) {
+predicate SLLseg_vals(x; y, vs) {
   (x == y) * (vs == []);
   (x -b> #v, #next) * SLLseg_vals(#next, y, #vs) * (vs == #v :: #vs)
 }
@@ -70,7 +70,7 @@ predicate SLLseg_vals(+x, y, vs) {
 // Pure predicate for list membership
 //
 
-predicate list_member(+vs, +v, r : Bool) {
+predicate list_member(vs, v; r : Bool) {
   (vs == []) * (r == false);
   (vs == v :: #rest) * (r == true) * list_member(#rest, v, #mem);
   (vs == #v :: #rest) * (! (#v == v)) * list_member(#rest, v, r)
@@ -79,7 +79,7 @@ predicate list_member(+vs, +v, r : Bool) {
 //
 // Predicate for freed list nodes
 //
-predicate freed_nodes(xs) {
+predicate freed_nodes(xs;) {
     (xs == [ null ]);
     (xs == #x :: #xs) * freed(#x) * freed_nodes(#xs)
 }
@@ -230,7 +230,7 @@ function SLL_allocate_node(v){
 //
 
 // General pre-condition
-predicate SLL_prepend_pre(+x, def, xs, vs, n) {
+predicate SLL_prepend_pre(x; def, xs, vs, n) {
     (def == 0) * SLL_addrs_incl(x, xs) * (vs == []) * (n == 0);
     (def == 2) * SLL_vals(x, vs) * (xs == []) * (n == 0);
     (def == 3) * SLL_incl(x, xs, vs) * (n == 0);
@@ -238,7 +238,7 @@ predicate SLL_prepend_pre(+x, def, xs, vs, n) {
 }
 
 // General post-condition
-predicate SLL_prepend_post(+def, +x, +xs, +k, +vs, +n, +retval) {
+predicate SLL_prepend_post(def, x, xs, k, vs, n, retval;) {
     (def == 0) * SLL_addrs_incl(retval, retval :: xs);
     (def == 2) * SLL_vals(retval, k :: vs);
     (def == 3) * SLL_incl(retval, retval :: xs, k :: vs);
@@ -259,7 +259,7 @@ function SLL_prepend(x, k){
 //
 
 // General pre-condition
-predicate SLL_length_pre(+x, def, var : Int) {
+predicate SLL_length_pre(x; def, var : Int) {
     (def == 0) * SLL_addrs_incl(x, #xs) * (var == len #xs);
     (def == 1) * SLL_addrs_excl(x, #xs) * (var == len #xs);
     (def == 2) * SLL_vals(x, #vs) * (var == len #vs);
@@ -269,7 +269,7 @@ predicate SLL_length_pre(+x, def, var : Int) {
 }
 
 // General post-condition
-predicate SLL_length_post(+def, +x, +retval) {
+predicate SLL_length_post(def, x, retval;) {
     (def == 0) * SLL_addrs_incl(x, #xs) * (retval == len #xs);
     (def == 1) * SLL_addrs_excl(x, #xs) * (retval == len #xs);
     (def == 2) * SLL_vals(x, #vs) * (retval == len #vs);
@@ -319,7 +319,7 @@ function SLL_length_iter(x) {
 //
 
 // General pre-condition
-predicate SLL_concat_pre(+x, +y, def, xx, xy, vx, vy, nx, ny, var : Int) {
+predicate SLL_concat_pre(x, y; def, xx, xy, vx, vy, nx, ny, var : Int) {
     (def == 0) * SLL_addrs_incl(x, xx) * SLL_addrs_incl(y, xy) * (vx == []) * (vy == []) * (nx == 0) * (ny == 0) * (var == len xx);
     (def == 2) * SLL_vals(x, vx) * SLL_vals(y, vy) * (xx == []) * (xy == []) * (nx == 0) * (ny == 0) * (var == len vx);
     (def == 3) * SLL_incl(x, xx, vx) * SLL_incl(y, xy, vy) * (nx == 0) * (ny == 0) * (var == len vx);
@@ -327,7 +327,7 @@ predicate SLL_concat_pre(+x, +y, def, xx, xy, vx, vy, nx, ny, var : Int) {
 }
 
 // General post-condition
-predicate SLL_concat_post(+def, +x, +y, +xx, +xy, +vx, +vy, +nx, +ny, +retval) {
+predicate SLL_concat_post(def, x, y, xx, xy, vx, vy, nx, ny, retval;) {
     (def == 0) * SLL_addrs_incl(retval, xx @ xy);
     (def == 2) * SLL_vals(retval, vx @ vy);
     (def == 3) * SLL_incl(retval, xx @ xy, vx @ vy);
@@ -382,7 +382,7 @@ function SLL_concat_iter(x, y){
 //
 
 // General pre-condition
-predicate SLL_reverse_pre(+x, def, xs, vs, n, var) {
+predicate SLL_reverse_pre(x; def, xs, vs, n, var) {
     (def == 0) * SLL_addrs_incl(x, xs) * (vs == []) * (n == 0) * (var == len xs);
     (def == 2) * SLL_vals(x, vs) * (xs == []) * (n == 0) * (var == len vs);
     (def == 3) * SLL_incl(x, xs, vs) * (n == 0) * (var == len xs);
@@ -390,7 +390,7 @@ predicate SLL_reverse_pre(+x, def, xs, vs, n, var) {
 }
 
 // General post-condition
-predicate SLL_reverse_post(+def, +x, +xs, +vs, +n, +retval) {
+predicate SLL_reverse_post(def, x, xs, vs, n, retval;) {
     (def == 0) * SLL_addrs_incl(retval, rev xs) * (vs == []) * (n == 0);
     (def == 2) * SLL_vals(retval, rev vs) * (xs == []) * (n == 0);
     (def == 3) * SLL_incl(retval, rev xs, rev vs) * (n == 0);
@@ -417,13 +417,13 @@ function SLL_reverse(x){
 //
 
 // General pre-condition
-predicate SLL_member_pre(+x, def, vs, var : Int) {
+predicate SLL_member_pre(x; def, vs, var : Int) {
     (def == 2) * SLL_vals(x, vs) * (var == len vs);
     (def == 3) * SLL_incl(x, #xs, vs) * (var == len vs);
     (def == 4) * SLL_excl(x, #xs, vs) * (var == len vs)
 }
 
-predicate nounfold SLL_member_post(+def, +x, +vs) {
+predicate nounfold SLL_member_post(def, x, vs;) {
     (def == 2) * SLL_vals(x, vs);
     (def == 3) * SLL_incl(x, #xs, vs);
     (def == 4) * SLL_excl(x, #xs, vs)
@@ -488,7 +488,7 @@ function SLL_member_iter(x, k) {
 //
 
 // General pre-condition
-predicate SLL_free_pre(+x, def, xs, var : Int) {
+predicate SLL_free_pre(x; def, xs, var : Int) {
     (def == 0) * SLL_addrs_incl(x, xs) * (var == len xs);
     (def == 1) * SLL_addrs_excl(x, xs) * (var == len xs);
     (def == 3) * SLL_incl(x, xs, #vs) * (var == len xs);
@@ -496,7 +496,7 @@ predicate SLL_free_pre(+x, def, xs, var : Int) {
 }
 
 // General post-condition
-predicate SLL_free_post(+def, +x, +xs) {
+predicate SLL_free_post(def, x, xs;) {
     (def == 0) * freed_nodes(xs @ [ null ]);
     (def == 1) * freed_nodes(x :: xs);
     (def == 3) * freed_nodes(xs @ [ null ]);

--- a/wisl/examples/SLL_iterative.wisl
+++ b/wisl/examples/SLL_iterative.wisl
@@ -5,7 +5,7 @@ predicate list(x; vs) {
   // Empty SLL
   (x == null) * (vs == []);
   // One SLL node and the rest
-  (x -b> #v, #next) * list(#next, #vs) *
+  (x -b> #v, #next) * list(#next; #vs) *
   (vs == #v :: #vs)
 }
 
@@ -14,8 +14,8 @@ predicate list(x; vs) {
 //
 predicate list_member(vs, v; r : Bool){
   (vs == []) * (r == false);
-  (vs == v :: #rest) * (r == true) * list_member(#rest, v, #mem);
-  (vs == #v :: #rest) * (! (#v == v)) * list_member(#rest, v, r)
+  (vs == v :: #rest) * (r == true) * list_member(#rest, v; #mem);
+  (vs == #v :: #rest) * (! (#v == v)) * list_member(#rest, v; r)
 }
 
 //
@@ -24,13 +24,13 @@ predicate list_member(vs, v; r : Bool){
 lemma list_member_append {
   statement:
     forall vs, v, r, w.
-      list_member(vs, v, r) |- list_member(vs @ [ w ], v, (r || (w == v)))
+      list_member(vs, v; r) |- list_member(vs @ [ w ], v; (r || (w == v)))
 
   proof:
     if (w == v) {} else {}; // FIXME: THIS IS HORRIFIC
     unfold list_member(vs, v, r);
     if (vs != []) {
-      assert {bind: #nv, #nvs, #nr} (vs == #nv :: #nvs) * list_member(#nvs, #v, #nr);
+      assert {bind: #nv, #nvs, #nr} (vs == #nv :: #nvs) * list_member(#nvs, #v; #nr);
       apply list_member_append(#nvs, v, #nr, w)
     }
 }
@@ -41,12 +41,12 @@ lemma list_member_append {
 lemma list_member_concat {
   statement:
     forall vs1, vs2, v.
-      list_member(vs1, v, #r1) * list_member(vs2, v, #r2) |- list_member(vs1 @ vs2, v, (#r1 || #r2))
+      list_member(vs1, v; #r1) * list_member(vs2, v; #r2) |- list_member(vs1 @ vs2, v; (#r1 || #r2))
 
   proof:
     unfold list_member(vs1, v, #r1);
     if (vs1 != []) {
-      assert {bind: #nv1, #nvs1, #nr1} (vs1 == #nv1 :: #nvs1) * list_member(#nvs1, v, #nr1);
+      assert {bind: #nv1, #nvs1, #nr1} (vs1 == #nv1 :: #nvs1) * list_member(#nvs1, v; #nr1);
       apply list_member_concat(#nvs1, vs2, v)
     }
 }
@@ -58,7 +58,7 @@ function list_allocate_node(v){
   [t] := v;
   return t
 }
-{ list(ret, [ #v ]) }
+{ list(ret; [ #v ]) }
 
 //
 // ITERATIVE LIST MANIPULATION
@@ -69,7 +69,7 @@ function list_allocate_node(v){
 //
 predicate lseg(x; y, vs) {
   (x == y) * (vs == []);
-  (x -b> #v, #next) * lseg(#next, y, #vs) * (vs == #v :: #vs)
+  (x -b> #v, #next) * lseg(#next; y, #vs) * (vs == #v :: #vs)
 }
 
 //
@@ -78,13 +78,13 @@ predicate lseg(x; y, vs) {
 lemma lseg_append {
   statement:
     forall x, vs, v, z.
-      lseg(x, #y, vs) * (#y -b> v, z) |- lseg(x, z, vs @ [ v ])
+      lseg(x; #y, vs) * (#y -b> v, z) |- lseg(x; z, vs @ [ v ])
 
   proof:
     unfold lseg(x, #y, vs);
     if (x != #y) {
       assert {bind: #nv, #nnext, #nvs}
-        (x -b> #nv, #nnext) * lseg(#nnext, #y, #nvs) *
+        (x -b> #nv, #nnext) * lseg(#nnext; #y, #nvs) *
         (vs == #nv :: #nvs);
       apply lseg_append(#nnext, #nvs, v, z);
       fold lseg(x, z, vs @ [ v ])
@@ -99,7 +99,7 @@ lemma lseg_append {
 lemma lseg_concat_list {
   statement:
     forall x, y.
-      lseg(x, y, #vx) * list(y, #vy) |- list(x, #vx @ #vy)
+      lseg(x; y, #vx) * list(y; #vy) |- list(x; #vx @ #vy)
 
   proof:
     unfold lseg(x, y, #vx);
@@ -115,7 +115,7 @@ lemma lseg_concat_list {
 lemma lseg_to_list {
   statement:
     forall x.
-      lseg(x, null, #vx) |- list(x, #vx)
+      lseg(x; null, #vx) |- list(x; #vx)
 
   proof:
     unfold lseg(x, null, #vx);
@@ -126,7 +126,7 @@ lemma lseg_to_list {
 }
 
 // 02. Appending a given value to a given SLL
-{ (x == #x) * (k == #k) * list(#x, #vx) }
+{ (x == #x) * (k == #k) * list(#x; #vx) }
 function list_append(x, k){
   y := list_allocate_node(k);
   if (x == null) {
@@ -136,7 +136,7 @@ function list_append(x, k){
     prev := head;
     next := [x + 1];
     [[ invariant {bind: prev, next, #vs1, #vs2, #v}
-          lseg(head, prev, #vs1) * (prev -b> #v, next) * list(next,  #vs2) *
+          lseg(head; prev, #vs1) * (prev -b> #v, next) * list(next;  #vs2) *
            (#vx == #vs1 @ (#v :: #vs2)) ]];
     while(next != null){
       [[ assert {bind: #prev} (prev == #prev) ]];
@@ -145,17 +145,17 @@ function list_append(x, k){
       [[ apply lseg_append(head,  #vs1, #v, prev) ]]
     };
     [prev + 1] := y;
-    [[ assert {bind: #svs, #sv} lseg(head, prev, #svs) * (prev -b> #sv, y) ]];
+    [[ assert {bind: #svs, #sv} lseg(head; prev, #svs) * (prev -b> #sv, y) ]];
     [[ apply lseg_append(head, #svs, #sv, y) ]];
-    [[ assert (lseg(head, y, #vx)) ]];
+    [[ assert (lseg(head; y, #vx)) ]];
     [[ apply lseg_concat_list(head, y) ]]
   };
   return x
 }
-{ list(ret, #vx @ [ #k ]) }
+{ list(ret; #vx @ [ #k ]) }
 
 // 03. Appending a given node to a given SLL
-{ (x == #x) * (y == #y) * list(#x, #vs) * list(#y, [#vy]) }
+{ (x == #x) * (y == #y) * list(#x; #vs) * list(#y; [#vy]) }
 function list_append_node(x, y){
   if (x == null) {
     x := y
@@ -164,7 +164,7 @@ function list_append_node(x, y){
     prev := head;
     next := [x + 1];
     [[ invariant {bind: prev, next, #vs1, #vs2, #v}
-          lseg(head, prev, #vs1) * (prev -b> #v, next) * list(next,  #vs2) *
+          lseg(head; prev, #vs1) * (prev -b> #v, next) * list(next;  #vs2) *
            (#vx == #vs1 @ (#v :: #vs2)) ]];
     while(next != null){
       [[ assert {bind: #prev} (prev == #prev) ]];
@@ -173,17 +173,17 @@ function list_append_node(x, y){
       [[ apply lseg_append(head,  #vs1, #v, prev) ]]
     };
     [prev + 1] := y;
-    [[ assert {bind: #svs, #sv} lseg(head, prev, #svs) * (prev -b> #sv, y) ]];
+    [[ assert {bind: #svs, #sv} lseg(head; prev, #svs) * (prev -b> #sv, y) ]];
     [[ apply lseg_append(head, #svs, #sv, y) ]];
-    [[ assert (lseg(head, y, #vs)) ]]; // <-- add deliberate bug to #vx
+    [[ assert (lseg(head; y, #vs)) ]]; // <-- add deliberate bug to #vx
     [[ apply lseg_concat_list(head, y) ]]
   };
   return x
 }
-{ list(ret, #vs @ [#vy]) }
+{ list(ret; #vs @ [#vy]) }
 
 // 04. Concatenating two lists
-{(x == #x) * (y == #y) * list(#x, #vx) * list(#y, #vy) }
+{(x == #x) * (y == #y) * list(#x; #vx) * list(#y; #vy) }
 function list_concat(x, y){
   if (x == null) {
     head := y
@@ -192,7 +192,7 @@ function list_concat(x, y){
     prev := head;
     next := [x + 1];
     [[ invariant {bind: prev, next, #vs1, #vs2, #v}
-          lseg(head, prev, #vs1) * (prev -b> #v, next) * list(next,  #vs2) *
+          lseg(head; prev, #vs1) * (prev -b> #v, next) * list(next;  #vs2) *
            (#vx == #vs1 @ (#v :: #vs2)) ]];
     while (next != null) {
         [[ assert {bind: #prev} (prev == #prev) ]];
@@ -201,16 +201,16 @@ function list_concat(x, y){
         [[ apply lseg_append(head,  #vs1, #v, prev) ]]
     };
     [prev + 1] := y;
-    [[ assert {bind:#svs, #sv} lseg(head, prev, #svs) * (prev -b> #sv, y) ]];
+    [[ assert {bind:#svs, #sv} lseg(head; prev, #svs) * (prev -b> #sv, y) ]];
     [[ apply lseg_append(head, #svs, #sv, y) ]];
     [[ apply lseg_concat_list(head, y) ]]
   };
   return head
 }
-{ list(ret, #vx @ #vy) }
+{ list(ret; #vx @ #vy) }
 
 // 05. Copying a given SLL
-{ (x == #x) * list(#x, #alpha) }
+{ (x == #x) * list(#x; #alpha) }
 function list_copy(x){
     y := null;
     if (x == null){
@@ -224,8 +224,8 @@ function list_copy(x){
         [[ fold lseg(x, t, [v]) ]];
         [[ fold lseg(y, p, []) ]];
         [[ invariant {bind: c, v, t, p, #alpha1, #alpha2, #alpha3, #a}
-          lseg(x, t, #alpha1) * list(t, #alpha2) * (v == #a) *
-            (#alpha == (#alpha1 @ #alpha2)) * lseg(y, p, #alpha3) * (p -b> #a, null) *
+          lseg(x; t, #alpha1) * list(t; #alpha2) * (v == #a) *
+            (#alpha == (#alpha1 @ #alpha2)) * lseg(y; p, #alpha3) * (p -b> #a, null) *
                 (#alpha1 == (#alpha3 @ [#a])) ]];
         while (t != null){
             [[ assert {bind: #t, #p} (t == #t) * (p == #p) ]];
@@ -238,22 +238,22 @@ function list_copy(x){
             [[ apply lseg_append(x, #alpha1, v, t) ]];
             [[ apply lseg_append(y, #alpha3, #a, p) ]]
         };
-        [[ assert {bind: #alpha3} lseg(y, p, #alpha3) ]];
+        [[ assert {bind: #alpha3} lseg(y; p, #alpha3) ]];
         [[ apply lseg_append(y, #alpha3, v, null) ]];
         [[ apply lseg_to_list(x) ]];
         [[ apply lseg_to_list(y) ]]
     };
     return y
 }
-{ list(#x, #alpha) * list(ret, #alpha) }
+{ list(#x; #alpha) * list(ret; #alpha) }
 
 // 06. Calculating the length of a given SLL
-{ (x == #x) * list(x, #vx) }
+{ (x == #x) * list(x; #vx) }
 function list_length(x) {
   y := x;
   n := 0;
   [[ invariant {bind: n, y, #nvx,  #nvy}
-      lseg(x, y,  #nvx) * list(y, #nvy) *
+      lseg(x; y,  #nvx) * list(y; #nvy) *
          (#vx == (#nvx@#nvy)) * (n == len #nvx) ]];
   while (y != null) {
     [[ assert {bind: #y} (y == #y) ]];
@@ -266,14 +266,14 @@ function list_length(x) {
   [[ apply lseg_to_list(x) ]];
   return n
 }
-{ list(#x, #vx) * (ret == len(#vx)) }
+{ list(#x; #vx) * (ret == len(#vx)) }
 
 // 07. Reversing a given SLL
-{ (x == #x) * list(#x, #vx) }
+{ (x == #x) * list(#x; #vx) }
 function list_reverse(x) {
   y := null;
   [[ invariant {bind: x, y, z, #nvx, #nvy}
-      list(x, #nvx) * list(y, #nvy) * (#vx == ((rev #nvy) @ #nvx)) ]];
+      list(x; #nvx) * list(y; #nvy) * (#vx == ((rev #nvy) @ #nvx)) ]];
   while (x != null) {
     z := [x + 1];
     [x + 1] := y;
@@ -282,17 +282,17 @@ function list_reverse(x) {
   };
   return y
 }
-{ list(ret, rev #vx) }
+{ list(ret; rev #vx) }
 
 // 08. Checking if a given value is in a given SLL
-{ (x == #x) * (k == #k) * list(#x, #alpha) * list_member(#alpha, #k, #r) }
+{ (x == #x) * (k == #k) * list(#x; #alpha) * list_member(#alpha, #k; #r) }
 function list_member(x, k) {
   found := false;
   next := x;
   [[ invariant {bind: found, next, #beta, #gamma, #rg}
-       lseg(x, next, #beta) * list(next, #gamma) *
+       lseg(x; next, #beta) * list(next; #gamma) *
          (#alpha == (#beta @ #gamma)) * (#r == (found || #rg)) *
-           list_member(#beta, k, found) * list_member(#gamma, k, #rg) ]];
+           list_member(#beta, k; found) * list_member(#gamma, k; #rg) ]];
   while ((found == false) && (next != null)){
     [[ assert (found == false) ]];
     [[ assert {bind: #next} (next == #next) ]];
@@ -305,18 +305,18 @@ function list_member(x, k) {
     [[ apply list_member_append(#beta, k, false, #v) ]]
   };
   [[ if (found == false) { apply lseg_to_list(#x); unfold list_member([], #k, false) } else {
-      assert {bind: #beta, #gamma} lseg(#x, next, #beta) * list(next, #gamma);
+      assert {bind: #beta, #gamma} lseg(#x; next, #beta) * list(next; #gamma);
       apply list_member_concat(#beta, #gamma, #k);
       apply lseg_concat_list(#x, next)
      } ]];
   return found
 }
-{ list(#x, #alpha) * list_member(#alpha, #k, #r) * (ret == #r) }
+{ list(#x; #alpha) * list_member(#alpha, #k; #r) * (ret == #r) }
 
 // 10. Freeing a given SLL
-{ (x == #x) * list(#x, #vs) }
+{ (x == #x) * list(#x; #vs) }
 function list_free(x) {
-  [[ invariant {bind: x, #rvs} list(x, #rvs) ]];
+  [[ invariant {bind: x, #rvs} list(x; #rvs) ]];
   while (x != null) {
     y := x;
     x := [x + 1];

--- a/wisl/examples/SLL_iterative.wisl
+++ b/wisl/examples/SLL_iterative.wisl
@@ -1,7 +1,7 @@
 //
 // Standard over-approximating SLL predicate with contents
 //
-predicate list(+x, vs) {
+predicate list(x; vs) {
   // Empty SLL
   (x == null) * (vs == []);
   // One SLL node and the rest
@@ -12,7 +12,7 @@ predicate list(+x, vs) {
 //
 // Pure predicate for list membership
 //
-predicate list_member(+vs, +v, r : Bool){
+predicate list_member(vs, v; r : Bool){
   (vs == []) * (r == false);
   (vs == v :: #rest) * (r == true) * list_member(#rest, v, #mem);
   (vs == #v :: #rest) * (! (#v == v)) * list_member(#rest, v, r)
@@ -67,7 +67,7 @@ function list_allocate_node(v){
 //
 // Standard over-approximating SLL segment predicate with contents
 //
-predicate lseg(+x, y, vs) {
+predicate lseg(x; y, vs) {
   (x == y) * (vs == []);
   (x -b> #v, #next) * lseg(#next, y, #vs) * (vs == #v :: #vs)
 }

--- a/wisl/examples/SLL_recursive.wisl
+++ b/wisl/examples/SLL_recursive.wisl
@@ -1,9 +1,9 @@
 predicate list(x; alpha) {
     (x == null) * (alpha == nil);
-    (x -> #v, #z) * list(#z, #beta) * (alpha == #v::#beta)
+    (x -> #v, #z) * list(#z; #beta) * (alpha == #v::#beta)
 }
 
-{ (x == #x) * list(#x, #alpha) }
+{ (x == #x) * list(#x; #alpha) }
 function llen(x) {
     if (x == null) {
         n := 0
@@ -14,9 +14,9 @@ function llen(x) {
     };
     return n
 }
-{ list(#x, #alpha) * (ret == len(#alpha)) }
+{ list(#x; #alpha) * (ret == len(#alpha)) }
 
-{ (x == #x) * (y == #y) * list(#x, #alpha) * list(#y, #beta) }
+{ (x == #x) * (y == #y) * list(#x; #alpha) * list(#y; #beta) }
 function concat(x, y) {
     if (x == null) {
         r := y
@@ -28,10 +28,10 @@ function concat(x, y) {
     };
     return r
 }
-{ list(ret, #alpha @ #beta) }
+{ list(ret; #alpha @ #beta) }
 
 
-// { list(#x, #alpha) * (v == #v) }
+// { list(#x; #alpha) * (v == #v) }
 // function append(x, v) {
 //     if (x == null) {
 //         y := new(2);
@@ -44,9 +44,9 @@ function concat(x, y) {
 //     };
 //     return y
 // }
-// { list(ret, #alpha@[#v]) }
+// { list(ret; #alpha@[#v]) }
 
-// { list(x, #alpha) * (x == #x) }
+// { list(x; #alpha) * (x == #x) }
 // function copy(x) {
 //     if (x == null) {
 //         ch := null
@@ -60,9 +60,9 @@ function concat(x, y) {
 //     };
 //     return ch
 // }
-// { list(#x, #alpha) * list(ret, #alpha) }
+// { list(#x; #alpha) * list(ret; #alpha) }
 
-// { list(x, #alpha) }
+// { list(x; #alpha) }
 // function dispose_list(x) {
 //     if (x == null) {
 //         skip

--- a/wisl/examples/SLL_recursive.wisl
+++ b/wisl/examples/SLL_recursive.wisl
@@ -1,4 +1,4 @@
-predicate list(+x, alpha) {
+predicate list(x; alpha) {
     (x == null) * (alpha == nil);
     (x -> #v, #z) * list(#z, #beta) * (alpha == #v::#beta)
 }

--- a/wisl/examples/frac/concurrent_binary_tree.wisl
+++ b/wisl/examples/frac/concurrent_binary_tree.wisl
@@ -16,21 +16,21 @@ predicate list_member(vs, v; r : Bool){
   (vs == #v :: #rest) * (! (#v == v)) * list_member(#rest, v; r)
 }
 
-predicate replaced(vs, ws, v, w;) {
+predicate replaced(vs, ws, v, w) {
     (vs == []) * (ws == []);
-    (vs == v :: #restvs) * (ws == w :: #restws) * replaced(#restvs, #restws, v, w;);
-    (vs == #v :: #restvs) * (ws == #v :: #restws) * (! (#v == v)) * replaced(#restvs, #restws, v, w;)
+    (vs == v :: #restvs) * (ws == w :: #restws) * replaced(#restvs, #restws, v, w);
+    (vs == #v :: #restvs) * (ws == #v :: #restws) * (! (#v == v)) * replaced(#restvs, #restws, v, w)
 }
 
 lemma replaced_concat {
     statement:
       forall vs1, ws1, vs2, ws2, v, w.
-        replaced(vs1, ws1, v, w;) * replaced(vs2, ws2, v, w;) |- replaced(vs1 @ vs2, ws1 @ ws2, v, w;)
+        replaced(vs1, ws1, v, w) * replaced(vs2, ws2, v, w) |- replaced(vs1 @ vs2, ws1 @ ws2, v, w)
 
     proof:
       unfold replaced(vs1, ws1, v, w);
       if (!(vs1 == [])) {
-        assert {bind: #nv, #nw, #nvs1, #nws1} (vs1 == #nv :: #nvs1) * (ws1 == #nw :: #nws1) * replaced(#nvs1, #nws1, v, w;);
+        assert {bind: #nv, #nw, #nvs1, #nws1} (vs1 == #nv :: #nvs1) * (ws1 == #nw :: #nws1) * replaced(#nvs1, #nws1, v, w);
         apply replaced_concat(#nvs1, #nws1, vs2, ws2, v, w)
       }
 }
@@ -52,7 +52,7 @@ lemma list_member_concat {
     }
 }
 
-predicate is_int(a: Int;) {
+predicate is_int(a: Int) {
     emp
 }
 
@@ -61,7 +61,7 @@ predicate max(a:Int, b:Int; c:Int) {
     (a <  b) * (c == b)
 }
 
-{ (a == #a) * is_int(#a;) * (b == #b) * is_int(#b;) }
+{ (a == #a) * is_int(#a) * (b == #b) * is_int(#b) }
 function max(a, b) {
     if (a >= b) {
         r := a
@@ -140,4 +140,4 @@ function replace(t, v, w) {
     };
     return 0
 }
-{ binary_tree(#t, 1.0; #r_tree) * replaced(#tree, #r_tree, #v, #w;) }
+{ binary_tree(#t, 1.0; #r_tree) * replaced(#tree, #r_tree, #v, #w) }

--- a/wisl/examples/frac/concurrent_binary_tree.wisl
+++ b/wisl/examples/frac/concurrent_binary_tree.wisl
@@ -1,22 +1,22 @@
 // tree holds the list representation of a pre-order traveresal of a binary tree with root at x.
-predicate binary_tree(+x, +p: Float, tree) {
+predicate binary_tree(x, p: Float; tree) {
     (x == null) * (tree == nil);
     (x -> (p: #a), (p: #l), (p: #r)) * binary_tree(#l, p, #left) * binary_tree(#r, p, #right) * (tree == #a::(#left @ #right))
 }
 
-predicate tree_height(+x, +p: Float, h: Int) {
+predicate tree_height(x, p: Float; h: Int) {
     (x == null) * (h == 0);
     (x -> (p: #a), (p: #l), (p: #r)) * tree_height(#l, p, #hl) * tree_height(#r, p, #hr) * (#hl >= #hr) * (h == #hl + 1);
     (x -> (p: #a), (p: #l), (p: #r)) * tree_height(#l, p, #hl) * tree_height(#r, p, #hr) * (#hl < #hr) * (h == #hr + 1)
 }
 
-predicate list_member(+vs, +v, r : Bool){
+predicate list_member(vs, v; r : Bool){
   (vs == []) * (r == false);
   (vs == v :: #rest) * (r == true);
   (vs == #v :: #rest) * (! (#v == v)) * list_member(#rest, v, r)
 }
 
-predicate replaced(+vs, +ws, +v, +w) {
+predicate replaced(vs, ws, v, w;) {
     (vs == []) * (ws == []);
     (vs == v :: #restvs) * (ws == w :: #restws) * replaced(#restvs, #restws, v, w);
     (vs == #v :: #restvs) * (ws == #v :: #restws) * (! (#v == v)) * replaced(#restvs, #restws, v, w)
@@ -52,11 +52,11 @@ lemma list_member_concat {
     }
 }
 
-predicate is_int(+a: Int) {
+predicate is_int(a: Int;) {
     emp
 }
 
-predicate max(+a:Int, +b:Int, c:Int) {
+predicate max(a:Int, b:Int; c:Int) {
     (a >= b) * (c == a);
     (a <  b) * (c == b)
 }

--- a/wisl/examples/frac/concurrent_binary_tree.wisl
+++ b/wisl/examples/frac/concurrent_binary_tree.wisl
@@ -1,36 +1,36 @@
 // tree holds the list representation of a pre-order traveresal of a binary tree with root at x.
 predicate binary_tree(x, p: Float; tree) {
     (x == null) * (tree == nil);
-    (x -> (p: #a), (p: #l), (p: #r)) * binary_tree(#l, p, #left) * binary_tree(#r, p, #right) * (tree == #a::(#left @ #right))
+    (x -> (p: #a), (p: #l), (p: #r)) * binary_tree(#l, p; #left) * binary_tree(#r, p; #right) * (tree == #a::(#left @ #right))
 }
 
 predicate tree_height(x, p: Float; h: Int) {
     (x == null) * (h == 0);
-    (x -> (p: #a), (p: #l), (p: #r)) * tree_height(#l, p, #hl) * tree_height(#r, p, #hr) * (#hl >= #hr) * (h == #hl + 1);
-    (x -> (p: #a), (p: #l), (p: #r)) * tree_height(#l, p, #hl) * tree_height(#r, p, #hr) * (#hl < #hr) * (h == #hr + 1)
+    (x -> (p: #a), (p: #l), (p: #r)) * tree_height(#l, p; #hl) * tree_height(#r, p; #hr) * (#hl >= #hr) * (h == #hl + 1);
+    (x -> (p: #a), (p: #l), (p: #r)) * tree_height(#l, p; #hl) * tree_height(#r, p; #hr) * (#hl < #hr) * (h == #hr + 1)
 }
 
 predicate list_member(vs, v; r : Bool){
   (vs == []) * (r == false);
   (vs == v :: #rest) * (r == true);
-  (vs == #v :: #rest) * (! (#v == v)) * list_member(#rest, v, r)
+  (vs == #v :: #rest) * (! (#v == v)) * list_member(#rest, v; r)
 }
 
 predicate replaced(vs, ws, v, w;) {
     (vs == []) * (ws == []);
-    (vs == v :: #restvs) * (ws == w :: #restws) * replaced(#restvs, #restws, v, w);
-    (vs == #v :: #restvs) * (ws == #v :: #restws) * (! (#v == v)) * replaced(#restvs, #restws, v, w)
+    (vs == v :: #restvs) * (ws == w :: #restws) * replaced(#restvs, #restws, v, w;);
+    (vs == #v :: #restvs) * (ws == #v :: #restws) * (! (#v == v)) * replaced(#restvs, #restws, v, w;)
 }
 
 lemma replaced_concat {
     statement:
       forall vs1, ws1, vs2, ws2, v, w.
-        replaced(vs1, ws1, v, w) * replaced(vs2, ws2, v, w) |- replaced(vs1 @ vs2, ws1 @ ws2, v, w)
+        replaced(vs1, ws1, v, w;) * replaced(vs2, ws2, v, w;) |- replaced(vs1 @ vs2, ws1 @ ws2, v, w;)
 
     proof:
       unfold replaced(vs1, ws1, v, w);
       if (!(vs1 == [])) {
-        assert {bind: #nv, #nw, #nvs1, #nws1} (vs1 == #nv :: #nvs1) * (ws1 == #nw :: #nws1) * replaced(#nvs1, #nws1, v, w);
+        assert {bind: #nv, #nw, #nvs1, #nws1} (vs1 == #nv :: #nvs1) * (ws1 == #nw :: #nws1) * replaced(#nvs1, #nws1, v, w;);
         apply replaced_concat(#nvs1, #nws1, vs2, ws2, v, w)
       }
 }
@@ -38,7 +38,7 @@ lemma replaced_concat {
 lemma list_member_concat {
   statement:
     forall vs1, vs2, v.
-      list_member(vs1, v, #r1) * list_member(vs2, v, #r2) |- list_member(vs1 @ vs2, v, (#r1 || #r2))
+      list_member(vs1, v; #r1) * list_member(vs2, v; #r2) |- list_member(vs1 @ vs2, v; (#r1 || #r2))
 
   proof:
     unfold list_member(vs1, v, #r1);
@@ -46,7 +46,7 @@ lemma list_member_concat {
       if (hd vs1 == v) {
         fold list_member(vs1 @ vs2, v, true)
       } else {
-        assert {bind: #nv1, #nvs1, #nr1} (vs1 == #nv1 :: #nvs1) * list_member(#nvs1, v, #nr1);
+        assert {bind: #nv1, #nvs1, #nr1} (vs1 == #nv1 :: #nvs1) * list_member(#nvs1, v; #nr1);
         apply list_member_concat(#nvs1, vs2, v)
       }
     }
@@ -61,7 +61,7 @@ predicate max(a:Int, b:Int; c:Int) {
     (a <  b) * (c == b)
 }
 
-{ (a == #a) * is_int(#a) * (b == #b) * is_int(#b) }
+{ (a == #a) * is_int(#a;) * (b == #b) * is_int(#b;) }
 function max(a, b) {
     if (a >= b) {
         r := a
@@ -70,10 +70,10 @@ function max(a, b) {
     };
     return r
 }
-{ max(#a, #b, ret) }
+{ max(#a, #b; ret) }
 
 [ spec height_spec: #p ]
-{ (t == #t) *  binary_tree(#t, #p, #tree) }
+{ (t == #t) *  binary_tree(#t, #p; #tree) }
 function height(t) {
     if (t == null) {
         r := 0
@@ -89,10 +89,10 @@ function height(t) {
     };
     return r
 }
-{ tree_height(#t, #p, ret) }
+{ tree_height(#t, #p; ret) }
 
 [ spec find_spec: #p ]
-{ (t == #t) * (v == #v) * binary_tree(#t, #p, #tree) }
+{ (t == #t) * (v == #v) * binary_tree(#t, #p; #tree) }
 function find(t, v) {
     if (t == null) {
         r := false
@@ -108,16 +108,16 @@ function find(t, v) {
                 is_in_right := find(rt, v) [ find_spec: (#p: #p) ]
             };
             r := is_in_left || is_in_right;
-            [[assert {bind: #left, #right} binary_tree(lt, #p, #left) * binary_tree(rt, #p, #right)]];
+            [[assert {bind: #left, #right} binary_tree(lt, #p; #left) * binary_tree(rt, #p; #right)]];
             [[apply list_member_concat(#left, #right, #v)]];
             [[fold list_member(x :: (#left @ #right), #v, r)]]
         }
     };
     return r
 }
-{ binary_tree(#t, #p, #tree) * list_member(#tree, #v, ret) }
+{ binary_tree(#t, #p; #tree) * list_member(#tree, #v; ret) }
 
-{ (t == #t) * (v == #v) * (w == #w) * binary_tree(#t, 1.0, #tree) }
+{ (t == #t) * (v == #v) * (w == #w) * binary_tree(#t, 1.0; #tree) }
 function replace(t, v, w) {
     if (t == null) {
         skip
@@ -130,14 +130,14 @@ function replace(t, v, w) {
         };
         lt := [t + 1];
         rt := [t + 2];
-        [[assert {bind: #left_tree, #right_tree} binary_tree(lt, 1.0, #left_tree) * binary_tree(rt, 1.0, #right_tree)]];
+        [[assert {bind: #left_tree, #right_tree} binary_tree(lt, 1.0; #left_tree) * binary_tree(rt, 1.0; #right_tree)]];
         par {
             u := replace(lt, v, w);
             u := replace(rt, v, w)
         };
-        [[assert {bind: #left_r_tree, #right_r_tree} binary_tree(lt, 1.0, #left_r_tree) * binary_tree(rt, 1.0, #right_r_tree)]];
+        [[assert {bind: #left_r_tree, #right_r_tree} binary_tree(lt, 1.0; #left_r_tree) * binary_tree(rt, 1.0; #right_r_tree)]];
         [[apply replaced_concat(#left_tree, #left_r_tree, #right_tree, #right_r_tree, #v, #w)]]
     };
     return 0
 }
-{ binary_tree(#t, 1.0, #r_tree) * replaced(#tree, #r_tree, #v, #w) }
+{ binary_tree(#t, 1.0; #r_tree) * replaced(#tree, #r_tree, #v, #w;) }

--- a/wisl/examples/frac/concurrent_binary_tree.wisl
+++ b/wisl/examples/frac/concurrent_binary_tree.wisl
@@ -1,13 +1,13 @@
 // tree holds the list representation of a pre-order traveresal of a binary tree with root at x.
-predicate binary_tree(+x, tree, +p: Float) {
+predicate binary_tree(+x, +p: Float, tree) {
     (x == null) * (tree == nil);
-    (x -> (p: #a), (p: #l), (p: #r)) * binary_tree(#l, #left, p) * binary_tree(#r, #right, p) * (tree == #a::(#left @ #right))
+    (x -> (p: #a), (p: #l), (p: #r)) * binary_tree(#l, p, #left) * binary_tree(#r, p, #right) * (tree == #a::(#left @ #right))
 }
 
-predicate tree_height(+x, h: Int, +p: Float) {
+predicate tree_height(+x, +p: Float, h: Int) {
     (x == null) * (h == 0);
-    (x -> (p: #a), (p: #l), (p: #r)) * tree_height(#l, #hl, p) * tree_height(#r, #hr, p) * (#hl >= #hr) * (h == #hl + 1);
-    (x -> (p: #a), (p: #l), (p: #r)) * tree_height(#l, #hl, p) * tree_height(#r, #hr, p) * (#hl < #hr) * (h == #hr + 1)
+    (x -> (p: #a), (p: #l), (p: #r)) * tree_height(#l, p, #hl) * tree_height(#r, p, #hr) * (#hl >= #hr) * (h == #hl + 1);
+    (x -> (p: #a), (p: #l), (p: #r)) * tree_height(#l, p, #hl) * tree_height(#r, p, #hr) * (#hl < #hr) * (h == #hr + 1)
 }
 
 predicate list_member(+vs, +v, r : Bool){
@@ -73,7 +73,7 @@ function max(a, b) {
 { max(#a, #b, ret) }
 
 [ spec height_spec: #p ]
-{ (t == #t) *  binary_tree(#t, #tree, #p) }
+{ (t == #t) *  binary_tree(#t, #p, #tree) }
 function height(t) {
     if (t == null) {
         r := 0
@@ -89,10 +89,10 @@ function height(t) {
     };
     return r
 }
-{ tree_height(#t, ret, #p) }
+{ tree_height(#t, #p, ret) }
 
 [ spec find_spec: #p ]
-{ (t == #t) * (v == #v) * binary_tree(#t, #tree, #p) }
+{ (t == #t) * (v == #v) * binary_tree(#t, #p, #tree) }
 function find(t, v) {
     if (t == null) {
         r := false
@@ -108,16 +108,16 @@ function find(t, v) {
                 is_in_right := find(rt, v) [ find_spec: (#p: #p) ]
             };
             r := is_in_left || is_in_right;
-            [[assert {bind: #left, #right} binary_tree(lt, #left, #p) * binary_tree(rt, #right, #p)]];
+            [[assert {bind: #left, #right} binary_tree(lt, #p, #left) * binary_tree(rt, #p, #right)]];
             [[apply list_member_concat(#left, #right, #v)]];
             [[fold list_member(x :: (#left @ #right), #v, r)]]
         }
     };
     return r
 }
-{ binary_tree(#t, #tree, #p) * list_member(#tree, #v, ret) }
+{ binary_tree(#t, #p, #tree) * list_member(#tree, #v, ret) }
 
-{ (t == #t) * (v == #v) * (w == #w) * binary_tree(#t, #tree, 1.0) }
+{ (t == #t) * (v == #v) * (w == #w) * binary_tree(#t, 1.0, #tree) }
 function replace(t, v, w) {
     if (t == null) {
         skip
@@ -130,14 +130,14 @@ function replace(t, v, w) {
         };
         lt := [t + 1];
         rt := [t + 2];
-        [[assert {bind: #left_tree, #right_tree} binary_tree(lt, #left_tree, 1.0) * binary_tree(rt, #right_tree, 1.0)]];
+        [[assert {bind: #left_tree, #right_tree} binary_tree(lt, 1.0, #left_tree) * binary_tree(rt, 1.0, #right_tree)]];
         par {
             u := replace(lt, v, w);
             u := replace(rt, v, w)
         };
-        [[assert {bind: #left_r_tree, #right_r_tree} binary_tree(lt, #left_r_tree, 1.0) * binary_tree(rt, #right_r_tree, 1.0)]];
+        [[assert {bind: #left_r_tree, #right_r_tree} binary_tree(lt, 1.0, #left_r_tree) * binary_tree(rt, 1.0, #right_r_tree)]];
         [[apply replaced_concat(#left_tree, #left_r_tree, #right_tree, #right_r_tree, #v, #w)]]
     };
     return 0
 }
-{ binary_tree(#t, #r_tree, 1.0) * replaced(#tree, #r_tree, #v, #w) }
+{ binary_tree(#t, 1.0, #r_tree) * replaced(#tree, #r_tree, #v, #w) }

--- a/wisl/examples/frac/floating_point.wisl
+++ b/wisl/examples/frac/floating_point.wisl
@@ -21,7 +21,7 @@ function floating_subtraction(x, y) {
     [r] := z;
     return r
 }
-{ points_to_sub(ret, #x, #y) }
+{ points_to_sub(ret, #x, #y;) }
 
 { (x == #x) * (y == #y) }
 function floating_multiplication(x, y) {

--- a/wisl/examples/frac/floating_point.wisl
+++ b/wisl/examples/frac/floating_point.wisl
@@ -1,4 +1,4 @@
-predicate points_to_sub(+x, +a: Float, +b: Float) {
+predicate points_to_sub(x, a: Float, b: Float;) {
     (a f>= b) * (#v == a f- b) * (x -> #v);
     (a f< b) * (#v == b f- a) * (x -> #v)
 }

--- a/wisl/examples/frac/floating_point.wisl
+++ b/wisl/examples/frac/floating_point.wisl
@@ -1,4 +1,4 @@
-predicate points_to_sub(x, a: Float, b: Float;) {
+predicate points_to_sub(x, a: Float, b: Float) {
     (a f>= b) * (#v == a f- b) * (x -> #v);
     (a f< b) * (#v == b f- a) * (x -> #v)
 }
@@ -21,7 +21,7 @@ function floating_subtraction(x, y) {
     [r] := z;
     return r
 }
-{ points_to_sub(ret, #x, #y;) }
+{ points_to_sub(ret, #x, #y) }
 
 { (x == #x) * (y == #y) }
 function floating_multiplication(x, y) {

--- a/wisl/examples/frac/lambda_terms.wisl
+++ b/wisl/examples/frac/lambda_terms.wisl
@@ -1,16 +1,16 @@
-predicate lambda_term(+x, +p: Float, v, t1, t2, type: Int) {
+predicate lambda_term(x, p: Float; v, t1, t2, type: Int) {
     (x -> (p: 0), (p: v), (p: t1)) * (type == 0) * (t2 == null) * lambda_term(t1, p, #v1, #t11, #t12, #type1);
     (x -> (p: 1), (p: t1), (p: t2)) * (type == 1) * (v == 0) * lambda_term(t1, p, #v1, #t11, #t12, #type1) * lambda_term(t2, p, #v2, #t21, #t22, #type2);
     (x -> (p: 2), (p: v)) * (type == 2) * (t1 == null) * (t2 == null)
 }
 
-predicate is_copy(+x, +y, +p1: Float, +p2: Float, v, t1, t2, type: Int) {
+predicate is_copy(x, y, p1: Float, p2: Float; v, t1, t2, type: Int) {
     (x -> (p1: 0), (p1: v), (p1: t1)) * (y -> (p2: 0), (p2: v), (p2: #t2)) * (type == 0) * (t2 == null) * is_copy(t1, #t2, p1, p2, #v, #t11, #t12, #type);
     (x -> (p1: 1), (p1: t1), (p1: t2)) * (y -> (p2: 1), (p2: #t21), (p2: #t22)) * (type == 1) * (v == 0) * is_copy(t1, #t21, p1, p2, #v1, #t11, #t12, #type1) * is_copy(t2, #t22, p1, p2, #v2, #t_21, #t_22, #type2);
     (x -> (p1: 2), (p1: v)) * (y -> (p2: 2), (p2: v)) * (type == 2) * (t1 == null) * (t2 == null)
 }
 
-predicate substituted(+t_in, +t, +v, +p1: Float, +p2: Float, +pt: Float, +t_out) {
+predicate substituted(t_in, t, v, p1: Float, p2: Float, pt: Float, t_out;) {
     (t_in -> (p1: 0), (p1: v), (p1: #t)) * (t_out -> (p2: 0), (p2: v), (p2: #t2)) * is_copy(#t, #t2, p1, p2, #tv, #tt1, #tt2, #type1) * lambda_term(t, pt, #w, #t11, #t12, #type2);
     (t_in -> (p1: 0), (p1: #v), (p1: #t)) * (! (#v == v)) * (t_out -> (p2: 0), (p2: #v), (p2: #t_out)) * substituted(#t, t, v, p1, p2, pt, #t_out);
     (t_in -> (p1: 1), (p1: #t1), (p1: #t2)) * (t_out -> (p2: 1), (p2: #t1_out), (p2: #t2_out)) * substituted(#t1, t, v, p1, p2, pt f/ 2.0, #t1_out) * substituted(#t2, t, v, p1, p2, pt f/ 2.0, #t2_out);

--- a/wisl/examples/frac/lambda_terms.wisl
+++ b/wisl/examples/frac/lambda_terms.wisl
@@ -1,6 +1,6 @@
-predicate lambda_term(+x, v, t1, t2, type: Int, +p: Float) {
-    (x -> (p: 0), (p: v), (p: t1)) * (type == 0) * (t2 == null) * lambda_term(t1, #v1, #t11, #t12, #type1, p);
-    (x -> (p: 1), (p: t1), (p: t2)) * (type == 1) * (v == 0) * lambda_term(t1, #v1, #t11, #t12, #type1, p) * lambda_term(t2, #v2, #t21, #t22, #type2, p);
+predicate lambda_term(+x, +p: Float, v, t1, t2, type: Int) {
+    (x -> (p: 0), (p: v), (p: t1)) * (type == 0) * (t2 == null) * lambda_term(t1, p, #v1, #t11, #t12, #type1);
+    (x -> (p: 1), (p: t1), (p: t2)) * (type == 1) * (v == 0) * lambda_term(t1, p, #v1, #t11, #t12, #type1) * lambda_term(t2, p, #v2, #t21, #t22, #type2);
     (x -> (p: 2), (p: v)) * (type == 2) * (t1 == null) * (t2 == null)
 }
 
@@ -11,36 +11,36 @@ predicate is_copy(+x, +y, +p1: Float, +p2: Float, v, t1, t2, type: Int) {
 }
 
 predicate substituted(+t_in, +t, +v, +p1: Float, +p2: Float, +pt: Float, +t_out) {
-    (t_in -> (p1: 0), (p1: v), (p1: #t)) * (t_out -> (p2: 0), (p2: v), (p2: #t2)) * is_copy(#t, #t2, p1, p2, #tv, #tt1, #tt2, #type1) * lambda_term(t, #w, #t11, #t12, #type2, pt);
+    (t_in -> (p1: 0), (p1: v), (p1: #t)) * (t_out -> (p2: 0), (p2: v), (p2: #t2)) * is_copy(#t, #t2, p1, p2, #tv, #tt1, #tt2, #type1) * lambda_term(t, pt, #w, #t11, #t12, #type2);
     (t_in -> (p1: 0), (p1: #v), (p1: #t)) * (! (#v == v)) * (t_out -> (p2: 0), (p2: #v), (p2: #t_out)) * substituted(#t, t, v, p1, p2, pt, #t_out);
     (t_in -> (p1: 1), (p1: #t1), (p1: #t2)) * (t_out -> (p2: 1), (p2: #t1_out), (p2: #t2_out)) * substituted(#t1, t, v, p1, p2, pt f/ 2.0, #t1_out) * substituted(#t2, t, v, p1, p2, pt f/ 2.0, #t2_out);
     (t_in -> (p1: 2), (p1: v)) * is_copy(t, t_out, pt, p2, #v, #t1, #t2, #type);
-    (t_in -> (p1: 2), (p1: #v)) * (! (v == #v)) * (t_out -> (p2: 2), (p2: #v)) * lambda_term(t, #w, #t1, #t2, #type, pt)
+    (t_in -> (p1: 2), (p1: #v)) * (! (v == #v)) * (t_out -> (p2: 2), (p2: #v)) * lambda_term(t, pt, #w, #t1, #t2, #type)
 }
 
 lemma split_lambda_term_permission {
     statement:
         forall x, v, t1, t2, type, p, p1, p2.
-            (p == p1 f+ p2) * (p1 f> 0.0) * (p2 f> 0.0) * lambda_term(x, v, t1, t2, type, p) |- lambda_term(x, v, t1, t2, type, p1) * lambda_term(x, v, t1, t2, type, p2)
+            (p == p1 f+ p2) * (p1 f> 0.0) * (p2 f> 0.0) * lambda_term(x, p, v, t1, t2, type) |- lambda_term(x, p1, v, t1, t2, type) * lambda_term(x, p2, v, t1, t2, type)
 
     proof:
-        unfold lambda_term(x, v, t1, t2, type, p);
+        unfold lambda_term(x, p, v, t1, t2, type);
         if (!(type == 2)) {
             if (type == 1) {
-                assert {bind: #v1, #t11, #t12, #type1, #v2, #t21, #t22, #type2} lambda_term(t1, #v1, #t11, #t12, #type1, p) * lambda_term(t2, #v2, #t21, #t22, #type2, p);
+                assert {bind: #v1, #t11, #t12, #type1, #v2, #t21, #t22, #type2} lambda_term(t1, p, #v1, #t11, #t12, #type1) * lambda_term(t2, p, #v2, #t21, #t22, #type2);
                 apply split_lambda_term_permission(t1, #v1, #t11, #t12, #type1, p, p1, p2);
                 apply split_lambda_term_permission(t2, #v2, #t21, #t22, #type2, p, p1, p2)
             } else {
-                assert {bind: #v1, #t11, #t12, #type1} lambda_term(t1, #v1, #t11, #t12, #type1, p);
+                assert {bind: #v1, #t11, #t12, #type1} lambda_term(t1, p, #v1, #t11, #t12, #type1);
                 apply split_lambda_term_permission(t1, #v1, #t11, #t12, #type1, p, p1, p2)
             };
-            fold lambda_term(x, v, t1, t2, type, p1);
-            fold lambda_term(x, v, t1, t2, type, p2)
+            fold lambda_term(x, p1, v, t1, t2, type);
+            fold lambda_term(x, p2, v, t1, t2, type)
         }
 }
 
 [spec copy_spec: #p]
-{ (x == #x) * lambda_term(#x, #v, #t1, #t2, #type, #p) }
+{ (x == #x) * lambda_term(#x, #p, #v, #t1, #t2, #type) }
 function copy(x) {
     type := [x];
     if (type == 2) {
@@ -72,7 +72,7 @@ function copy(x) {
 { is_copy(#x, ret, #p, 1.0, #v, #t1, #t2, #type) }
 
 [spec subst_spec: #px, #py]
-{ (x == #x) * (y == #y) * (v == #v) * lambda_term(#x, #vx, #tx1, #tx2, #type_x, #px) * lambda_term(#y, #vy, #ty1, #ty2, #type_y, #py) }
+{ (x == #x) * (y == #y) * (v == #v) * lambda_term(#x, #px, #vx, #tx1, #tx2, #type_x) * lambda_term(#y, #py, #vy, #ty1, #ty2, #type_y) }
 function subst(x, y, v) {
     type := [x];
     if (type == 2) {

--- a/wisl/examples/frac/lambda_terms.wisl
+++ b/wisl/examples/frac/lambda_terms.wisl
@@ -10,10 +10,10 @@ predicate is_copy(x, y, p1: Float, p2: Float; v, t1, t2, type: Int) {
     (x -> (p1: 2), (p1: v)) * (y -> (p2: 2), (p2: v)) * (type == 2) * (t1 == null) * (t2 == null)
 }
 
-predicate substituted(t_in, t, v, p1: Float, p2: Float, pt: Float, t_out;) {
+predicate substituted(t_in, t, v, p1: Float, p2: Float, pt: Float, t_out) {
     (t_in -> (p1: 0), (p1: v), (p1: #t)) * (t_out -> (p2: 0), (p2: v), (p2: #t2)) * is_copy(#t, #t2, p1, p2; #tv, #tt1, #tt2, #type1) * lambda_term(t, pt; #w, #t11, #t12, #type2);
-    (t_in -> (p1: 0), (p1: #v), (p1: #t)) * (! (#v == v)) * (t_out -> (p2: 0), (p2: #v), (p2: #t_out)) * substituted(#t, t, v, p1, p2, pt, #t_out;);
-    (t_in -> (p1: 1), (p1: #t1), (p1: #t2)) * (t_out -> (p2: 1), (p2: #t1_out), (p2: #t2_out)) * substituted(#t1, t, v, p1, p2, pt f/ 2.0, #t1_out;) * substituted(#t2, t, v, p1, p2, pt f/ 2.0, #t2_out;);
+    (t_in -> (p1: 0), (p1: #v), (p1: #t)) * (! (#v == v)) * (t_out -> (p2: 0), (p2: #v), (p2: #t_out)) * substituted(#t, t, v, p1, p2, pt, #t_out);
+    (t_in -> (p1: 1), (p1: #t1), (p1: #t2)) * (t_out -> (p2: 1), (p2: #t1_out), (p2: #t2_out)) * substituted(#t1, t, v, p1, p2, pt f/ 2.0, #t1_out) * substituted(#t2, t, v, p1, p2, pt f/ 2.0, #t2_out);
     (t_in -> (p1: 2), (p1: v)) * is_copy(t, t_out, pt, p2; #v, #t1, #t2, #type);
     (t_in -> (p1: 2), (p1: #v)) * (! (v == #v)) * (t_out -> (p2: 2), (p2: #v)) * lambda_term(t, pt; #w, #t1, #t2, #type)
 }
@@ -111,4 +111,4 @@ function subst(x, y, v) {
     };
     return r
 }
-{ substituted(#x, #y, #v, #px, 1.0, #py, ret;) }
+{ substituted(#x, #y, #v, #px, 1.0, #py, ret) }

--- a/wisl/examples/frac/lambda_terms.wisl
+++ b/wisl/examples/frac/lambda_terms.wisl
@@ -1,37 +1,37 @@
 predicate lambda_term(x, p: Float; v, t1, t2, type: Int) {
-    (x -> (p: 0), (p: v), (p: t1)) * (type == 0) * (t2 == null) * lambda_term(t1, p, #v1, #t11, #t12, #type1);
-    (x -> (p: 1), (p: t1), (p: t2)) * (type == 1) * (v == 0) * lambda_term(t1, p, #v1, #t11, #t12, #type1) * lambda_term(t2, p, #v2, #t21, #t22, #type2);
+    (x -> (p: 0), (p: v), (p: t1)) * (type == 0) * (t2 == null) * lambda_term(t1, p; #v1, #t11, #t12, #type1);
+    (x -> (p: 1), (p: t1), (p: t2)) * (type == 1) * (v == 0) * lambda_term(t1, p; #v1, #t11, #t12, #type1) * lambda_term(t2, p; #v2, #t21, #t22, #type2);
     (x -> (p: 2), (p: v)) * (type == 2) * (t1 == null) * (t2 == null)
 }
 
 predicate is_copy(x, y, p1: Float, p2: Float; v, t1, t2, type: Int) {
-    (x -> (p1: 0), (p1: v), (p1: t1)) * (y -> (p2: 0), (p2: v), (p2: #t2)) * (type == 0) * (t2 == null) * is_copy(t1, #t2, p1, p2, #v, #t11, #t12, #type);
-    (x -> (p1: 1), (p1: t1), (p1: t2)) * (y -> (p2: 1), (p2: #t21), (p2: #t22)) * (type == 1) * (v == 0) * is_copy(t1, #t21, p1, p2, #v1, #t11, #t12, #type1) * is_copy(t2, #t22, p1, p2, #v2, #t_21, #t_22, #type2);
+    (x -> (p1: 0), (p1: v), (p1: t1)) * (y -> (p2: 0), (p2: v), (p2: #t2)) * (type == 0) * (t2 == null) * is_copy(t1, #t2, p1, p2; #v, #t11, #t12, #type);
+    (x -> (p1: 1), (p1: t1), (p1: t2)) * (y -> (p2: 1), (p2: #t21), (p2: #t22)) * (type == 1) * (v == 0) * is_copy(t1, #t21, p1, p2; #v1, #t11, #t12, #type1) * is_copy(t2, #t22, p1, p2; #v2, #t_21, #t_22, #type2);
     (x -> (p1: 2), (p1: v)) * (y -> (p2: 2), (p2: v)) * (type == 2) * (t1 == null) * (t2 == null)
 }
 
 predicate substituted(t_in, t, v, p1: Float, p2: Float, pt: Float, t_out;) {
-    (t_in -> (p1: 0), (p1: v), (p1: #t)) * (t_out -> (p2: 0), (p2: v), (p2: #t2)) * is_copy(#t, #t2, p1, p2, #tv, #tt1, #tt2, #type1) * lambda_term(t, pt, #w, #t11, #t12, #type2);
-    (t_in -> (p1: 0), (p1: #v), (p1: #t)) * (! (#v == v)) * (t_out -> (p2: 0), (p2: #v), (p2: #t_out)) * substituted(#t, t, v, p1, p2, pt, #t_out);
-    (t_in -> (p1: 1), (p1: #t1), (p1: #t2)) * (t_out -> (p2: 1), (p2: #t1_out), (p2: #t2_out)) * substituted(#t1, t, v, p1, p2, pt f/ 2.0, #t1_out) * substituted(#t2, t, v, p1, p2, pt f/ 2.0, #t2_out);
-    (t_in -> (p1: 2), (p1: v)) * is_copy(t, t_out, pt, p2, #v, #t1, #t2, #type);
-    (t_in -> (p1: 2), (p1: #v)) * (! (v == #v)) * (t_out -> (p2: 2), (p2: #v)) * lambda_term(t, pt, #w, #t1, #t2, #type)
+    (t_in -> (p1: 0), (p1: v), (p1: #t)) * (t_out -> (p2: 0), (p2: v), (p2: #t2)) * is_copy(#t, #t2, p1, p2; #tv, #tt1, #tt2, #type1) * lambda_term(t, pt; #w, #t11, #t12, #type2);
+    (t_in -> (p1: 0), (p1: #v), (p1: #t)) * (! (#v == v)) * (t_out -> (p2: 0), (p2: #v), (p2: #t_out)) * substituted(#t, t, v, p1, p2, pt, #t_out;);
+    (t_in -> (p1: 1), (p1: #t1), (p1: #t2)) * (t_out -> (p2: 1), (p2: #t1_out), (p2: #t2_out)) * substituted(#t1, t, v, p1, p2, pt f/ 2.0, #t1_out;) * substituted(#t2, t, v, p1, p2, pt f/ 2.0, #t2_out;);
+    (t_in -> (p1: 2), (p1: v)) * is_copy(t, t_out, pt, p2; #v, #t1, #t2, #type);
+    (t_in -> (p1: 2), (p1: #v)) * (! (v == #v)) * (t_out -> (p2: 2), (p2: #v)) * lambda_term(t, pt; #w, #t1, #t2, #type)
 }
 
 lemma split_lambda_term_permission {
     statement:
         forall x, v, t1, t2, type, p, p1, p2.
-            (p == p1 f+ p2) * (p1 f> 0.0) * (p2 f> 0.0) * lambda_term(x, p, v, t1, t2, type) |- lambda_term(x, p1, v, t1, t2, type) * lambda_term(x, p2, v, t1, t2, type)
+            (p == p1 f+ p2) * (p1 f> 0.0) * (p2 f> 0.0) * lambda_term(x, p; v, t1, t2, type) |- lambda_term(x, p1; v, t1, t2, type) * lambda_term(x, p2; v, t1, t2, type)
 
     proof:
         unfold lambda_term(x, p, v, t1, t2, type);
         if (!(type == 2)) {
             if (type == 1) {
-                assert {bind: #v1, #t11, #t12, #type1, #v2, #t21, #t22, #type2} lambda_term(t1, p, #v1, #t11, #t12, #type1) * lambda_term(t2, p, #v2, #t21, #t22, #type2);
+                assert {bind: #v1, #t11, #t12, #type1, #v2, #t21, #t22, #type2} lambda_term(t1, p; #v1, #t11, #t12, #type1) * lambda_term(t2, p; #v2, #t21, #t22, #type2);
                 apply split_lambda_term_permission(t1, #v1, #t11, #t12, #type1, p, p1, p2);
                 apply split_lambda_term_permission(t2, #v2, #t21, #t22, #type2, p, p1, p2)
             } else {
-                assert {bind: #v1, #t11, #t12, #type1} lambda_term(t1, p, #v1, #t11, #t12, #type1);
+                assert {bind: #v1, #t11, #t12, #type1} lambda_term(t1, p; #v1, #t11, #t12, #type1);
                 apply split_lambda_term_permission(t1, #v1, #t11, #t12, #type1, p, p1, p2)
             };
             fold lambda_term(x, p1, v, t1, t2, type);
@@ -40,7 +40,7 @@ lemma split_lambda_term_permission {
 }
 
 [spec copy_spec: #p]
-{ (x == #x) * lambda_term(#x, #p, #v, #t1, #t2, #type) }
+{ (x == #x) * lambda_term(#x, #p; #v, #t1, #t2, #type) }
 function copy(x) {
     type := [x];
     if (type == 2) {
@@ -69,10 +69,10 @@ function copy(x) {
     [r] := type;
     return r
 }
-{ is_copy(#x, ret, #p, 1.0, #v, #t1, #t2, #type) }
+{ is_copy(#x, ret, #p, 1.0; #v, #t1, #t2, #type) }
 
 [spec subst_spec: #px, #py]
-{ (x == #x) * (y == #y) * (v == #v) * lambda_term(#x, #px, #vx, #tx1, #tx2, #type_x) * lambda_term(#y, #py, #vy, #ty1, #ty2, #type_y) }
+{ (x == #x) * (y == #y) * (v == #v) * lambda_term(#x, #px; #vx, #tx1, #tx2, #type_x) * lambda_term(#y, #py; #vy, #ty1, #ty2, #type_y) }
 function subst(x, y, v) {
     type := [x];
     if (type == 2) {
@@ -111,4 +111,4 @@ function subst(x, y, v) {
     };
     return r
 }
-{ substituted(#x, #y, #v, #px, 1.0, #py, ret) }
+{ substituted(#x, #y, #v, #px, 1.0, #py, ret;) }

--- a/wisl/examples/frac/simple_concurrency.wisl
+++ b/wisl/examples/frac/simple_concurrency.wisl
@@ -1,9 +1,9 @@
-predicate is_zero(+x, y) {
+predicate is_zero(x; y) {
     (x == 0) * (y == 1);
     (! (x == 0)) * (y == 0)
 }
 
-predicate is_int(+x: Int) {
+predicate is_int(x: Int;) {
     emp
 }
 

--- a/wisl/examples/frac/simple_concurrency.wisl
+++ b/wisl/examples/frac/simple_concurrency.wisl
@@ -3,7 +3,7 @@ predicate is_zero(x; y) {
     (! (x == 0)) * (y == 0)
 }
 
-predicate is_int(x: Int;) {
+predicate is_int(x: Int) {
     emp
 }
 
@@ -35,7 +35,7 @@ function SHOULD_FAIL_incorrect_write(x, v) {
 }
 { (ret == 0) * (#x -> #v) }
 
-{ (x == #x) * (p == #p) * (w == #w) * is_int(#w;) * is_int(#v;) * (#p f<= 1.0) * (#x -> (#p: #v)) }
+{ (x == #x) * (p == #p) * (w == #w) * is_int(#w) * is_int(#v) * (#p f<= 1.0) * (#x -> (#p: #v)) }
 function read_and_add(x, p, w) {
     n := [x];
     m := n + w;
@@ -70,7 +70,7 @@ function conc_disjoint_writes() {
 }
 { ret -> 1, 2, 3 }
 
-{ (x == #x) * (#x -> #v) * is_int(#v;) }
+{ (x == #x) * (#x -> #v) * is_int(#v) }
 function conc_reads_same_loc(x) {
     y := new(2);
     par {

--- a/wisl/examples/frac/simple_concurrency.wisl
+++ b/wisl/examples/frac/simple_concurrency.wisl
@@ -17,7 +17,7 @@ function read(x, p) {
     };
     return r
 }
-{ is_zero(#v, ret) * (#x -> (#p: #v)) }
+{ is_zero(#v; ret) * (#x -> (#p: #v)) }
 
 { (x == #x) * (v == #v) * (#x -> (1.0: #y))}
 function write(x, v) {
@@ -35,7 +35,7 @@ function SHOULD_FAIL_incorrect_write(x, v) {
 }
 { (ret == 0) * (#x -> #v) }
 
-{ (x == #x) * (p == #p) * (w == #w) * is_int(#w) * is_int(#v) * (#p f<= 1.0) * (#x -> (#p: #v)) }
+{ (x == #x) * (p == #p) * (w == #w) * is_int(#w;) * is_int(#v;) * (#p f<= 1.0) * (#x -> (#p: #v)) }
 function read_and_add(x, p, w) {
     n := [x];
     m := n + w;
@@ -70,7 +70,7 @@ function conc_disjoint_writes() {
 }
 { ret -> 1, 2, 3 }
 
-{ (x == #x) * (#x -> #v) * is_int(#v) }
+{ (x == #x) * (#x -> #v) * is_int(#v;) }
 function conc_reads_same_loc(x) {
     y := new(2);
     par {

--- a/wisl/examples/loop.wisl
+++ b/wisl/examples/loop.wisl
@@ -1,24 +1,24 @@
 
 predicate list(x; alpha) {
     (x == null) * (alpha == nil);
-    (x -> #a, #z) * (alpha == #a :: #beta) * list(#z, #beta)
+    (x -> #a, #z) * (alpha == #a :: #beta) * list(#z; #beta)
 }
 
 predicate lseg(x, y; alpha) {
   (x == y) * (alpha == nil);
-  (x -> #a, #z) * (alpha == #a :: #beta) * lseg(#z, y, #beta)
+  (x -> #a, #z) * (alpha == #a :: #beta) * lseg(#z, y; #beta)
 }
 
 lemma lseg_to_list {
   statement:
     forall x, alpha.
-      (x == #x) * (alpha == #alpha) * lseg(#x, null, #alpha) |- list(#x, #alpha)
+      (x == #x) * (alpha == #alpha) * lseg(#x, null; #alpha) |- list(#x; #alpha)
   variant: len alpha
   proof: unfold lseg(#x, null, #alpha);
          if (#x == null) {
            fold list(#x, #alpha)
          } else {
-           assert {bind: #next, #beta} (#x + 1 -> #next) * lseg(#next, null, #beta);
+           assert {bind: #next, #beta} (#x + 1 -> #next) * lseg(#next, null; #beta);
            apply lseg_to_list(#next, #beta);
            fold list(#x, #alpha)
          }
@@ -28,25 +28,25 @@ lemma lseg_append {
   statement:
     forall x, y, alpha, a, z.
       (x == #x) * (y == #y) * (alpha == #alpha) * (a == #a) * (z == #z) *
-      lseg(#x, #y, #alpha) *
-      (#y -> #a, #z) |- lseg(#x, #z, #alpha @ [ #a ])
+      lseg(#x, #y; #alpha) *
+      (#y -> #a, #z) |- lseg(#x, #z; #alpha @ [ #a ])
   variant: len alpha
   proof: unfold lseg(#x, #y, #alpha);
          if (#alpha == []) {
            fold lseg(#x, #z, #alpha @ [#a])
          } else {
-           assert {bind: #next, #beta} (#x + 1 -> #next) * lseg(#next, #y, #beta);
+           assert {bind: #next, #beta} (#x + 1 -> #next) * lseg(#next, #y; #beta);
            apply lseg_append(#next, #y, #beta, #a, #z); 
            fold lseg(#x, #z, #alpha @ [#a])
          } 
 }
 
-{ (x == #x) * list(#x, #alpha) }
+{ (x == #x) * list(#x; #alpha) }
 function llen(x) {
   y := x;
   n := 0;
   [[ fold lseg(x, y, []) ]];
-  [[ invariant {bind: y, n, #a1, #a2} lseg(x, y, #a1) * list(y, #a2) * (#alpha == #a1 @ #a2) * (n == len #a1) ]];
+  [[ invariant {bind: y, n, #a1, #a2} lseg(x, y; #a1) * list(y; #a2) * (#alpha == #a1 @ #a2) * (n == len #a1) ]];
   while (y != null) {
     [[ unfold list(y, #a2) ]];
     [[ assert {bind: #y, #b, #t} (y == #y) * (#y -> #b, #t) ]];
@@ -58,5 +58,5 @@ function llen(x) {
   [[ apply lseg_to_list(x, #alpha) ]];
   return n
 }
-{ list(#x, alpha) * (ret == len(#alpha)) }
+{ list(#x; alpha) * (ret == len(#alpha)) }
 

--- a/wisl/examples/loop.wisl
+++ b/wisl/examples/loop.wisl
@@ -1,10 +1,10 @@
 
-predicate list(+x, alpha) {
+predicate list(x; alpha) {
     (x == null) * (alpha == nil);
     (x -> #a, #z) * (alpha == #a :: #beta) * list(#z, #beta)
 }
 
-predicate lseg(+x, +y, alpha) {
+predicate lseg(x, y; alpha) {
   (x == y) * (alpha == nil);
   (x -> #a, #z) * (alpha == #a :: #beta) * lseg(#z, y, #beta)
 }

--- a/wisl/examples/tree.wisl
+++ b/wisl/examples/tree.wisl
@@ -1,4 +1,4 @@
-predicate tree(+t) {
+predicate tree(t;) {
     (t == null);
     (t -b> #v, #left, #right) * tree(#left) * tree(#right)
 }

--- a/wisl/examples/tree.wisl
+++ b/wisl/examples/tree.wisl
@@ -1,9 +1,9 @@
 predicate tree(t;) {
     (t == null);
-    (t -b> #v, #left, #right) * tree(#left) * tree(#right)
+    (t -b> #v, #left, #right) * tree(#left;) * tree(#right;)
 }
 
-{ (x == #x) * tree(#x) }
+{ (x == #x) * tree(#x;) }
 function tree_dispose(x) {
   if (x != null) {
     y := [x+1];

--- a/wisl/examples/tree.wisl
+++ b/wisl/examples/tree.wisl
@@ -1,9 +1,9 @@
-predicate tree(t;) {
+predicate tree(t) {
     (t == null);
-    (t -b> #v, #left, #right) * tree(#left;) * tree(#right;)
+    (t -b> #v, #left, #right) * tree(#left) * tree(#right)
 }
 
-{ (x == #x) * tree(#x;) }
+{ (x == #x) * tree(#x) }
 function tree_dispose(x) {
   if (x != null) {
     y := [x+1];

--- a/wisl/examples/wand.wisl
+++ b/wisl/examples/wand.wisl
@@ -8,9 +8,9 @@ predicate Q(x;) {
 
 lemma should_fail {
   statement:
-    forall x, y. P(x, y) |- Q(x) * (Q(x) -* P(x, y))
+    forall x, y. P(x; y) |- Q(x;) * (Q(x;) -* P(x; y))
   proof:
-    package (Q(x) -* P(x, y))
+    package (Q(x;) -* P(x; y))
 }
 
 predicate R(x, y;) {
@@ -44,29 +44,29 @@ predicate leq_six(x;) {
 
 lemma pure_wand {
   statement:
-    forall x. (5 <= x) |- (leq_five(x) -* eq_five(x))
+    forall x. (5 <= x) |- (leq_five(x;) -* eq_five(x;))
   proof:
-    package (leq_five(x) -* eq_five(x))
+    package (leq_five(x;) -* eq_five(x;))
 }
 
 lemma pure_wand_fail {
   statement:
-    forall x. (5 <= x) |- (leq_six(x) -* eq_five(x))
+    forall x. (5 <= x) |- (leq_six(x;) -* eq_five(x;))
   proof:
-    package (leq_six(x) -* eq_five(x))
+    package (leq_six(x;) -* eq_five(x;))
 }
 
 lemma should_succeed {
   statement:
-    forall x, y. R(x, y) |- S(x) * (S(x) -* R(x, y))
+    forall x, y. R(x, y;) |- S(x;) * (S(x;) -* R(x, y;))
   proof:
-    package (S(x) -* R(x, y))
+    package (S(x;) -* R(x, y;))
 }
 
 lemma empty_wand {
   statement:
-    forall x. x -> #a |- (empty() -* xpt(x))
+    forall x. x -> #a |- (empty(;) -* xpt(x;))
   proof:
-    package (empty() -* xpt(x))
+    package (empty(;) -* xpt(x;))
 }
 

--- a/wisl/examples/wand.wisl
+++ b/wisl/examples/wand.wisl
@@ -1,8 +1,8 @@
-predicate P(+x, y) {
+predicate P(x; y) {
   (x -> y) * (y -> x)
 }
 
-predicate Q(x) {
+predicate Q(x;) {
   x -> #k
 }
 
@@ -13,32 +13,32 @@ lemma should_fail {
     package (Q(x) -* P(x, y))
 }
 
-predicate R(+x, +y) {
+predicate R(x, y;) {
   (x -> #a, y) * (y -> #b, x)
 }
 
-predicate S(+x) {
+predicate S(x;) {
   x -> #a
 }
 
-predicate empty() {
+predicate empty(;) {
   emp
 }
 
-predicate xpt(+x) {
+predicate xpt(x;) {
   x -> #k
 }
 
 
-predicate leq_five(+x) {
+predicate leq_five(x;) {
   (x <= 5)
 }
 
-predicate eq_five(+x) {
+predicate eq_five(x;) {
   (x == 5)
 }
 
-predicate leq_six(+x) {
+predicate leq_six(x;) {
   (x <= 6)
 }
 

--- a/wisl/examples/wand.wisl
+++ b/wisl/examples/wand.wisl
@@ -2,71 +2,71 @@ predicate P(x; y) {
   (x -> y) * (y -> x)
 }
 
-predicate Q(x;) {
+predicate Q(x) {
   x -> #k
 }
 
 lemma should_fail {
   statement:
-    forall x, y. P(x; y) |- Q(x;) * (Q(x;) -* P(x; y))
+    forall x, y. P(x; y) |- Q(x) * (Q(x) -* P(x; y))
   proof:
-    package (Q(x;) -* P(x; y))
+    package (Q(x) -* P(x; y))
 }
 
-predicate R(x, y;) {
+predicate R(x, y) {
   (x -> #a, y) * (y -> #b, x)
 }
 
-predicate S(x;) {
+predicate S(x) {
   x -> #a
 }
 
-predicate empty(;) {
+predicate empty() {
   emp
 }
 
-predicate xpt(x;) {
+predicate xpt(x) {
   x -> #k
 }
 
 
-predicate leq_five(x;) {
+predicate leq_five(x) {
   (x <= 5)
 }
 
-predicate eq_five(x;) {
+predicate eq_five(x) {
   (x == 5)
 }
 
-predicate leq_six(x;) {
+predicate leq_six(x) {
   (x <= 6)
 }
 
 lemma pure_wand {
   statement:
-    forall x. (5 <= x) |- (leq_five(x;) -* eq_five(x;))
+    forall x. (5 <= x) |- (leq_five(x) -* eq_five(x))
   proof:
-    package (leq_five(x;) -* eq_five(x;))
+    package (leq_five(x) -* eq_five(x))
 }
 
 lemma pure_wand_fail {
   statement:
-    forall x. (5 <= x) |- (leq_six(x;) -* eq_five(x;))
+    forall x. (5 <= x) |- (leq_six(x) -* eq_five(x))
   proof:
-    package (leq_six(x;) -* eq_five(x;))
+    package (leq_six(x) -* eq_five(x))
 }
 
 lemma should_succeed {
   statement:
-    forall x, y. R(x, y;) |- S(x;) * (S(x;) -* R(x, y;))
+    forall x, y. R(x, y) |- S(x) * (S(x) -* R(x, y))
   proof:
-    package (S(x;) -* R(x, y;))
+    package (S(x) -* R(x, y))
 }
 
 lemma empty_wand {
   statement:
-    forall x. x -> #a |- (empty(;) -* xpt(x;))
+    forall x. x -> #a |- (empty() -* xpt(x))
   proof:
-    package (empty(;) -* xpt(x;))
+    package (empty() -* xpt(x))
 }
 

--- a/wisl/lib/ParserAndCompiler/WLexer.mll
+++ b/wisl/lib/ParserAndCompiler/WLexer.mll
@@ -87,7 +87,7 @@ rule read =
   | ':'      { COLON (curr lexbuf) }
   | ','      { COMMA (curr lexbuf) }
   | "."      { DOT (curr lexbuf) }
-  | ';'      { SEMICOLON (curr lexbuf) }
+  | ';'      { SCOLON (curr lexbuf) }
   | "|-"     { VDASH (curr lexbuf) }
   (* binary operators *)
   | "::"     { LSTCONS }

--- a/wisl/lib/ParserAndCompiler/WParser.mly
+++ b/wisl/lib/ParserAndCompiler/WParser.mly
@@ -9,7 +9,7 @@
 
 (* punctuation *)
 %token <CodeLoc.t> COLON            /* : */
-%token <CodeLoc.t> SEMICOLON        /* ; */
+%token <CodeLoc.t> SCOLON           /* ; */
 %token <CodeLoc.t> COMMA            /* , */
 %token <CodeLoc.t> DOT              /* . */
 %token <CodeLoc.t> ASSIGN           /* := */
@@ -219,18 +219,18 @@ var_list:
 
 
 statement_list_and_return:
-  | RETURN; e = expression; SEMICOLON? { ([], e)  }
-  | sm = statement; SEMICOLON; sle = statement_list_and_return
+  | RETURN; e = expression; SCOLON? { ([], e)  }
+  | sm = statement; SCOLON; sle = statement_list_and_return
     { let (sl, e) = sle in (sm::sl, e) }
 
 statement_list:
-  | sl = separated_nonempty_list_option_trailing(SEMICOLON, statement) { sl }
+  | sl = separated_nonempty_list_option_trailing(SCOLON, statement) { sl }
 
 
 /* not useful at the moment */
 /*
 logic_cmds:
-  | LCMD; lcmds = separated_list(SEMICOLON, logic_command); RCBRACE { lcmds }
+  | LCMD; lcmds = separated_list(SCOLON, logic_command); RCBRACE { lcmds }
  */
 
 type_target:
@@ -273,7 +273,7 @@ function_call:
     }
 
 function_call_list:
-  sl = separated_nonempty_list(SEMICOLON, function_call) { sl }
+  sl = separated_nonempty_list(SCOLON, function_call) { sl }
 
 
 statement:
@@ -471,15 +471,15 @@ with_variant_def:
   | WITH; variant = variant_def { variant }
 
 proof_def:
-  | PROOF; COLON; pr = separated_nonempty_list(SEMICOLON, logic_command)
+  | PROOF; COLON; pr = separated_nonempty_list(SCOLON, logic_command)
     { pr }
 
 predicate:
   | lstart = PREDICATE; pred_nounfold = option(NOUNFOLD); lpname = IDENTIFIER; LBRACE;
-    ins = separated_list(COMMA, pred_param); SEMICOLON;
-    outs = separated_list(COMMA, pred_param);
+    ins = separated_list(COMMA, pred_param);
+    outs = outs(pred_param);
     RBRACE; LCBRACE;
-    pred_definitions = separated_nonempty_list(SEMICOLON, logic_assertion);
+    pred_definitions = separated_nonempty_list(SCOLON, logic_assertion);
     lend = RCBRACE;
     { let (_, pred_name) = lpname in
       let pred_params = ins @ outs in
@@ -529,13 +529,13 @@ logic_command:
       let loc = CodeLoc.merge lstart lend in
       WLCmd.make bare_lcmd loc }
   | lstart = IF; LBRACE; g = logic_expression; lend = RBRACE;
-    LCBRACE; thencmds = separated_list(SEMICOLON, logic_command); RCBRACE;
-    ELSE; LCBRACE; elsecmds = separated_list(SEMICOLON, logic_command); RCBRACE
+    LCBRACE; thencmds = separated_list(SCOLON, logic_command); RCBRACE;
+    ELSE; LCBRACE; elsecmds = separated_list(SCOLON, logic_command); RCBRACE
     { let bare_lcmd = WLCmd.LogicIf (g, thencmds, elsecmds) in
       let loc = CodeLoc.merge lstart lend in
       WLCmd.make bare_lcmd loc }
   | lstart = IF; LBRACE; g = logic_expression; lend = RBRACE;
-    LCBRACE; thencmds = separated_list(SEMICOLON, logic_command); RCBRACE;
+    LCBRACE; thencmds = separated_list(SCOLON, logic_command); RCBRACE;
     { let bare_lcmd = WLCmd.LogicIf (g, thencmds, []) in
       let loc = CodeLoc.merge lstart lend in
       WLCmd.make bare_lcmd loc }
@@ -571,9 +571,9 @@ lvar_or_pvar:
   | lx = LVAR { lx }
 
 wand:
-  | lname = IDENTIFIER; LBRACE; lins = separated_list(COMMA, logic_expression); SEMICOLON; louts = separated_list(COMMA, logic_expression); RBRACE;
+  | lname = IDENTIFIER; LBRACE; lins = separated_list(COMMA, logic_expression); SCOLON; louts = separated_list(COMMA, logic_expression); RBRACE;
     WAND;
-    rname = IDENTIFIER; LBRACE; rins = separated_list(COMMA, logic_expression); SEMICOLON; routs = separated_list(COMMA, logic_expression); lend = RBRACE
+    rname = IDENTIFIER; LBRACE; rins = separated_list(COMMA, logic_expression); SCOLON; routs = separated_list(COMMA, logic_expression); lend = RBRACE
     {
       let (lstart, lname) = lname in
       let (_, rname) = rname in
@@ -595,7 +595,10 @@ logic_assertion:
   | wand = wand
     { let (lhs, rhs, loc) = wand in
       WLAssert.make (LWand { lhs; rhs }) loc }
-  | lpr = IDENTIFIER; LBRACE; ins = separated_list(COMMA, logic_expression); SEMICOLON; outs = separated_list(COMMA, logic_expression); lend = RBRACE
+  | lpr = IDENTIFIER; LBRACE;
+    ins = separated_list(COMMA, logic_expression);
+    outs = outs(logic_expression);
+    lend = RBRACE
     { let (lstart, pr) = lpr in
       let bare_assert = WLAssert.LPred (pr, ins, outs) in
       let loc = CodeLoc.merge lstart lend in
@@ -726,3 +729,12 @@ separated_nonempty_list_option_trailing(SEP, X):
   | x = X SEP xs = separated_nonempty_list_option_trailing(SEP, X);
       { [x] @ xs }
   | x = X SEP { [x] }
+
+%inline outs(X):
+  xs = option_preceded_separated_list(SCOLON, COMMA, X)
+  { xs }
+
+%inline option_preceded_separated_list(PREC, SEP, X):
+  | PREC; xs = separated_list(SEP, X) { xs }
+  | { [] }
+

--- a/wisl/lib/ParserAndCompiler/WParser.mly
+++ b/wisl/lib/ParserAndCompiler/WParser.mly
@@ -117,7 +117,7 @@
 %type <WLExpr.t>                         variant_def
 %type <WLExpr.t>                         with_variant_def
 %type <WLCmd.t list>                     proof_def
-%type <(string * WType.t option) * bool> pred_param_ins
+%type <string * WType.t option>          pred_param
 %type <(string * string) list>           unfold_bindings
 %type <string * string>                  unfold_binding
 %type <CodeLoc.t * string list>          bindings_with_loc
@@ -475,20 +475,16 @@ proof_def:
     { pr }
 
 predicate:
-  | lstart = PREDICATE; pred_nounfold = option(NOUNFOLD); lpname = IDENTIFIER; LBRACE; params_ins = separated_list(COMMA, pred_param_ins); RBRACE; LCBRACE;
+  | lstart = PREDICATE; pred_nounfold = option(NOUNFOLD); lpname = IDENTIFIER; LBRACE;
+    ins = separated_list(COMMA, pred_param); SEMICOLON;
+    outs = separated_list(COMMA, pred_param);
+    RBRACE; LCBRACE;
     pred_definitions = separated_nonempty_list(SEMICOLON, logic_assertion);
     lend = RCBRACE;
     { let (_, pred_name) = lpname in
-      let (pred_params, ins) : (string * WType.t option) list * bool list = List.split params_ins in
-      (* ins looks like [true, false, true] *)
-      let ins = List.mapi (fun i is_in -> if is_in then Some i else None) ins in
-      (* ins looks like [Some 0, None, Some 2] *)
-      let ins = List.filter Option.is_some ins in
-      (* ins looks like [Some 0, Some 2] *)
-      let ins = List.map Option.get ins in
-      (* ins looks like [0, 2] *)
-  		let pred_ins = if (List.length ins) > 0 then ins else (List.mapi (fun i _ -> i) pred_params) in
-      (* if ins is empty then everything is an in *)
+      let pred_params = ins @ outs in
+      (* In-parameters are the first [List.length ins] parameters *)
+      let pred_ins = List.mapi (fun i _ -> i) ins in
       let pred_nounfold = (pred_nounfold <> None) in
       let pred_loc = CodeLoc.merge lstart lend in
       let pred_id = Generators.gen_id () in
@@ -502,11 +498,10 @@ predicate:
         pred_id;
       } }
 
-pred_param_ins:
-  | inp = option(PLUS); lx = IDENTIFIER; option(preceded(COLON, type_target))
+pred_param:
+  | lx = IDENTIFIER; ty = option(preceded(COLON, type_target))
     { let (_, x) = lx in
-      let isin = Option.is_some inp in
-      ((x, Option.map fst $3), isin) }
+      (x, Option.map fst ty) }
 
 
 logic_command:

--- a/wisl/lib/ParserAndCompiler/WParser.mly
+++ b/wisl/lib/ParserAndCompiler/WParser.mly
@@ -571,14 +571,14 @@ lvar_or_pvar:
   | lx = LVAR { lx }
 
 wand:
-  | lname = IDENTIFIER; LBRACE; largs = separated_list(COMMA, logic_expression); RBRACE;
+  | lname = IDENTIFIER; LBRACE; lins = separated_list(COMMA, logic_expression); SEMICOLON; louts = separated_list(COMMA, logic_expression); RBRACE;
     WAND;
-    rname = IDENTIFIER; LBRACE; rargs = separated_list(COMMA, logic_expression); lend = RBRACE
+    rname = IDENTIFIER; LBRACE; rins = separated_list(COMMA, logic_expression); SEMICOLON; routs = separated_list(COMMA, logic_expression); lend = RBRACE
     {
       let (lstart, lname) = lname in
       let (_, rname) = rname in
       let loc = CodeLoc.merge lstart lend in
-      ((lname, largs), (rname, rargs), loc)
+      ((lname, lins @ louts), (rname, rins @ routs), loc)
     }
 
 logic_expression_with_permission:
@@ -595,9 +595,9 @@ logic_assertion:
   | wand = wand
     { let (lhs, rhs, loc) = wand in
       WLAssert.make (LWand { lhs; rhs }) loc }
-  | lpr = IDENTIFIER; LBRACE; params = separated_list(COMMA, logic_expression); lend = RBRACE
+  | lpr = IDENTIFIER; LBRACE; ins = separated_list(COMMA, logic_expression); SEMICOLON; outs = separated_list(COMMA, logic_expression); lend = RBRACE
     { let (lstart, pr) = lpr in
-      let bare_assert = WLAssert.LPred (pr, params) in
+      let bare_assert = WLAssert.LPred (pr, ins, outs) in
       let loc = CodeLoc.merge lstart lend in
       WLAssert.make bare_assert loc }
   | loc = EMP

--- a/wisl/lib/ParserAndCompiler/wisl2Gil.ml
+++ b/wisl/lib/ParserAndCompiler/wisl2Gil.ml
@@ -971,6 +971,8 @@ let compile_pred filepath pred =
       =
     pred
   in
+  (* WISL puts in-parameters first, so [ins_number] is their count *)
+  let ins_number = List.length pred_ins in
   let types = WTypeMap.infer_types_pred pred_params pred_definitions in
   let getWISLTypes str = (str, WTypeMap.type_of_variable str types) in
   let paramsWISLType = List.map (fun (x, _) -> getWISLTypes x) pred_params in
@@ -991,7 +993,7 @@ let compile_pred filepath pred =
       pred_internal = false;
       pred_num_params = List.length pred_params;
       pred_params;
-      pred_ins;
+      ins_number;
       pred_definitions = List.map build_def pred_definitions;
       pred_normalised = false;
       (* FIXME: ADD SUPPORT FOR FACTS, GUARD, ABSTRACT, PURE *)

--- a/wisl/lib/ParserAndCompiler/wisl2Gil.ml
+++ b/wisl/lib/ParserAndCompiler/wisl2Gil.ml
@@ -204,7 +204,8 @@ let rec compile_lexpr ?(fname = "main") (lexpr : WLExpr.t) :
         let gvars1, asrtl1, comp_expr1 = compile_lexpr e1 in
         let gvars2, asrtl2, comp_expr2 = compile_lexpr e2 in
         let pred_i_plus =
-          Asrt.Pred (internal_pred, [ comp_expr1; comp_expr2; Expr.LVar lout ])
+          Asrt.Pred
+            (internal_pred, [ comp_expr1; comp_expr2 ], [ Expr.LVar lout ])
         in
         ( gvars1 @ gvars2 @ [ lout ],
           asrtl1 @ asrtl2 @ [ pred_i_plus ],
@@ -347,11 +348,14 @@ let rec compile_lassert ?(fname = "main") asser : string list * Asrt.t =
       (exs1 @ exs2, cla1 @ cla2)
   | LPointsTo (le1, lle) -> compile_pointsto ~block:false le1 lle
   | LBlockPointsTo (le1, lle) -> compile_pointsto ~block:true le1 lle
-  | LPred (pr, lel) ->
-      let exsl, all, el = list_split_3 (List.map compile_lexpr lel) in
-      let exs = List.concat exsl in
-      let al = List.concat all in
-      (exs, Asrt.Pred (pr, el) :: al)
+  | LPred (pr, ins, outs) ->
+      let exsl_in, all_in, el_in = list_split_3 (List.map compile_lexpr ins) in
+      let exsl_out, all_out, el_out =
+        list_split_3 (List.map compile_lexpr outs)
+      in
+      let exs = List.concat (exsl_in @ exsl_out) in
+      let al = List.concat (all_in @ all_out) in
+      (exs, Asrt.Pred (pr, el_in, el_out) :: al)
   | LWand { lhs = lname, largs; rhs = rname, rargs } ->
       let exs1, al1, el1 = list_split_3 (List.map compile_lexpr largs) in
       let exs2, al2, el2 = list_split_3 (List.map compile_lexpr rargs) in

--- a/wisl/lib/state_ex/wislLifter.ml
+++ b/wisl/lib/state_ex/wislLifter.ml
@@ -1345,8 +1345,9 @@ struct
     let open Asrt in
     function
     | Emp -> Fmt.pf ft "emp"
-    | Pred (name, params) ->
-        Fmt.pf ft "%s(%a)" name (pp_comma_sep pp_expr) params
+    | Pred (name, ins, outs) ->
+        Fmt.pf ft "%s(%a; %a)" name (pp_comma_sep pp_expr) ins
+          (pp_comma_sep pp_expr) outs
     | Types tls ->
         let pp_tl ft (e, t) = Fmt.pf ft "%a : %s" pp_expr e (Type.str t) in
         Fmt.pf ft "%a" (pp_comma_sep pp_tl) tls

--- a/wisl/lib/state_frac/wislLifter.ml
+++ b/wisl/lib/state_frac/wislLifter.ml
@@ -1296,8 +1296,9 @@ struct
     let open Asrt in
     function
     | Emp -> Fmt.pf ft "emp"
-    | Pred (name, params) ->
-        Fmt.pf ft "%s(%a)" name (pp_comma_sep pp_expr) params
+    | Pred (name, ins, outs) ->
+        Fmt.pf ft "%s(%a; %a)" name (pp_comma_sep pp_expr) ins
+          (pp_comma_sep pp_expr) outs
     | Types tls ->
         let pp_tl ft (e, t) = Fmt.pf ft "%a : %s" pp_expr e (Type.str t) in
         Fmt.pf ft "%a" (pp_comma_sep pp_tl) tls

--- a/wisl/lib/syntax/WLAssert.ml
+++ b/wisl/lib/syntax/WLAssert.ml
@@ -5,7 +5,7 @@ type tt =
   | LEmp
   | LStar of t * t
   | LWand of { lhs : string * WLExpr.t list; rhs : string * WLExpr.t list }
-  | LPred of string * WLExpr.t list
+  | LPred of string * WLExpr.t list * WLExpr.t list
   | LPointsTo of WLExpr.t * (WLExpr.t option * WLExpr.t) list
   | LBlockPointsTo of WLExpr.t * (WLExpr.t option * WLExpr.t) list
   | LType of WLExpr.t * WType.t
@@ -49,7 +49,7 @@ let rec get_vars_and_lvars asrt =
   | LEmp -> (SS.empty, SS.empty)
   | LStar (a1, a2) ->
       double_union (get_vars_and_lvars a1) (get_vars_and_lvars a2)
-  | LPred (_, lel) -> from_wlexpr_list lel
+  | LPred (_, ins, outs) -> from_wlexpr_list (ins @ outs)
   | LPointsTo (el, lel) -> resolve_points_to el lel
   | LBlockPointsTo (el, lel) -> resolve_points_to el lel
   | LPure lf -> WLExpr.get_vars_and_lvars lf
@@ -72,7 +72,7 @@ let rec get_by_id id la =
   let aux lap =
     match get lap with
     | LStar (la1, la2) -> getter la1 |>> (getter, la2)
-    | LPred (_, lel) -> lexpr_list_visitor lel
+    | LPred (_, ins, outs) -> lexpr_list_visitor (ins @ outs)
     | LPointsTo (le1, lle2) -> resolve_points_to le1 lle2
     | LBlockPointsTo (le1, lle2) -> resolve_points_to le1 lle2
     | LPure lf -> lform_getter lf
@@ -92,7 +92,8 @@ let rec pp fmt asser =
   match get asser with
   | LEmp -> Format.pp_print_string fmt "emp"
   | LStar (a1, a2) -> Fmt.pf fmt "@[(%a) * (%a)@]" pp a1 pp a2
-  | LPred (pname, lel) -> Fmt.pf fmt "@[%s(%a)@]" pname pp_params lel
+  | LPred (pname, ins, outs) ->
+      Fmt.pf fmt "@[%s(%a; %a)@]" pname pp_params ins pp_params outs
   | LWand { lhs = lname, largs; rhs = rname, rargs } ->
       Fmt.pf fmt "@[%s(%a) -* %s(%a)]" lname pp_params largs rname pp_params
         rargs
@@ -117,7 +118,7 @@ let rec substitution (subst : (string, WLExpr.tt) Hashtbl.t) (a : t) : t =
     match wlanode with
     | LEmp -> LEmp
     | LStar (a1, a2) -> LStar (f a1, f a2)
-    | LPred (name, le) -> LPred (name, List.map fe le)
+    | LPred (name, ins, outs) -> LPred (name, List.map fe ins, List.map fe outs)
     | LWand { lhs = lname, largs; rhs = rname, rargs } ->
         LWand
           { lhs = (lname, List.map fe largs); rhs = (rname, List.map fe rargs) }

--- a/wisl/lib/syntax/WLAssert.mli
+++ b/wisl/lib/syntax/WLAssert.mli
@@ -2,7 +2,7 @@ type tt =
   | LEmp
   | LStar of t * t
   | LWand of { lhs : string * WLExpr.t list; rhs : string * WLExpr.t list }
-  | LPred of string * WLExpr.t list
+  | LPred of string * WLExpr.t list * WLExpr.t list
   | LPointsTo of WLExpr.t * (WLExpr.t option * WLExpr.t) list
       (** x -> a, b <=> (x -> a) * (x+1 -> b) *)
   | LBlockPointsTo of WLExpr.t * (WLExpr.t option * WLExpr.t) list

--- a/wisl/lib/syntax/WTypeMap.ml
+++ b/wisl/lib/syntax/WTypeMap.ml
@@ -117,7 +117,8 @@ let rec infer_single_assert_step asser known =
   | WLAssert.LEmp -> known
   | WLAssert.LStar (la1, la2) ->
       infer_single_assert_step la2 (infer_single_assert_step la1 known)
-  | WLAssert.LPred (_, lel) -> List.fold_left infer_logic_expr known lel
+  | WLAssert.LPred (_, ins, outs) ->
+      List.fold_left infer_logic_expr known (ins @ outs)
   | WLAssert.LWand { lhs = _, largs; rhs = _, rargs } ->
       List.fold_left infer_logic_expr known largs |> fun acc ->
       List.fold_left infer_logic_expr acc rargs

--- a/wisl/runtime/wisl_core.gil
+++ b/wisl/runtime/wisl_core.gil
@@ -3,10 +3,10 @@
 (******** PREDICATES REGARDING CELLS ********)
 
 (* ptr -> value in WISL *)
-pred i__pred_cell (+ptr: List, value):
+pred i__pred_cell (ptr: List; value):
       (ptr == {{ #loc, #offset }}) *
       <cell>(#loc, #offset; value);
 
-pred freed(+ptr: List):
+pred freed(ptr: List;):
       (ptr == {{ #l, 0i }}) * types(#l: Obj) *
       <freed>(#l;);

--- a/wisl/runtime/wisl_core.gil
+++ b/wisl/runtime/wisl_core.gil
@@ -7,6 +7,6 @@ pred i__pred_cell (ptr: List; value):
       (ptr == {{ #loc, #offset }}) *
       <cell>(#loc, #offset; value);
 
-pred freed(ptr: List;):
+pred freed(ptr: List):
       (ptr == {{ #l, 0i }}) * types(#l: Obj) *
-      <freed>(#l;);
+      <freed>(#l);

--- a/wisl/runtime/wisl_pointer_arith.gil
+++ b/wisl/runtime/wisl_pointer_arith.gil
@@ -105,33 +105,33 @@ proc i__gt (el, er) {
 
 (******** PREDICATES REGARDING POINTER AND NUMBER OPERATIONS ********)
 
-(* i__pred_add(x, y, z) is true if executing i__add(x, y) would return z *)
+(* i__pred_add(x, y; z) is true if executing i__add(x, y) would return z *)
 pred i__pred_add (el, er; out):
       types(el: List, er: Int) * (el == {{ #loc, #offset }}) * (out == {{ #loc, #offset i+ er }}),
       types(er: List, el: Int) * (er == {{ #loc, #offset}}) * (out == {{ #loc, #offset i+ el }}),
       types(er: Int, el: Int) * (out == (er i+ el));
 
-(* i__pred_minus(x, y, z) is true if executing i__minus(x, y) would return z *)
+(* i__pred_minus(x, y; z) is true if executing i__minus(x, y) would return z *)
 pred i__pred_minus (el, er; out):
       types(el: List, er: Int) * (el == {{ #loc, #offset }}) * (out == {{ #loc, #offset i- er }}),
       types(er: Int, el: Int) * (out == (el i- er));
 
-(* i__pred_lt(x, y, z) is true if executing i__lt(x, y) would return z *)
+(* i__pred_lt(x, y; z) is true if executing i__lt(x, y) would return z *)
 pred i__pred_lt (el, er; out):
       types(el: List, er: List) * (el == {{ #locl, #offsetl }}) * (er == {{ #locr, #offsetr }}) * (#locr == #locl) * (out == (#offsetl i< #offsetr)),
       types(el: Int, er: Int) * (out == (el i< er));
 
-(* i__pred_gt(x, y, z) is true if executing i__gt(x, y) would return z *)
+(* i__pred_gt(x, y; z) is true if executing i__gt(x, y) would return z *)
 pred i__pred_gt (el, er; out):
       types(el: List, er: List) * (el == {{ #locl, #offsetl }}) * (er == {{ #locr, #offsetr }}) * (#locr == #locl) * (out == (not (#offsetl i<= #offsetr))),
       types(el: Int, er: Int) * (out == (not (el i<= er)));
 
-(* i__pred_leq(x, y, z) is true if executing i__leq(x, y) would return z *)
+(* i__pred_leq(x, y; z) is true if executing i__leq(x, y) would return z *)
 pred i__pred_leq (el, er; out):
       types(el: List, er: List) * (el == {{ #locl, #offsetl }}) * (er == {{ #locr, #offsetr }}) * (#locr == #locl) * (out == (#offsetl i<= #offsetr)),
       types(el: Int, er: Int) * (out == (el i<= er));
 
-(* i__pred_geq(x, y, z) is true if executing i__geq(x, y) would return z *)
+(* i__pred_geq(x, y; z) is true if executing i__geq(x, y) would return z *)
 pred i__pred_geq (el, er; out):
       types(el: List, er: List) * (el == {{ #locl, #offsetl }}) * (er == {{ #locr, #offsetr }}) * (#locr == #locl) * (out == (not (#offsetl i< #offsetr))),
       types(el: Int, er: Int) * (out == (not (el i< er)));

--- a/wisl/runtime/wisl_pointer_arith.gil
+++ b/wisl/runtime/wisl_pointer_arith.gil
@@ -106,32 +106,32 @@ proc i__gt (el, er) {
 (******** PREDICATES REGARDING POINTER AND NUMBER OPERATIONS ********)
 
 (* i__pred_add(x, y, z) is true if executing i__add(x, y) would return z *)
-pred i__pred_add (+el, +er, out):
+pred i__pred_add (el, er; out):
       types(el: List, er: Int) * (el == {{ #loc, #offset }}) * (out == {{ #loc, #offset i+ er }}),
       types(er: List, el: Int) * (er == {{ #loc, #offset}}) * (out == {{ #loc, #offset i+ el }}),
       types(er: Int, el: Int) * (out == (er i+ el));
 
 (* i__pred_minus(x, y, z) is true if executing i__minus(x, y) would return z *)
-pred i__pred_minus (+el, +er, out):
+pred i__pred_minus (el, er; out):
       types(el: List, er: Int) * (el == {{ #loc, #offset }}) * (out == {{ #loc, #offset i- er }}),
       types(er: Int, el: Int) * (out == (el i- er));
 
 (* i__pred_lt(x, y, z) is true if executing i__lt(x, y) would return z *)
-pred i__pred_lt (+el, +er, out):
+pred i__pred_lt (el, er; out):
       types(el: List, er: List) * (el == {{ #locl, #offsetl }}) * (er == {{ #locr, #offsetr }}) * (#locr == #locl) * (out == (#offsetl i< #offsetr)),
       types(el: Int, er: Int) * (out == (el i< er));
 
 (* i__pred_gt(x, y, z) is true if executing i__gt(x, y) would return z *)
-pred i__pred_gt (+el, +er, out):
+pred i__pred_gt (el, er; out):
       types(el: List, er: List) * (el == {{ #locl, #offsetl }}) * (er == {{ #locr, #offsetr }}) * (#locr == #locl) * (out == (not (#offsetl i<= #offsetr))),
       types(el: Int, er: Int) * (out == (not (el i<= er)));
 
 (* i__pred_leq(x, y, z) is true if executing i__leq(x, y) would return z *)
-pred i__pred_leq (+el, +er, out):
+pred i__pred_leq (el, er; out):
       types(el: List, er: List) * (el == {{ #locl, #offsetl }}) * (er == {{ #locr, #offsetr }}) * (#locr == #locl) * (out == (#offsetl i<= #offsetr)),
       types(el: Int, er: Int) * (out == (el i<= er));
 
 (* i__pred_geq(x, y, z) is true if executing i__geq(x, y) would return z *)
-pred i__pred_geq (+el, +er, out):
+pred i__pred_geq (el, er; out):
       types(el: List, er: List) * (el == {{ #locl, #offsetl }}) * (er == {{ #locr, #offsetr }}) * (#locr == #locl) * (out == (not (#offsetl i< #offsetr))),
       types(el: Int, er: Int) * (out == (not (el i< er)));


### PR DESCRIPTION
Depends on #379 

Change the syntax predicates to avoid having the clunky `+` to indicate in-parameters and have ins first, and then outs after a semi-colon.

This is better reviewed commit-by-commit.
- The first commit re-orders arguments in every predicate so that in-parameters come before out-parameters.
- The second commit changes the syntax of predicate *declaration* so that ins and outs must be separated with a semicolon
- The third commit changes the syntax of predicate *calls* with the same thing
