### PR TITLE
Drive-by: kill shift-reduce conflicts

### DIFF
--- a/Gillian-C/lib/annot_parser.mly
+++ b/Gillian-C/lib/annot_parser.mly
@@ -122,21 +122,34 @@
 (* NOps *)
 %token SETUNION
 
-(* Precedence *)
+(* Precedence.
+   Expression operators use standard arithmetic precedence.  The formula
+   connectives (=> || && not) sit below the comparison operators
+   (== <# <=# --e--), which in turn sit below every expression operator, so
+   that the operands of a comparison or points-to greedily absorb arithmetic
+   (e.g. [x -> a + b] is [x -> (a+b)]).  [low_prec] is the (lowest) precedence
+   given to the comparison, points-to-constructor and [formula -> assertion]
+   coercion productions; keeping it below [RBRACE] resolves the harmless
+   ambiguity of a parenthesised pure assertion in favour of the parentheses.
+   [DOT] is the lowest of all, so a quantifier body extends as far right as
+   possible.  Note that [*] (STAR) is overloaded: it is arithmetic
+   multiplication inside an expression and separating conjunction between
+   (closed) assertions; both uses share this single, high precedence. *)
 %nonassoc DOT
-
-%left IMPLIES
-%left STAR
+%nonassoc low_prec LEQ LLT LLEQ LSETMEM
+%nonassoc RBRACE
+%right IMPLIES
+%left LOR
+%left LAND
 %nonassoc LNOT
-
-%nonassoc EQ
-%nonassoc SETSUB
+%left OR
+%left AND
+%nonassoc EQ LT SETMEM SETSUB
 %left SETDIFF
 %nonassoc LSTCONS
 %left LSTCAT
-%left PLUS
-
-%nonassoc binop_prec
+%left PLUS MINUS
+%left STAR DIV PTRPLUS
 %nonassoc unop_prec
 
 %start <CLogic.CProg.t> prog
@@ -351,7 +364,7 @@ assertion:
     let ptr = CExpr.SExpr (String v) in
     CAssert.PointsTo { ptr; constr=cs; typ=Global }
   }
-  | f = formula { CAssert.Pure f }
+  | f = formula { CAssert.Pure f } %prec low_prec
   | ZEROS; LBRACE; ptr = expression; COMMA; size = expression; RBRACE
     { CAssert.Zeros(ptr, size) }
   | ARRAY; LBRACE; ptr = expression; COMMA; chunk = typ; COMMA;  size = expression; COMMA; content = expression; RBRACE
@@ -410,7 +423,7 @@ constructor:
     el = separated_nonempty_list(SCOLON, expression); RCBRACE
     { Constructor.ConsTyp (id, el) } */
   | e = expression
-    { CConstructor.ConsExpr e }
+    { CConstructor.ConsExpr e } %prec low_prec
 
 
 expression:
@@ -421,7 +434,7 @@ expression:
     { CExpr.EList el }
   | NIL { CExpr.EList [] }
   | e1 = expression; b = binop; e2 = expression
-    { CExpr.BinOp (e1, b, e2) } %prec binop_prec
+    { CExpr.BinOp (e1, b, e2) }
   | u = unop; e = expression
     { CExpr.UnOp (u, e) } %prec unop_prec
   | SETOP; el = separated_list(COMMA, expression); SETCL
@@ -459,7 +472,10 @@ simple_expr:
   | loc = LOC { CSimplExpr.Loc loc }
   | str = STRING { CSimplExpr.String str}
 
-binop:
+(* Inlined so that each [e1 op e2] production inherits the precedence of its
+   operator token (see the precedence table above), instead of the old flat
+   [%prec binop_prec]. *)
+%inline binop:
   | LSTCONS { CBinOp.LstCons }
   | LSTCAT  { CBinOp.LstCat }
   | PLUS    { CBinOp.Plus }

--- a/Gillian-C2/lib/compiler/c2_annot_parser.mly
+++ b/Gillian-C2/lib/compiler/c2_annot_parser.mly
@@ -132,21 +132,34 @@
 (* NOps *)
 %token SETUNION
 
