### PR TITLE
Preds are just Core preds with ✨flavour✨

### DIFF
--- a/Gillian-C/lib/Constr.ml
+++ b/Gillian-C/lib/Constr.ml
@@ -42,8 +42,8 @@ module Others = struct
   (* The in/out split below must match the runtime predicate definitions, since
      the engine trusts the split carried by the assertion. All-ins predicates
      use [pred]; predicates with out-parameters spell out [ins] and [outs]. *)
-  let pred name ins outs = Asrt.Pred (name, ins, outs)
-  let pred_in name ins = Asrt.Pred (name, ins, [])
+  let pred name ins outs = Asrt.pred name ins outs
+  let pred_in name ins = Asrt.pred name ins []
 
   (* [i__malloced] is, unfortunately, declared with a different in/out split
      depending on the architecture: [(p; bytes)] in 64-bit, [(p, bytes;)] in

--- a/Gillian-C/lib/gil_logic_gen.ml
+++ b/Gillian-C/lib/gil_logic_gen.ml
@@ -144,7 +144,7 @@ let assert_of_member cenv members id typ =
       let list_is_components = pvmember#==(Expr.list args_without_ins) in
       let ofs = Expr.Infix.(pvofs + fo) in
       (* Struct predicates have the location and offset as their two ins. *)
-      let pred_call = Asrt.Pred (pred_name, [ pvloc; ofs ], args_without_ins) in
+      let pred_call = Asrt.pred pred_name [ pvloc; ofs ] args_without_ins in
       [ list_is_components; pred_call ]
   | Tarray (ty, n, _) ->
       let n = ValueTranslation.int_of_z n in
@@ -166,13 +166,12 @@ let assert_of_member cenv members id typ =
         let open Internal_Predicates in
         let open VTypes in
         match typ with
-        | Tint _ ->
-            (mk int_type lvval, Asrt.Pred (int_get, [ pvmember ], [ lvval ]))
+        | Tint _ -> (mk int_type lvval, Asrt.pred int_get [ pvmember ] [ lvval ])
         | Tlong _ ->
-            (mk long_type lvval, Asrt.Pred (long_get, [ pvmember ], [ lvval ]))
+            (mk long_type lvval, Asrt.pred long_get [ pvmember ] [ lvval ])
         | Tfloat _ ->
-            (mk float_type lvval, Asrt.Pred (float_get, [ pvmember ], [ lvval ]))
-        | Tpointer _ -> (pvmember, Asrt.Pred (is_ptr_opt, [ pvmember ], []))
+            (mk float_type lvval, Asrt.pred float_get [ pvmember ] [ lvval ])
+        | Tpointer _ -> (pvmember, Asrt.pred is_ptr_opt [ pvmember ] [])
         | _ ->
             failwith
               (Printf.sprintf "unhandled struct field type for now : %s"
@@ -449,9 +448,7 @@ let trans_constr ?fname:_ ~(typ : CAssert.points_to_type) ann s c =
   let tloc = types ObjectType in
   (* let mk_num n = Expr.Lit (Num (float_of_int n)) in *)
   (* let zero = mk_num 0 in *)
-  let ptr_call p l o =
-    Asrt.Pred (Internal_Predicates.ptr_get, [ p ], [ l; o ])
-  in
+  let ptr_call p l o = Asrt.pred Internal_Predicates.ptr_get [ p ] [ l; o ] in
   let sz = function
     | CSVal.Sint _ -> 4
     | Slong _ -> 8
@@ -548,7 +545,7 @@ let trans_constr ?fname:_ ~(typ : CAssert.points_to_type) ann s c =
         split3_expr_comp (List.map trans_expr el)
       in
       let pr =
-        Asrt.Pred (struct_pred, [ locv; ofsv ], params_fields) :: more_asrt
+        Asrt.pred struct_pred [ locv; ofsv ] params_fields :: more_asrt
       in
       pr @ to_assert @ [ malloc_chunk siz ]
 
@@ -590,7 +587,7 @@ let rec trans_asrt ~fname ~ann asrt =
     | Pred (p, c_ins, c_outs) ->
         let ap_in, _, g_ins = split3_expr_comp (List.map trans_expr c_ins) in
         let ap_out, _, g_outs = split3_expr_comp (List.map trans_expr c_outs) in
-        Pred (p, g_ins, g_outs) :: (ap_in @ ap_out)
+        Asrt.pred p g_ins g_outs :: (ap_in @ ap_out)
     | Emp -> [ Asrt.Emp ]
     | PointsTo { ptr = s; constr = c; typ } -> trans_constr ~fname ~typ ann s c
   in
@@ -876,17 +873,17 @@ let bounds signedness bit_size =
   (Expr.int_z min, Expr.int_z max)
 
 let predicate_from_triple (e, csmt, ct) =
-  let pred pname = Asrt.Pred (pname, [ e ], []) in
+  let pred pname = Asrt.pred pname [ e ] [] in
   let open Internal_Predicates in
   match (csmt, ct) with
   | _, Ctypes.Tpointer (Tfunction _, _) -> pred is_ptr_to_0
   | _, Ctypes.Tpointer _ -> pred is_ptr_opt
   | AST.Tint, Tint (size, signedness, _) ->
       let min, max = bounds signedness (bit_size size) in
-      Asrt.Pred (Internal_Predicates.is_bounded_int, [ e; min; max ], [])
+      Asrt.pred Internal_Predicates.is_bounded_int [ e; min; max ] []
   | AST.Tlong, Tlong (signedness, _) ->
       let min, max = bounds signedness 64 in
-      Asrt.Pred (Internal_Predicates.is_bounded_long, [ e; min; max ], [])
+      Asrt.pred Internal_Predicates.is_bounded_long [ e; min; max ] []
   | AST.Tsingle, _ -> pred is_single
   | AST.Tfloat, _ -> pred is_float
   | _ ->

--- a/Gillian-C2/lib/compiler/constr.ml
+++ b/Gillian-C2/lib/compiler/constr.ml
@@ -36,8 +36,8 @@ module Others = struct
 
   (* The in/out split must match the runtime predicate definitions, since the
      engine trusts the split carried by the assertion. *)
-  let pred name ins outs = Asrt.Pred (name, ins, outs)
-  let pred_in name ins = Asrt.Pred (name, ins, [])
+  let pred name ins outs = Asrt.pred name ins outs
+  let pred_in name ins = Asrt.pred name ins []
 
   let malloced_abst ~ptr ~total_size =
     pred Internal_Predicates.malloced [ ptr ] [ total_size ]

--- a/Gillian-C2/lib/compiler/gil_logic_gen.ml
+++ b/Gillian-C2/lib/compiler/gil_logic_gen.ml
@@ -130,7 +130,7 @@ let convert_struct_field
         in
         let field_arg_list = pvmember#==(Expr.list field_args) in
         (* Struct predicates have the location and offset as their two ins. *)
-        let pred_call = Asrt.Pred (pred_name, [ pvloc; ofs ], field_args) in
+        let pred_call = Asrt.pred pred_name [ pvloc; ofs ] field_args in
         (Some GilType.ListType, [ field_arg_list; pred_call ])
     | Array (type_', len) ->
         let chunk =
@@ -165,14 +165,14 @@ let convert_struct_field
                     | I_ssize_t -> is_ssize_t
                     | I_bool -> is_bool
                   in
-                  let asrt = Asrt.Pred (pred, [ pvmember ], []) in
+                  let asrt = Asrt.pred pred [ pvmember ] [] in
                   Some (Some IntType, [ asrt ])
               | Signedbv _ | Unsignedbv _ | Enum _ | EnumTag _ ->
                   Some (Some IntType, [])
               | Double | Float -> Some (Some NumberType, [])
               | Pointer _ ->
                   let is_ptr_asrt =
-                    Asrt.Pred (Internal_Predicates.is_ptr, [ pvmember ], [])
+                    Asrt.pred Internal_Predicates.is_ptr [ pvmember ] []
                   in
                   Some (Some ListType, [ is_ptr_asrt ])
               | _ -> None
@@ -412,9 +412,7 @@ let trans_constr ~(ctx : Ctx.t) ~(typ : CAssert.points_to_type) ~pvar_map s c =
   let gen_ofs_var () = Expr.LVar (fresh_lvar ()) in
   let te = trans_expr ~pvar_map in
   let tse = trans_simpl_expr ~pvar_map in
-  let ptr_call p l o =
-    Asrt.Pred (Internal_Predicates.ptr_get, [ p ], [ l; o ])
-  in
+  let ptr_call p l o = Asrt.pred Internal_Predicates.ptr_get [ p ] [ l; o ] in
   let sz x = CSVal.size_of ~ctx x |> Z.of_int in
   let interpret_s ~typ s =
     match typ with
@@ -491,7 +489,7 @@ let trans_constr ~(ctx : Ctx.t) ~(typ : CAssert.points_to_type) ~pvar_map s c =
       in
       let more_asrt, _, params_fields = split3_expr_comp (List.map te el) in
       let pr =
-        Asrt.Pred (struct_pred, [ locv; ofsv ], params_fields) :: more_asrt
+        Asrt.pred struct_pred [ locv; ofsv ] params_fields :: more_asrt
       in
       pr @ to_assert @ [ malloc_chunk size ]
 
@@ -536,7 +534,7 @@ let rec trans_asrt ~ctx ~pvar_map asrt =
     | Pred (p, c_ins, c_outs) ->
         let ap_in, _, g_ins = split3_expr_comp (List.map te c_ins) in
         let ap_out, _, g_outs = split3_expr_comp (List.map te c_outs) in
-        Pred (p, g_ins, g_outs) :: (ap_in @ ap_out)
+        Asrt.pred p g_ins g_outs :: (ap_in @ ap_out)
     | Emp -> [ Asrt.Emp ]
     | PointsTo { ptr = s; constr = c; typ } ->
         trans_constr ~pvar_map ~ctx ~typ s c
@@ -684,7 +682,7 @@ let get_param_typasrt param =
     | _ -> None
   in
   match (pred, param.identifier) with
-  | Some pred, Some id -> Some (Asrt.Pred (pred, [ PVar id ], []))
+  | Some pred, Some id -> Some (Asrt.pred pred [ PVar id ] [])
   | _ -> None
 
 let trans_sspec ~ctx ~pvar_map ~params sspecs =
@@ -845,7 +843,7 @@ module Machine_preds = struct
       let perm = Expr.string Perm.(to_string Freeable) in
       Asrt.
         [
-          Pred (Internal_Predicates.ptr_get, [ PVar "p" ], [ l; Expr.zero_i ]);
+          Asrt.pred Internal_Predicates.ptr_get [ PVar "p" ] [ l; Expr.zero_i ];
           CorePred
             ( LActions.(str_ga Single),
               [ l; start; chunk ],

--- a/Gillian-C2/lib/memory_model/predicates.ml
+++ b/Gillian-C2/lib/memory_model/predicates.ml
@@ -37,8 +37,8 @@ module Others = struct
 
   (* The in/out split must match the runtime predicate definitions, since the
      engine trusts the split carried by the assertion. *)
-  let pred name ins outs = Asrt.Pred (name, ins, outs)
-  let pred_in name ins = Asrt.Pred (name, ins, [])
+  let pred name ins outs = Asrt.pred name ins outs
+  let pred_in name ins = Asrt.pred name ins []
 
   let malloced_abst ~ptr ~total_size =
     pred Internal_Predicates.malloced [ ptr ] [ total_size ]

--- a/Gillian-JS/lib/Compiler/JSIL2GIL.ml
+++ b/Gillian-JS/lib/Compiler/JSIL2GIL.ml
@@ -83,7 +83,8 @@ let rec jsil2gil_asrt (a : Asrt.t) : GAsrt.t =
   | MetaData (e1, e2) -> [ Asrt_utils.metadata ~loc:(fe e1) ~metadata:(fe e2) ]
   | EmptyFields (e1, e2) ->
       [ Asrt_utils.empty_fields ~loc:(fe e1) ~domain:(fe e2) ]
-  | Pred (pn, ins, outs) -> [ Pred (pn, List.map fe ins, List.map fe outs) ]
+  | Pred (pn, ins, outs) ->
+      [ GAsrt.pred pn (List.map fe ins) (List.map fe outs) ]
   | Pure f -> [ Pure (jsil2gil_expr f) ]
   | Types vts -> [ Types (List.map (fun (v, t) -> (fe v, t)) vts) ]
 

--- a/Gillian-JS/lib/Compiler/JSIL_PostParser.ml
+++ b/Gillian-JS/lib/Compiler/JSIL_PostParser.ml
@@ -207,7 +207,7 @@ let scope_info_to_assertion
   let this_asrt = make_this_assertion () in
 
   if fid <> JS2JSIL_Helpers.main_fid then
-    let init_heap_asrt : Asrt.t = Pred (heap_asrt_name, [], []) in
+    let init_heap_asrt : Asrt.t = Asrt.Pred (heap_asrt_name, [], []) in
     Asrt.star
       (glob_constraints @ (this_asrt :: init_heap_asrt :: a_schain :: a_vars))
   else Asrt.star (glob_constraints @ (this_asrt :: a_schain :: a_vars))

--- a/GillianCore/GIL_Syntax/Asrt.ml
+++ b/GillianCore/GIL_Syntax/Asrt.ml
@@ -1,7 +1,6 @@
 (** {b GIL logic assertions}. *)
 type atom = TypeDef__.assertion_atom =
   | Emp  (** Empty heap *)
-  | Pred of string * Expr.t list * Expr.t list  (** Predicates *)
   | Pure of Expr.t  (** Pure formula *)
   | Types of (Expr.t * Type.t) list  (** Typing assertion *)
   | CorePred of string * Expr.t list * Expr.t list  (** Core assertion *)
@@ -15,6 +14,28 @@ let atom_to_yojson = TypeDef__.assertion_atom_to_yojson
 let atom_of_yojson = TypeDef__.assertion_atom_of_yojson
 let to_yojson = TypeDef__.assertion_to_yojson
 let of_yojson = TypeDef__.assertion_of_yojson
+
+(* User-defined predicates no longer have their own assertion variant: they are
+   encoded as {!CorePred}s whose name is the user predicate name prefixed with
+   [user_pred_prefix]. The prefix is defined {b once}, here. *)
+let user_pred_prefix = "GILLIAN_USER_PRED__"
+
+(** [user_pred_name p] is the core-predicate name that encodes the user-defined
+    predicate [p]. *)
+let user_pred_name (name : string) : string = user_pred_prefix ^ name
+
+(** [as_user_pred_name s] returns [Some p] when the core-predicate name [s]
+    encodes a user-defined predicate [p] (i.e. [s = user_pred_name p]), and
+    [None] when [s] is a genuine core predicate. *)
+let as_user_pred_name (name : string) : string option =
+  let n = String.length user_pred_prefix in
+  if String.length name >= n && String.sub name 0 n = user_pred_prefix then
+    Some (String.sub name n (String.length name - n))
+  else None
+
+(** Builds a user-predicate assertion (a {!CorePred} with the encoded name). *)
+let pred (name : string) (ins : Expr.t list) (outs : Expr.t list) : atom =
+  CorePred (user_pred_name name, ins, outs)
 
 let compare x y =
   let cmp = Stdlib.compare in
@@ -55,8 +76,8 @@ let prioritise (a1 : atom) (a2 : atom) =
   | Types [ (e, _) ], Types [ (e', _) ] -> lloc_aloc_pvar_lvar e e'
   | Types _, _ -> -1
   | _, Types _ -> 1
-  | Pred _, _ -> 1
-  | _, Pred _ -> -1
+  | CorePred (n1, _, _), _ when Option.is_some (as_user_pred_name n1) -> 1
+  | _, CorePred (n2, _, _) when Option.is_some (as_user_pred_name n2) -> -1
   | _, _ -> Stdlib.compare a1 a2
 
 module MyAssertion = struct
@@ -71,7 +92,6 @@ module Set = Set.Make (MyAssertion)
 let map (f_e : Expr.t -> Expr.t) : t -> t =
   List.map (function
     | Emp -> Emp
-    | Pred (s, ins, outs) -> Pred (s, List.map f_e ins, List.map f_e outs)
     | Pure form -> Pure (f_e form)
     | Types lt -> Types (List.map (fun (exp, typ) -> (f_e exp, typ)) lt)
     | CorePred (x, es1, es2) -> CorePred (x, List.map f_e es1, List.map f_e es2)
@@ -104,7 +124,11 @@ let pred_names : t -> string list =
     object
       inherit [_] Visitors.reduce
       inherit Visitors.Utils.non_ordered_list_monoid
-      method! visit_Pred () name _ _ = [ name ]
+
+      method! visit_CorePred () name _ _ =
+        match as_user_pred_name name with
+        | Some pred_name -> [ pred_name ]
+        | None -> []
     end
   in
   collector#visit_assertion ()
@@ -117,7 +141,7 @@ let pure_asrts : t -> Expr.t list =
 
 (* Check if --a-- is a pure assertion *)
 let is_pure_asrt : atom -> bool = function
-  | Pred _ | CorePred _ | Wand _ -> false
+  | CorePred _ | Wand _ -> false
   | _ -> true
 
 (* Eliminate Emp assertions.
@@ -135,17 +159,20 @@ let make_pure (a : t) : Expr.t =
 let _pp_atom ?(e_pp : Format.formatter -> Expr.t -> unit = Expr.pp) fmt =
   function
   | Emp -> Fmt.string fmt "emp"
-  | Pred (name, ins, outs) ->
-      let name = Pp_utils.maybe_quote_ident name in
-      let pp_e_l = Fmt.list ~sep:Fmt.comma e_pp in
-      Fmt.pf fmt "@[<h>%s(%a; %a)@]" name pp_e_l ins pp_e_l outs
   | Types tls ->
       let pp_tl f (e, t) = Fmt.pf f "%a : %s" e_pp e (Type.str t) in
       Fmt.pf fmt "types(@[%a@])" (Fmt.list ~sep:Fmt.comma pp_tl) tls
   | Pure f -> e_pp fmt f
-  | CorePred (a, ins, outs) ->
+  | CorePred (a, ins, outs) -> (
       let pp_e_l = Fmt.list ~sep:Fmt.comma e_pp in
-      Fmt.pf fmt "@[<h><%s>(%a; %a)@]" a pp_e_l ins pp_e_l outs
+      match as_user_pred_name a with
+      | Some pred_name ->
+          (* A user-defined predicate: printed [name(ins; outs)]. *)
+          let pred_name = Pp_utils.maybe_quote_ident pred_name in
+          Fmt.pf fmt "@[<h>%s(%a; %a)@]" pred_name pp_e_l ins pp_e_l outs
+      | None ->
+          (* A genuine core predicate: printed [<name>(ins; outs)]. *)
+          Fmt.pf fmt "@[<h><%s>(%a; %a)@]" a pp_e_l ins pp_e_l outs)
   | Wand { lhs = lname, largs; rhs = rname, rargs } ->
       let lname = Pp_utils.maybe_quote_ident lname in
       let rname = Pp_utils.maybe_quote_ident rname in

--- a/GillianCore/GIL_Syntax/Gil_syntax.mli
+++ b/GillianCore/GIL_Syntax/Gil_syntax.mli
@@ -448,7 +448,6 @@ module Asrt : sig
 
   type atom =
     | Emp  (** Empty heap *)
-    | Pred of string * Expr.t list * Expr.t list  (** Predicates *)
     | Pure of Expr.t  (** Pure formula *)
     | Types of (Expr.t * Type.t) list  (** Typing assertion *)
     | CorePred of string * Expr.t list * Expr.t list  (** Core assertion *)
@@ -457,6 +456,21 @@ module Asrt : sig
   [@@deriving yojson, eq]
 
   type t = atom list [@@deriving yojson, eq]
+
+  (** Prefix encoding a user-defined predicate as a {!CorePred} name. Set once;
+      never hardcode it elsewhere. *)
+  val user_pred_prefix : string
+
+  (** [user_pred_name p] is the core-predicate name encoding user predicate [p].
+  *)
+  val user_pred_name : string -> string
+
+  (** [as_user_pred_name s] is [Some p] when [s] encodes the user predicate [p],
+      and [None] when [s] is a genuine core predicate. *)
+  val as_user_pred_name : string -> string option
+
+  (** [pred name ins outs] builds a user-predicate assertion atom. *)
+  val pred : string -> Expr.t list -> Expr.t list -> atom
 
   (** Comparison of assertions *)
   val compare : atom -> atom -> int
@@ -1330,13 +1344,6 @@ module Visitors : sig
          ; visit_PhiAssignment :
              'c -> 'f Cmd.t -> (string * Expr.t list) list -> 'f Cmd.t
          ; visit_Pi : 'c -> Constant.t -> Constant.t
-         ; visit_Pred :
-             'c ->
-             Asrt.atom ->
-             string ->
-             Expr.t list ->
-             Expr.t list ->
-             Asrt.atom
          ; visit_Pure : 'c -> Asrt.atom -> Expr.t -> Asrt.atom
          ; visit_Random : 'c -> Constant.t -> Constant.t
          ; visit_ReturnError : 'c -> 'f Cmd.t -> 'f Cmd.t
@@ -1592,10 +1599,6 @@ module Visitors : sig
       'c -> 'f Cmd.t -> (string * Expr.t list) list -> 'f Cmd.t
 
     method visit_Pi : 'c -> Constant.t -> Constant.t
-
-    method visit_Pred :
-      'c -> Asrt.atom -> string -> Expr.t list -> Expr.t list -> Asrt.atom
-
     method visit_Pure : 'c -> Asrt.atom -> Expr.t -> Asrt.atom
     method visit_Random : 'c -> Constant.t -> Constant.t
     method visit_ReturnError : 'c -> 'f Cmd.t -> 'f Cmd.t
@@ -1851,7 +1854,6 @@ module Visitors : sig
          ; visit_Pi : 'c -> 'f
          ; visit_IPlus : 'c -> 'f
          ; visit_FPlus : 'c -> 'f
-         ; visit_Pred : 'c -> string -> Expr.t list -> Expr.t list -> 'f
          ; visit_Pure : 'c -> Expr.t -> 'f
          ; visit_Random : 'c -> 'f
          ; visit_ReturnError : 'c -> 'f
@@ -2069,7 +2071,6 @@ module Visitors : sig
     method visit_Pi : 'c -> 'f
     method visit_IPlus : 'c -> 'f
     method visit_FPlus : 'c -> 'f
-    method visit_Pred : 'c -> string -> Expr.t list -> Expr.t list -> 'f
     method visit_Pure : 'c -> Expr.t -> 'f
     method visit_Random : 'c -> 'f
     method visit_ReturnError : 'c -> 'f
@@ -2288,7 +2289,6 @@ module Visitors : sig
          ; visit_PVar : 'c -> string -> unit
          ; visit_PhiAssignment : 'c -> (string * Expr.t list) list -> unit
          ; visit_Pi : 'c -> unit
-         ; visit_Pred : 'c -> string -> Expr.t list -> Expr.t list -> unit
          ; visit_Pure : 'c -> Expr.t -> unit
          ; visit_Random : 'c -> unit
          ; visit_ReturnError : 'c -> unit
@@ -2507,7 +2507,6 @@ module Visitors : sig
     method visit_PVar : 'c -> string -> unit
     method visit_PhiAssignment : 'c -> (string * Expr.t list) list -> unit
     method visit_Pi : 'c -> unit
-    method visit_Pred : 'c -> string -> Expr.t list -> Expr.t list -> unit
     method visit_Pure : 'c -> Expr.t -> unit
     method visit_Random : 'c -> unit
     method visit_ReturnError : 'c -> unit

--- a/GillianCore/GIL_Syntax/Pred.ml
+++ b/GillianCore/GIL_Syntax/Pred.ml
@@ -167,7 +167,9 @@ let check_pvars (predicates : (string, t) Hashtbl.t) : unit =
 let extend_asrt_pred_types (preds : (string, t) Hashtbl.t) (a : Asrt.t) :
     (Asrt.t, string) result =
   let f : Asrt.atom -> (Asrt.t, string) result = function
-    | Asrt.Pred (name, ins, outs) as a ->
+    | Asrt.CorePred (cp_name, ins, outs) as a
+      when Option.is_some (Asrt.as_user_pred_name cp_name) ->
+        let name = Option.get (Asrt.as_user_pred_name cp_name) in
         let les = ins @ outs in
         let* pred =
           match Hashtbl.find_opt preds name with
@@ -282,7 +284,7 @@ let close_token_call (pred : t) : Asrt.atom =
     in_args pred pred.pred_params |> List.map (fun (x, _t) -> Expr.PVar x)
   in
   (* The close token is an all-ins predicate. *)
-  Asrt.Pred (name, args, [])
+  Asrt.pred name args []
 
 (* Given a name, if it's a close_token name, returns the name of the corresponding predicate,
    otherwise return None. *)

--- a/GillianCore/GIL_Syntax/TypeDef__.ml
+++ b/GillianCore/GIL_Syntax/TypeDef__.ml
@@ -155,7 +155,6 @@ and expr =
 
 and assertion_atom =
   | Emp
-  | Pred of string * expr list * expr list
   | Pure of expr
   | Types of (expr * typ) list
   | CorePred of string * expr list * expr list

--- a/GillianCore/debugging/utils/match_map.ml
+++ b/GillianCore/debugging/utils/match_map.ml
@@ -76,7 +76,9 @@ functor
             L.Report_id.pp child_id L.Report_id.pp id type_ Content_type.match_;
         let p =
           match asrt_report.step with
-          | Pred (p, _, _), _ -> p
+          | CorePred (name, _, _), _
+            when Option.is_some (Asrt.as_user_pred_name name) ->
+              Option.get (Asrt.as_user_pred_name name)
           | _ -> assertion
         in
         { id = child_id; kind = Fold p; result = result_of_id child_id }

--- a/GillianCore/engine/Abstraction/LogicPreprocessing.ml
+++ b/GillianCore/engine/Abstraction/LogicPreprocessing.ml
@@ -14,19 +14,35 @@ let rec auto_unfold
     (predicates : (string, Pred.t) Hashtbl.t)
     (rec_tbl : (string, bool) Hashtbl.t)
     (asrt : Asrt.t) : Asrt.t list =
+  let should_not_unfold name =
+    (* We don't unfold:
+       - Recursive predicates (except in some very specific cases)
+       - predicates marked with no-unfold
+       - predicates with a guard *)
+    (Hashtbl.find rec_tbl name && not unfold_rec_predicates)
+    ||
+    let pred = Hashtbl.find predicates name in
+    pred.pred_nounfold || Option.is_some pred.pred_guard
+  in
+  (* The original first arm's guard: a user predicate we must keep folded. *)
+  let must_keep_folded cp_name =
+    match Asrt.as_user_pred_name cp_name with
+    | Some name -> should_not_unfold name
+    | None -> false
+  in
+  (* The original second arm's guard: the assertion is a user predicate. *)
+  let is_user_pred cp_name = Option.is_some (Asrt.as_user_pred_name cp_name) in
+  (* The user predicate has already been unfolded (it is in [unfolded_preds]). *)
+  let is_already_unfolded cp_name =
+    match Asrt.as_user_pred_name cp_name with
+    | Some name -> Hashtbl.mem unfolded_preds name
+    | None -> false
+  in
   asrt
   |> List.map (function
-       (* We don't unfold:
-           - Recursive predicates (except in some very specific cases)
-           - predicates marked with no-unfold
-           - predicates with a guard *)
-       | Asrt.Pred (name, _, _) as asrt
-         when (Hashtbl.find rec_tbl name && not unfold_rec_predicates)
-              ||
-              let pred = Hashtbl.find predicates name in
-              pred.pred_nounfold || Option.is_some pred.pred_guard ->
-           [ [ asrt ] ]
-       | Pred (name, ins, outs) when Hashtbl.mem unfolded_preds name ->
+       | Asrt.CorePred (cp_name, ins, outs) as asrt
+         when (not (must_keep_folded cp_name)) && is_already_unfolded cp_name ->
+           let name = Option.get (Asrt.as_user_pred_name cp_name) in
            let args = ins @ outs in
            L.verbose (fun fmt ->
                fmt "Unfolding predicate: %s with nounfold %b" name
@@ -52,12 +68,13 @@ let rec auto_unfold
              List.map (SVal.SSubst.substitute_asrt subst ~partial:false) defs
            in
            L.tmi (fun m ->
-               m "%a ->\n%a" Asrt.pp_atom
-                 (Asrt.Pred (name, ins, outs))
+               m "%a ->\n%a" Asrt.pp_atom asrt
                  (Fmt.list ~sep:(Fmt.any "\n;\n") Asrt.pp)
                  asrts);
            asrts
-       | Pred (name, ins, outs) as asrt -> (
+       | Asrt.CorePred (cp_name, ins, outs) as asrt
+         when (not (must_keep_folded cp_name)) && is_user_pred cp_name -> (
+           let name = Option.get (Asrt.as_user_pred_name cp_name) in
            let args = ins @ outs in
            try
              L.tmi (fun fmt -> fmt "AutoUnfold: %a : %s" Asrt.pp_atom asrt name);

--- a/GillianCore/engine/Abstraction/MP.ml
+++ b/GillianCore/engine/Abstraction/MP.ml
@@ -529,9 +529,6 @@ let ins_outs_assertion
   | Emp -> []
   | Pure form -> ins_outs_formula kb form
   | CorePred (_, lie, loe) -> ins_and_outs_from_lists kb lie loe
-  | Pred (_p_name, ins, outs) ->
-      (* The in/out split is carried by the assertion's syntax (the [;]). *)
-      ins_and_outs_from_lists kb ins outs
   (* The types assertion has no outs and requires all ins *)
   | Types [ (e, _) ] ->
       let ins = simple_ins_expr e in
@@ -553,7 +550,7 @@ let simplify_asrts ?(sorted = true) a =
     match a with
     | Pure (Lit (Bool true)) | Emp -> []
     | Pure (BinOp (f1, And, f2)) -> aux (Pure f1) @ aux (Pure f2)
-    | Pure _ | Pred _ | CorePred _ | Wand _ -> [ a ]
+    | Pure _ | CorePred _ | Wand _ -> [ a ]
     | Types _ -> (
         let a = Reduction.reduce_assertion [ a ] in
         match a with
@@ -932,7 +929,9 @@ let pp_asrt
     (fmt : Format.formatter)
     (a : Asrt.t) =
   let pp_atom_asrt fmt = function
-    | Asrt.Pred (name, ins, outs) -> (
+    | Asrt.CorePred (cp_name, ins, outs)
+      when Option.is_some (Asrt.as_user_pred_name cp_name) -> (
+        let name = Option.get (Asrt.as_user_pred_name cp_name) in
         let args = ins @ outs in
         match preds_printer with
         | Some pp_pred -> (Fmt.hbox pp_pred) fmt (name, args)

--- a/GillianCore/engine/Abstraction/Matcher.ml
+++ b/GillianCore/engine/Abstraction/Matcher.ml
@@ -567,7 +567,8 @@ module Make (State : SState.S) :
     | Emp ->
         L.verbose (fun fmt -> fmt "Emp assertion.");
         [ Ok astate ]
-    | CorePred (a_id, ins, outs) ->
+    | CorePred (a_id, ins, outs)
+      when Option.is_none (Asrt.as_user_pred_name a_id) ->
         L.verbose (fun fmt -> fmt "Memory producer.");
 
         let vs = List.map (subst_in_expr subst) (ins @ outs) in
@@ -594,7 +595,8 @@ module Make (State : SState.S) :
         match state' with
         | None -> []
         | Some _ -> [ Ok { state; preds; wands; pred_defs } ])
-    | Pred (pname, ins, outs) ->
+    | CorePred (cp_name, ins, outs) ->
+        let pname = Option.get (Asrt.as_user_pred_name cp_name) in
         L.verbose (fun fmt -> fmt "Predicate assertion.");
         let les = ins @ outs in
         let vs = List.map (subst_in_expr subst) les in
@@ -1235,7 +1237,8 @@ module Make (State : SState.S) :
         let open Res_list.Syntax in
         let res_list =
           match (p : Asrt.atom) with
-          | CorePred (a_id, e_ins, e_outs) -> (
+          | CorePred (a_id, e_ins, e_outs)
+            when Option.is_none (Asrt.as_user_pred_name a_id) -> (
               let vs_ins = List.map (subst_in_expr_opt astate subst) e_ins in
               let failure = List.exists (fun x -> x = None) vs_ins in
               if failure then (
@@ -1262,7 +1265,8 @@ module Make (State : SState.S) :
                     let error = StateErr.EAsrt ([], fail_pf) in
                     Res_list.error_with error
                 | Vanish -> Res_list.vanish)
-          | Pred (pname, ins, outs) ->
+          | CorePred (cp_name, ins, outs) ->
+              let pname = Option.get (Asrt.as_user_pred_name cp_name) in
               let les = ins @ outs in
               L.verbose (fun m -> m "Matching predicate assertion");
               (* Perform substitution in all predicate parameters *)
@@ -1856,8 +1860,8 @@ module Make (State : SState.S) :
       if pred.pred_abstract || Option.is_some pred.pred_guard then
         [
           [
-            Asrt.Pred
-              (pred.pred_name, Pred.in_args pred largs, Pred.out_args pred largs);
+            Asrt.pred pred.pred_name (Pred.in_args pred largs)
+              (Pred.out_args pred largs);
           ];
         ]
       else
@@ -1947,7 +1951,9 @@ module Make (State : SState.S) :
         split_answer option =
       let open Syntaxes.Option in
       match (step, errs) with
-      | (Pred (name, ins, outs), _), _ ->
+      | (CorePred (cp_name, ins, outs), _), _
+        when Option.is_some (Asrt.as_user_pred_name cp_name) ->
+          let name = Option.get (Asrt.as_user_pred_name cp_name) in
           let MP.{ pred; def_mp; _ } = MP.get_pred_def astate.pred_defs name in
           let* () =
             if pred.pred_abstract || Option.is_some pred.pred_guard then None

--- a/GillianCore/engine/Abstraction/Normaliser.ml
+++ b/GillianCore/engine/Abstraction/Normaliser.ml
@@ -492,14 +492,16 @@ module Make (SPState : PState.S) = struct
     List.fold_left
       (fun (core_asrts, pure, types, preds, wands) (a : Asrt.atom) ->
         match a with
-        | CorePred (a, es1, es2) ->
-            ((a, es1, es2) :: core_asrts, pure, types, preds, wands)
+        | CorePred (cp_name, es1, es2) -> (
+            match Asrt.as_user_pred_name cp_name with
+            | Some name ->
+                (core_asrts, pure, types, (name, es1 @ es2) :: preds, wands)
+            | None ->
+                ((cp_name, es1, es2) :: core_asrts, pure, types, preds, wands))
         | Wand { lhs; rhs } ->
             (core_asrts, pure, types, preds, Wands.{ lhs; rhs } :: wands)
         | Emp -> (core_asrts, pure, types, preds, wands)
         | Types lst -> (core_asrts, pure, lst @ types, preds, wands)
-        | Pred (name, ins, outs) ->
-            (core_asrts, pure, types, (name, ins @ outs) :: preds, wands)
         | Pure f -> (core_asrts, f :: pure, types, preds, wands))
       ([], [], [], [], []) a
 

--- a/GillianCore/engine/Abstraction/Preds.ml
+++ b/GillianCore/engine/Abstraction/Preds.ml
@@ -231,6 +231,6 @@ let to_assertions
   let preds = to_list preds in
   let pred_to_assert (n, args) =
     let ins, outs = split_ins_outs n args in
-    Asrt.Pred (n, ins, outs)
+    Asrt.pred n ins outs
   in
   List.sort Asrt.compare (List.map pred_to_assert preds)

--- a/GillianCore/engine/Abstraction/Verifier.ml
+++ b/GillianCore/engine/Abstraction/Verifier.ml
@@ -683,7 +683,12 @@ struct
     object
       inherit [_] Visitors.reduce
       inherit Visitors.Utils.ss_monoid
-      method! visit_Pred _ pred_name _ _ = SS.singleton pred_name
+
+      method! visit_CorePred _ name _ _ =
+        match Asrt.as_user_pred_name name with
+        | Some pred_name -> SS.singleton pred_name
+        | None -> SS.empty
+
       method! visit_Fold _ pred_name _ _ = SS.singleton pred_name
       method! visit_Unfold _ pred_name _ _ _ = SS.singleton pred_name
       method! visit_GUnfold _ pred_name = SS.singleton pred_name

--- a/GillianCore/engine/BiAbduction/BiState.ml
+++ b/GillianCore/engine/BiAbduction/BiState.ml
@@ -201,10 +201,11 @@ module Make (State : SState.S) = struct
                    | Some s -> State.assume_t s e t)
                  (Some this_state)
             |> Option.to_list
-        | CorePred (corepred, ins, outs) ->
-            State.produce_core_pred corepred this_state (ins @ outs)
-        | Wand _ -> raise (Failure "DEATH. fix_list_apply wand")
-        | Pred _ -> raise (Failure "DEATH. fix_list_apply pred"))
+        | CorePred (corepred, ins, outs) -> (
+            match Asrt.as_user_pred_name corepred with
+            | Some _ -> raise (Failure "DEATH. fix_list_apply pred")
+            | None -> State.produce_core_pred corepred this_state (ins @ outs))
+        | Wand _ -> raise (Failure "DEATH. fix_list_apply wand"))
       [ s ] asrt
 
   type post_res = (Flag.t * Asrt.t list) option

--- a/GillianCore/engine/FOLogic/Reduction.ml
+++ b/GillianCore/engine/FOLogic/Reduction.ml
@@ -2881,9 +2881,6 @@ let reduce_assertion_loop
               rhs = (rname, List.map fe rargs);
             };
         ]
-    (* Predicates *)
-    | Pred (name, ins, outs) ->
-        [ Pred (name, List.map fe ins, List.map fe outs) ]
     (* Pure assertions *)
     | Pure (Lit (Bool true)) -> []
     | Pure (BinOp (f1, BinOp.And, f2)) -> [ Pure f1; Pure f2 ]

--- a/GillianCore/gil_parser/GIL_Parser.mly
+++ b/GillianCore/gil_parser/GIL_Parser.mly
@@ -844,7 +844,7 @@ g_assertion_target:
   | pcall = predicate_call
     {
       let (name, ins, outs) = pcall in
-      [ Asrt.Pred (name, ins, outs) ]
+      [ Asrt.pred name ins outs ]
     }
 (* types (type_pairs) *)
   | LTYPES; LBRACE; type_pairs = separated_list(COMMA, type_env_pair_target); RBRACE

--- a/wisl/lib/ParserAndCompiler/wisl2Gil.ml
+++ b/wisl/lib/ParserAndCompiler/wisl2Gil.ml
@@ -204,8 +204,7 @@ let rec compile_lexpr ?(fname = "main") (lexpr : WLExpr.t) :
         let gvars1, asrtl1, comp_expr1 = compile_lexpr e1 in
         let gvars2, asrtl2, comp_expr2 = compile_lexpr e2 in
         let pred_i_plus =
-          Asrt.Pred
-            (internal_pred, [ comp_expr1; comp_expr2 ], [ Expr.LVar lout ])
+          Asrt.pred internal_pred [ comp_expr1; comp_expr2 ] [ Expr.LVar lout ]
         in
         ( gvars1 @ gvars2 @ [ lout ],
           asrtl1 @ asrtl2 @ [ pred_i_plus ],
@@ -355,7 +354,7 @@ let rec compile_lassert ?(fname = "main") asser : string list * Asrt.t =
       in
       let exs = List.concat (exsl_in @ exsl_out) in
       let al = List.concat (all_in @ all_out) in
-      (exs, Asrt.Pred (pr, el_in, el_out) :: al)
+      (exs, Asrt.pred pr el_in el_out :: al)
   | LWand { lhs = lname, largs; rhs = rname, rargs } ->
       let exs1, al1, el1 = list_split_3 (List.map compile_lexpr largs) in
       let exs2, al2, el2 = list_split_3 (List.map compile_lexpr rargs) in

--- a/wisl/lib/state_ex/wislLifter.ml
+++ b/wisl/lib/state_ex/wislLifter.ml
@@ -1345,23 +1345,26 @@ struct
     let open Asrt in
     function
     | Emp -> Fmt.pf ft "emp"
-    | Pred (name, ins, outs) ->
-        Fmt.pf ft "%s(%a; %a)" name (pp_comma_sep pp_expr) ins
-          (pp_comma_sep pp_expr) outs
     | Types tls ->
         let pp_tl ft (e, t) = Fmt.pf ft "%a : %s" pp_expr e (Type.str t) in
         Fmt.pf ft "%a" (pp_comma_sep pp_tl) tls
     | Pure e -> Fmt.pf ft "%a" pp_expr e
     | CorePred (a, ins, outs) -> (
-        match (WislLActions.ga_from_str a, ins, outs) with
-        | Some Cell, [ loc; offset ], [ value ] ->
-            Fmt.pf ft "[%a, %a] -> %a" pp_expr loc pp_expr offset pp_expr value
-        | Some Bound, [ loc ], [ bound ] ->
-            Fmt.pf ft "%a has bound %a" pp_expr loc pp_expr bound
-        | Some Freed, [ loc ], [] -> Fmt.pf ft "%a is freed" pp_expr loc
-        | _ ->
-            Fmt.pf ft "%s(%a, %a)" a (pp_comma_sep pp_expr) ins
-              (pp_comma_sep pp_expr) outs)
+        match Asrt.as_user_pred_name a with
+        | Some name ->
+            Fmt.pf ft "%s(%a; %a)" name (pp_comma_sep pp_expr) ins
+              (pp_comma_sep pp_expr) outs
+        | None -> (
+            match (WislLActions.ga_from_str a, ins, outs) with
+            | Some Cell, [ loc; offset ], [ value ] ->
+                Fmt.pf ft "[%a, %a] -> %a" pp_expr loc pp_expr offset pp_expr
+                  value
+            | Some Bound, [ loc ], [ bound ] ->
+                Fmt.pf ft "%a has bound %a" pp_expr loc pp_expr bound
+            | Some Freed, [ loc ], [] -> Fmt.pf ft "%a is freed" pp_expr loc
+            | _ ->
+                Fmt.pf ft "%s(%a, %a)" a (pp_comma_sep pp_expr) ins
+                  (pp_comma_sep pp_expr) outs))
     | Wand { lhs = lname, largs; rhs = rname, rargs } ->
         Fmt.pf ft "%s(%a) -* %s(%a)" lname (pp_comma_sep pp_expr) largs rname
           (pp_comma_sep pp_expr) rargs

--- a/wisl/lib/state_frac/wislLifter.ml
+++ b/wisl/lib/state_frac/wislLifter.ml
@@ -1296,23 +1296,26 @@ struct
     let open Asrt in
     function
     | Emp -> Fmt.pf ft "emp"
-    | Pred (name, ins, outs) ->
-        Fmt.pf ft "%s(%a; %a)" name (pp_comma_sep pp_expr) ins
-          (pp_comma_sep pp_expr) outs
     | Types tls ->
         let pp_tl ft (e, t) = Fmt.pf ft "%a : %s" pp_expr e (Type.str t) in
         Fmt.pf ft "%a" (pp_comma_sep pp_tl) tls
     | Pure e -> Fmt.pf ft "%a" pp_expr e
     | CorePred (a, ins, outs) -> (
-        match (WislLActions.ga_from_str a, ins, outs) with
-        | Some Cell, [ loc; offset ], [ value ] ->
-            Fmt.pf ft "[%a, %a] -> %a" pp_expr loc pp_expr offset pp_expr value
-        | Some Bound, [ loc ], [ bound ] ->
-            Fmt.pf ft "%a has bound %a" pp_expr loc pp_expr bound
-        | Some Freed, [ loc ], [] -> Fmt.pf ft "%a is freed" pp_expr loc
-        | _ ->
-            Fmt.pf ft "%s(%a, %a)" a (pp_comma_sep pp_expr) ins
-              (pp_comma_sep pp_expr) outs)
+        match Asrt.as_user_pred_name a with
+        | Some name ->
+            Fmt.pf ft "%s(%a; %a)" name (pp_comma_sep pp_expr) ins
+              (pp_comma_sep pp_expr) outs
+        | None -> (
+            match (WislLActions.ga_from_str a, ins, outs) with
+            | Some Cell, [ loc; offset ], [ value ] ->
+                Fmt.pf ft "[%a, %a] -> %a" pp_expr loc pp_expr offset pp_expr
+                  value
+            | Some Bound, [ loc ], [ bound ] ->
+                Fmt.pf ft "%a has bound %a" pp_expr loc pp_expr bound
+            | Some Freed, [ loc ], [] -> Fmt.pf ft "%a is freed" pp_expr loc
+            | _ ->
+                Fmt.pf ft "%s(%a, %a)" a (pp_comma_sep pp_expr) ins
+                  (pp_comma_sep pp_expr) outs))
     | Wand { lhs = lname, largs; rhs = rname, rargs } ->
         Fmt.pf ft "%s(%a) -* %s(%a)" lname (pp_comma_sep pp_expr) largs rname
           (pp_comma_sep pp_expr) rargs


### PR DESCRIPTION
Based on #380, look only at the last commit if you're reviewing this before we merge the others.

The core of this PR is this diff:
```diff
	type atom = TypeDef__.assertion_atom =
	  | Emp  (** Empty heap *)
-	  | Pred of string * Expr.t list * Expr.t list  (** Predicates *)
      | Pure of Expr.t  (** Pure formula *)
	  | Types of (Expr.t * Type.t) list  (** Typing assertion *)
	  | CorePred of string * Expr.t list * Expr.t list  (** Core assertion *)
	  | Wand of { lhs : string * Expr.t list; rhs : string * Expr.t list }
	      (** Magic wand of the form [P(...) -* Q(...)] *)
 ```
 
 Instead, predicates are now represented as core predicates that start with a magic string `GILLIAN_USER_PRED__pred_name`.
This does not change the instantiations of Gillian (except for compiling user-defined predicates which do that compilation correctly). Similarly, the GIL parser still parses and produces the old version of the code.