### PR TITLE
Remove uselesss fields in machine_model that broke macos

### DIFF
--- a/Gillian-C2/lib/common/machine_model.ml
+++ b/Gillian-C2/lib/common/machine_model.ml
@@ -8,17 +8,10 @@ type t = {
   double_width : int;
   int_width : int;
   is_big_endian : bool;
-  long_double_width : int;
   long_int_width : int;
-  long_long_int_width : int;
-  memory_operand_size : int;
   null_is_zero : bool;
   pointer_width : int;
-  short_int_width : int;
   single_width : int;
-  wchar_t_is_unsigned : bool;
-  wchar_t_width : int;
-  word_size : int;
 }
 [@@deriving to_yojson, eq, show { with_path = false }]
 
@@ -31,17 +24,10 @@ let archi64 =
     double_width = 64;
     int_width = 32;
     is_big_endian = false;
-    long_double_width = 128;
     long_int_width = 64;
-    long_long_int_width = 64;
-    memory_operand_size = 4;
     null_is_zero = true;
     pointer_width = 64;
-    short_int_width = 16;
     single_width = 32;
-    wchar_t_width = 32;
-    word_size = 32;
-    wchar_t_is_unsigned = false;
   }
 
 let int_chunk { int_width; _ } =

--- a/Gillian-C2/lib/goto_program/machine_model_parse.ml
+++ b/Gillian-C2/lib/goto_program/machine_model_parse.ml
@@ -39,20 +39,10 @@ module Builder = struct
       double_width = get ~field:"double_width" b.double_width;
       int_width = get ~field:"int_width" b.int_width;
       is_big_endian = get ~field:"is_big_endian" b.is_big_endian;
-      long_double_width = get ~field:"long_double_width" b.long_double_width;
       long_int_width = get ~field:"long_int_width" b.long_int_width;
-      long_long_int_width =
-        get ~field:"long_long_int_width" b.long_long_int_width;
-      memory_operand_size =
-        get ~field:"memory_operand_size" b.memory_operand_size;
       null_is_zero = get ~field:"null_is_zero" b.null_is_zero;
       pointer_width = get ~field:"pointer_width" b.pointer_width;
-      short_int_width = get ~field:"short_int_width" b.short_int_width;
       single_width = get ~field:"single_width" b.single_width;
-      wchar_t_is_unsigned =
-        get ~field:"wchar_t_is_unsigned" b.wchar_t_is_unsigned;
-      wchar_t_width = get ~field:"wchar_t_width" b.wchar_t_width;
-      word_size = get ~field:"word_size" b.word_size;
     }
 end
 


### PR DESCRIPTION
Gillian-C2 wasn't running on macos because the Machine_model didn't exactly match the linux one. I removed the fields that werent used and were conflicting