-(* Precedence *)
+(* Precedence.
+   Expression operators use standard arithmetic precedence.  The formula
+   connectives (=> || && not) sit below the comparison operators
+   (== <# <=# --e--), which in turn sit below every expression operator, so
+   that the operands of a comparison or points-to greedily absorb arithmetic
+   (e.g. [x -> a + b] is [x -> (a+b)]).  [low_prec] is the (lowest) precedence
+   given to the comparison, points-to-constructor and [formula -> assertion]
+   coercion productions; keeping it below [RBRACE] resolves the harmless
+   ambiguity of a parenthesised pure assertion in favour of the parentheses.
+   [DOT] is the lowest of all, so a quantifier body extends as far right as
+   possible.  Note that [*] (STAR) is overloaded: it is arithmetic
+   multiplication inside an expression and separating conjunction between
+   (closed) assertions; both uses share this single, high precedence. *)
 %nonassoc DOT
-
-%left IMPLIES
-%left STAR
+%nonassoc low_prec LEQ LLT LLEQ LSETMEM
+%nonassoc RBRACE
+%right IMPLIES
+%left LOR
+%left LAND
 %nonassoc LNOT
-
-%nonassoc EQ
-%nonassoc SETSUB
+%left OR
+%left AND
+%nonassoc EQ LT SETMEM SETSUB
 %left SETDIFF
 %nonassoc LSTCONS
 %left LSTCAT
-%left PLUS
-
-%nonassoc binop_prec
+%left PLUS MINUS
+%left STAR DIV PTRPLUS
 %nonassoc unop_prec
 
 %start <CProg.t> prog
@@ -361,7 +374,7 @@ assertion:
     let ptr = CExpr.SExpr (String v) in
     CAssert.PointsTo { ptr; constr=cs; typ=Global }
   }
-  | f = formula { CAssert.Pure f }
+  | f = formula { CAssert.Pure f } %prec low_prec
   | ZEROS; LBRACE; ptr = expression; COMMA; size = expression; RBRACE
     { CAssert.Zeros(ptr, size) }
   | ARRAY; LBRACE; ptr = expression; COMMA; chunk = typ; COMMA;  size = expression; COMMA; content = expression; RBRACE
@@ -419,7 +432,7 @@ constructor:
     el = separated_nonempty_list(SCOLON, expression); RCBRACE
     { Constructor.ConsTyp (id, el) } */
   | e = expression
-    { CConstructor.ConsExpr e }
+    { CConstructor.ConsExpr e } %prec low_prec
 
 
 expression:
@@ -430,7 +443,7 @@ expression:
     { CExpr.EList el }
   | NIL { CExpr.EList [] }
   | e1 = expression; b = binop; e2 = expression
-    { CExpr.BinOp (e1, b, e2) } %prec binop_prec
+    { CExpr.BinOp (e1, b, e2) }
   | u = unop; e = expression
     { CExpr.UnOp (u, e) } %prec unop_prec
   | SETOP; el = separated_list(COMMA, expression); SETCL
@@ -468,7 +481,10 @@ simple_expr:
   | loc = LOC { CSimplExpr.Loc loc }
   | str = STRING { CSimplExpr.String str}
 
-binop:
+(* Inlined so that each [e1 op e2] production inherits the precedence of its
+   operator token (see the precedence table above), instead of the old flat
+   [%prec binop_prec]. *)
+%inline binop:
   | LSTCONS { CBinOp.LstCons }
   | LSTCAT  { CBinOp.LstCat }
   | PLUS    { CBinOp.Plus }

--- a/Gillian-JS/lib/Parsing/Javert_Parser.mly
+++ b/Gillian-JS/lib/Parsing/Javert_Parser.mly
@@ -232,6 +232,14 @@ let normalised_lvar_r = Str.regexp "##NORMALISED_LVAR"
 
 (***** Precedence of operators *****)
 (* The later an operator is listed, the higher precedence it is given. *)
+(* [coerce_prec] is the (lowest) precedence of the [pure -> assertion]
+   coercion; making it lower than [RBRACE] resolves the (harmless) ambiguity
+   of a parenthesised pure assertion in favour of the pure-assertion
+   parentheses. [ISINT] is given a very low precedence so that its expression
+   argument binds as much as possible (i.e. [is-int a + b] is [is-int (a+b)]). *)
+%nonassoc coerce_prec
+%nonassoc RBRACE
+%nonassoc ISINT
 (* Logic operators have lower precedence *)
 %nonassoc DOT
 %left LOR
@@ -256,7 +264,6 @@ let normalised_lvar_r = Str.regexp "##NORMALISED_LVAR"
 %left TIMES DIV MOD M_POW
 %left M_ATAN2 STRCAT SETDIFF
 
-%nonassoc binop_prec
 %nonassoc unop_prec
 
 (* Common *)
@@ -371,7 +378,11 @@ unop_target:
   | INTTONUM    { UnOp.IntToNum }
   | NUMTOINT    { UnOp.NumToInt }
 
-binop_target:
+(* Inlined so that each [e1 op e2] production inherits the precedence of its
+   operator token, letting the precedence table above disambiguate expressions
+   (instead of the old [%prec binop_prec] which forced a flat left-associative
+   parse regardless of operator). *)
+%inline binop_target:
   | EQUAL              { BinOp.Equal }
   | LESSTHAN           { BinOp.FLessThan }
   | LESSTHANEQUAL      { BinOp.FLessThanEqual }
@@ -410,7 +421,7 @@ expr_target:
   }
   | ALOC { Expr.ALoc $1 }
   | v = VAR { Expr.PVar v }
-  | e1=expr_target; bop=binop_target; e2=expr_target { Expr.BinOp (e1, bop, e2) } %prec binop_prec
+  | e1=expr_target; bop=binop_target; e2=expr_target { Expr.BinOp (e1, bop, e2) }
   | e1=expr_target; LSTCONS; e2=expr_target { Expr.NOp (LstCat, [ EList [ e1 ]; e2 ]) }
   | e1=expr_target; GREATERTHAN;  e2=expr_target { Expr.BinOp (e2, FLessThan, e1) }
   | e1=expr_target; GREATERTHANEQUAL; e2=expr_target { Expr.BinOp (e2, FLessThanEqual, e1) }
@@ -508,7 +519,7 @@ assertion_target:
   | LBRACE; ass=assertion_target; RBRACE
     { ass }
   | f = pure_assertion_target
-    { Asrt.Pure f }
+    { Asrt.Pure f } %prec coerce_prec
 
 /* COMMANDS */
 
@@ -948,7 +959,7 @@ js_lexpr_target:
     { JSExpr.LVar lvar }
 (* e binop e *)
   | e1=js_lexpr_target; bop=binop_target; e2=js_lexpr_target
-    { JSExpr.BinOp (e1, bop, e2) } %prec binop_prec
+    { JSExpr.BinOp (e1, bop, e2) }
 (* List cons *)
   | e1=js_lexpr_target; LSTCONS; e2=js_lexpr_target { JSExpr.NOp (LstCat, [ EList [ e1 ]; e2 ]) }
 (* unop e *)
@@ -1054,7 +1065,7 @@ js_pure_assertion_target:
 js_assertion_target:
 (* Pure *)
   | f = js_pure_assertion_target
-    { JSAsrt.Pure f }
+    { JSAsrt.Pure f } %prec coerce_prec
 (* P * Q *)
 (* The precedence of the separating conjunction is not the same as the arithmetic product *)
   | left_ass=js_assertion_target; TIMES; right_ass=js_assertion_target

--- a/GillianCore/gil_parser/GIL_Parser.mly
+++ b/GillianCore/gil_parser/GIL_Parser.mly
@@ -255,24 +255,12 @@ let normalised_lvar_r = Str.regexp "##NORMALISED_LVAR"
 %token EOF
 
 (***** Precedence of operators *****)
-(* The later an operator is listed, the higher precedence it is given. *)
-(* Logic operators have lower precedence *)
-(* Program operators have higher precedence.*)
-(* Based on JavaScript:
-   https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Operator_Precedence *)
-%nonassoc DOT
-%left separating_conjunction
-%left LIMPLIES
-%left OR, LOR
-%left AND, LAND
-%nonassoc EQ
-%nonassoc FLT FLE FGT FGE ILT ILE IGT IGE SLT
-%left LEFTSHIFT SIGNEDRIGHTSHIFT UNSIGNEDRIGHTSHIFT LEFTSHIFTL SIGNEDRIGHTSHIFTL UNSIGNEDRIGHTSHIFTL
-%left BITWISEOR BITWISEXOR BITWISEAND BITWISEXORL BITWISEORL BITWISEANDL
-%left FPLUS FMINUS IPLUS IMINUS
-%left FTIMES FDIV FMOD ITIMES IDIV IMOD M_POW
-%left M_ATAN2 STRCAT SETDIFF
-%nonassoc SETMEM SETSUB
+(* Expression operator precedence is enforced structurally, through the
+   layered cascade of expression rules (atomic_expr_target, unary_expr,
+   set_op_expr, ..., implication_expr), so no precedence declarations are
+   needed for them. The only precedence still required is that of the
+   separating conjunction, which is left-associative. *)
+%left separating_conjunction FTIMES
 
 (***** Types and entry points *****)
 %type <Literal.t>    lit_target
@@ -298,12 +286,15 @@ let normalised_lvar_r = Str.regexp "##NORMALISED_LVAR"
 (********* Common Stuff *********)
 (********************************)
 
-import_target:
-  IMPORT; imports = separated_nonempty_list(COMMA, STRING); SCOLON { imports }
-;
-
-import_verify_target:
-  IMPORT; VERIFY; imports = separated_nonempty_list(COMMA, STRING); SCOLON { imports }
+(* A single import line, either normal ([import "a", "b";]) or to-verify
+   ([import verify "c";]). Merging both into one rule (disambiguated by the
+   token following [import]) avoids the shift/reduce conflict that arose from
+   having two separately-optional import sections both starting with [import]. *)
+import_line_target:
+  | IMPORT; imports = separated_nonempty_list(COMMA, STRING); SCOLON
+    { List.map (fun path -> (path, false)) imports }
+  | IMPORT; VERIFY; imports = separated_nonempty_list(COMMA, STRING); SCOLON
+    { List.map (fun path -> (path, true)) imports }
 ;
 
 proc_name:
@@ -415,10 +406,6 @@ atomic_expr_target:
 (* Ignore variable *)
   | UNDERSCORE
     { Expr.LVar (LVar.alloc ()) }
-  | EXISTS; vars = separated_nonempty_list(COMMA, lvar_type_target); DOT; e = expr_target
-    { Expr.Exists (vars, e) }
-  | LFORALL; vars = separated_nonempty_list(COMMA, lvar_type_target); DOT; e = expr_target
-    { Expr.ForAll (vars, e) }
 ;
 
 unary_expr:
@@ -549,8 +536,20 @@ implication_expr:
   | e1 = implication_expr; LIMPLIES; e2 = or_expr
     { Expr.BinOp (e1, Impl, e2) }
 
+(* Quantifiers bind the loosest: their body extends as far to the right as
+   possible. They live above the operator-precedence cascade, so a bare
+   quantifier is only accepted at the top of an expression (or, as everywhere
+   else, when parenthesised). *)
+quantified_expr:
+  | implication_expr { $1 }
+  | EXISTS; vars = separated_nonempty_list(COMMA, lvar_type_target); DOT; e = quantified_expr
+    { Expr.Exists (vars, e) }
+  | LFORALL; vars = separated_nonempty_list(COMMA, lvar_type_target); DOT; e = quantified_expr
+    { Expr.ForAll (vars, e) }
+;
+
 expr_target:
-    implication_expr { $1 }
+    quantified_expr { $1 }
 ;
 
 top_level_expr_target:
@@ -574,20 +573,14 @@ var_and_var_target:
 gmain_target:
   init_data = option(INIT_DATA);
   internal = option(INTERNAL_FILE);
-  imports = option(import_target);
-  imports_to_verify = option(import_verify_target);
+  imports = list(import_line_target);
   g_prog = gdeclaration_target;
   EOF
     {
       internal_file := Option.is_some internal;
       let init_data = Option.value init_data ~default:`Null in
-      let imports = List.map (fun path -> (path, false))
-        (Option.value ~default:[] imports)
-      in
-      let imports_to_verify = List.map (fun path -> (path, true))
-        (Option.value ~default:[] imports_to_verify)
-      in
-      (Prog.update_imports g_prog (imports @ imports_to_verify), init_data);
+      let imports = List.concat imports in
+      (Prog.update_imports g_prog imports, init_data);
     }
 ;
 

--- a/wisl/lib/ParserAndCompiler/WParser.mly
+++ b/wisl/lib/ParserAndCompiler/WParser.mly
@@ -81,8 +81,19 @@
 %token <CodeLoc.t> EMP LSTNIL
 %token <CodeLoc.t * string> LVAR
 
-(* Precedence *)
+(* Precedence.
+   [separating_conjunction] is the lowest: the assertion [*] combines whole
+   assertions.  [coerce_prec] is the precedence of the bare
+   [logic_expression -> assertion] coercion; keeping it below [RBRACE] makes a
+   parenthesised pure expression parse as an expression (and then coerce)
+   rather than ambiguously as an assertion.  [*] (TIMES) is separating
+   conjunction in the logic and is *not* an expression operator there (logic
+   expressions never multiply), so a bare pure expression followed by [*]
+   reduces to an assertion and the [*] separates.  Expression operators
+   otherwise use standard arithmetic precedence. *)
 %left separating_conjunction
+%nonassoc coerce_prec
+%nonassoc RBRACE
 %left OR
 %left AND
 %nonassoc EQUAL NEQ
@@ -91,8 +102,7 @@
 %left LSTCAT
 %left PLUS MINUS FPLUS FMINUS
 %left TIMES DIV MOD FTIMES FDIV FMOD
-
-%nonassoc binop_prec
+%nonassoc LSTNTH
 %nonassoc unop_prec
 
 (* Types and start *)
@@ -402,14 +412,22 @@ expression:
     { let bare_expr = WExpr.BinOp (e1, b, e2) in
       let lstart, lend = WExpr.get_loc e1, WExpr.get_loc e2 in
       let loc = CodeLoc.merge lstart lend in
-      WExpr.make bare_expr loc } %prec binop_prec
+      WExpr.make bare_expr loc }
+  (* [*] is only multiplication in program expressions (there is no separating
+     conjunction here), so it lives with the other binops. It is kept out of
+     [binop] because in the logic [*] means separating conjunction. *)
+  | e1 = expression; TIMES; e2 = expression
+    { let bare_expr = WExpr.BinOp (e1, WBinOp.TIMES, e2) in
+      let lstart, lend = WExpr.get_loc e1, WExpr.get_loc e2 in
+      let loc = CodeLoc.merge lstart lend in
+      WExpr.make bare_expr loc }
   | e1 = expression; NEQ; e2 = expression
     { let bare_expr = WExpr.BinOp (e1, EQUAL, e2) in
       let lstart, lend = WExpr.get_loc e1, WExpr.get_loc e2 in
       let loc = CodeLoc.merge lstart lend in
       let expr = WExpr.make bare_expr loc in
       let bare_expr = WExpr.UnOp (NOT, expr) in
-      WExpr.make bare_expr loc } %prec binop_prec
+      WExpr.make bare_expr loc }
   | lu = unop_with_loc; e = expression
     { let (lstart, u) = lu in
       let bare_expr = WExpr.UnOp (u, e) in
@@ -417,7 +435,11 @@ expression:
       let loc = CodeLoc.merge lstart lend in
       WExpr.make bare_expr loc } %prec unop_prec
 
-binop:
+(* Inlined so each [e1 op e2] production inherits the precedence of its
+   operator token (see the precedence table above).  [TIMES] is deliberately
+   absent: in the logic it is separating conjunction, and in program
+   expressions it is handled by a dedicated production. *)
+%inline binop:
   | EQUAL         { WBinOp.EQUAL }
   | LESSTHAN      { WBinOp.LESSTHAN }
   | GREATERTHAN   { WBinOp.GREATERTHAN }
@@ -429,7 +451,6 @@ binop:
   | FGREATEREQUAL { WBinOp.FGREATEREQUAL }
   | PLUS          { WBinOp.PLUS }
   | MINUS         { WBinOp.MINUS }
-  | TIMES         { WBinOp.TIMES }
   | DIV           { WBinOp.DIV }
   | MOD           { WBinOp.MOD }
   | FPLUS         { WBinOp.FPLUS }
@@ -601,10 +622,6 @@ wand:
     }
 
 logic_assertion_top_level:
-  | formula = logic_expression;
-    { let bare_assert = WLAssert.LPure formula in
-      let loc = WLExpr.get_loc formula in
-      WLAssert.make bare_assert loc }
   | la = logic_assertion; { la }
 
 logic_expression_with_permission:
@@ -621,9 +638,15 @@ logic_assertion:
   | wand = wand
     { let (lhs, rhs, loc) = wand in
       WLAssert.make (LWand { lhs; rhs }) loc }
+  (* A predicate call with an explicit in/out separator [;].  The
+     semicolon-less form [p(a, b)] is instead parsed as a pure-function
+     application (a [logic_expression]) and turned into an (all-in) predicate
+     call by the coercion below; this avoids an unresolvable reduce/reduce
+     conflict between predicate calls and pure-function applications. *)
   | lpr = IDENTIFIER; LBRACE;
     ins = separated_list(COMMA, logic_expression);
-    outs = outs(logic_expression);
+    SCOLON;
+    outs = separated_list(COMMA, logic_expression);
     lend = RBRACE
     { let (lstart, pr) = lpr in
       let bare_assert = WLAssert.LPred (pr, ins, outs) in
@@ -661,26 +684,24 @@ logic_assertion:
       let lend = get_lend le2 in
       let loc = CodeLoc.merge lstart lend in
       WLAssert.make bare_assert loc }
-  | lstart = LBRACE; formula = logic_expression; lend = RBRACE;
-    { let bare_assert = WLAssert.LPure formula in
-      let loc = CodeLoc.merge lstart lend in
-      WLAssert.make bare_assert loc }
-  | loc = TRUE
-    { let bare_lexpr = WLExpr.LVal (WVal.Bool true) in
-      let lexpr = WLExpr.make bare_lexpr loc in
-      let bare_assert = WLAssert.LPure lexpr in
-      WLAssert.make bare_assert loc }
-  | loc = FALSE
-    { let bare_lexpr = WLExpr.LVal (WVal.Bool false) in
-      let lexpr = WLExpr.make bare_lexpr loc in
-      let bare_assert = WLAssert.LPure lexpr in
-      WLAssert.make bare_assert loc }
   | e = logic_expression; COLON; ty = type_target
     { let (ty, lend) = ty in
       let bare_assert = WLAssert.LType (e, ty) in
       let lstart = WLExpr.get_loc e in
       let loc = CodeLoc.merge lstart lend in
       WLAssert.make bare_assert loc }
+  (* A bare (pure) logic expression is a pure assertion.  A bare
+     application [p(args)] denotes an all-in predicate call (pure functions
+     only appear as sub-expressions, never as a whole assertion).  This is the
+     single place where pure expressions become assertions, so [TRUE], [FALSE]
+     and a parenthesised pure expression [(e)] all go through here. *)
+  | f = logic_expression
+    { let bare_assert =
+        match WLExpr.get f with
+        | WLExpr.LPureFunApp (name, args) -> WLAssert.LPred (name, args, [])
+        | _ -> WLAssert.LPure f
+      in
+      WLAssert.make bare_assert (WLExpr.get_loc f) } %prec coerce_prec
 
 logic_expression:
   | lstart = LBRACE; le = logic_expression; lend = RBRACE
@@ -748,8 +769,10 @@ logic_expression:
       WLExpr.make bare_lexpr loc
     }
 
-(* We also have lists in the logic *)
-logic_binop:
+(* We also have lists in the logic.  Inlined (like [binop]) so each operator
+   keeps its own precedence.  Note there is no [*] here: in the logic [*] is
+   separating conjunction, never multiplication. *)
+%inline logic_binop:
   | b = binop { b }
   | LSTCONS { WBinOp.LSTCONS }
   | LSTCAT { WBinOp.LSTCAT }


### PR DESCRIPTION
As in the name, I was tired of the compile prints :p 